### PR TITLE
update frontendIPConfigurations to array

### DIFF
--- a/schemas/2015-08-01/Microsoft.Network.json
+++ b/schemas/2015-08-01/Microsoft.Network.json
@@ -276,14 +276,14 @@
             ]
         },
         "frontendIPConfigurations": {
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
                 "properties": {
+                    "name": {
+                        "type": "string"
+                    },
                     "properties": {
-                        "subnet": {
-                            "$ref": "#/definitions/id"
+                        "properties": {
+                            "subnet": {
+                                "$ref": "#/definitions/id"
                         },
                         "privateIPAddress": {
                             "type": "string"
@@ -514,7 +514,10 @@
                 "properties": {
                     "properties": {
                         "frontendIPConfigurations": {
-                            "$ref": "#/definitions/frontendIPConfigurations"
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/frontendIPConfigurations"
+                            }
                         },
                         "backendAddressPools": {
                             "type": "array",


### PR DESCRIPTION
I believe that frontendIPConfigurations property on the loadBalancers properties should have been an array like the other properties. At least that is what is working when you use the schema to deploy a loadbalancer.