### PR TITLE
Remove backendIPConfiguration from inboundNatRulesProperties required properties.

### DIFF
--- a/schemas/2015-08-01/Microsoft.Network.json
+++ b/schemas/2015-08-01/Microsoft.Network.json
@@ -443,7 +443,6 @@
             "type": "object",
             "required": [
                 "frontendIPConfiguration",
-                "backendIPConfiguration",
                 "protocol",
                 "frontendPort",
                 "backendPort"


### PR DESCRIPTION
backendIPConfiguration is not required for inboundNatRule.