### PR TITLE
Adding expression support and more descriptions to all resource schemas

### DIFF
--- a/schemas/2014-02-26/microsoft.visualstudio.json
+++ b/schemas/2014-02-26/microsoft.visualstudio.json
@@ -21,11 +21,27 @@
           "type": "object",
           "properties": {
             "OperationType": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "microsoft.visualstudio/account: Type of operation being performed on the account, which can be either Create or Link."
             },
             "AccountName": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "microsoft.visualstudio/account: Name of the Visual Studio Online account"
             }
           }
@@ -70,11 +86,27 @@
           "type": "object",
           "properties": {
             "ProcessTemplateId": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "microsoft.visualstudio/account/project: Process template guid for the project"
             },
             "VersionControlOption": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "microsoft.visualstudio/account/project: Version control type for the project, currently TfsVc and Git"
             }
           }

--- a/schemas/2014-02-26/microsoft.visualstudio.json
+++ b/schemas/2014-02-26/microsoft.visualstudio.json
@@ -21,27 +21,13 @@
           "type": "object",
           "properties": {
             "OperationType": {
-              "oneOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "microsoft.visualstudio/account: Type of operation being performed on the account, which can be either Create or Link."
             },
             "AccountName": {
-              "oneOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "microsoft.visualstudio/account: Name of the Visual Studio Online account"
             }
           }
@@ -86,27 +72,13 @@
           "type": "object",
           "properties": {
             "ProcessTemplateId": {
-              "oneOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "microsoft.visualstudio/account/project: Process template guid for the project"
             },
             "VersionControlOption": {
-              "oneOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "microsoft.visualstudio/account/project: Version control type for the project, currently TfsVc and Git"
             }
           }

--- a/schemas/2014-02-26/microsoft.visualstudio.json
+++ b/schemas/2014-02-26/microsoft.visualstudio.json
@@ -21,7 +21,7 @@
           "type": "object",
           "properties": {
             "OperationType": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                 },
@@ -33,7 +33,7 @@
               "description": "microsoft.visualstudio/account: Type of operation being performed on the account, which can be either Create or Link."
             },
             "AccountName": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                 },
@@ -86,7 +86,7 @@
           "type": "object",
           "properties": {
             "ProcessTemplateId": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                 },
@@ -98,7 +98,7 @@
               "description": "microsoft.visualstudio/account/project: Process template guid for the project"
             },
             "VersionControlOption": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                 },

--- a/schemas/2014-04-01-preview/Microsoft.Cache.json
+++ b/schemas/2014-04-01-preview/Microsoft.Cache.json
@@ -21,53 +21,61 @@
           "type": "object",
           "properties": {
             "sku": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "oneOf": [
-                    {
-                      "enum": [
-                        "Basic",
-                        "Standard"
-                      ]
-                    },
-                    {
-                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                    }
-                  ],
-                  "description": "Microsoft.Cache/Redis: sku/name"
-                },
-                "family": {
-                  "oneOf": [
-                    {
-                      "enum": [
-                        "C"
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "Basic",
+                            "Standard"
+                          ]
+                        },
+                        {
+                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                        }
                       ],
-                      "default": "C"
+                      "description": "Microsoft.Cache/Redis: sku/name"
                     },
-                    {
-                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                    "family": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "C"
+                          ],
+                          "default": "C"
+                        },
+                        {
+                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                        }
+                      ],
+                      "description": "Microsoft.Cache/Redis: sku/size"
+                    },
+                    "capacity": {
+                      "oneOf": [
+                        {
+                          "enum": [ 0, 1, 2, 3, 4, 5, 6 ]
+                        },
+                        {
+                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                        }
+                      ],
+                      "description": "Microsoft.Cache/Redis: sku/capacity"
                     }
-                  ],
-                  "description": "Microsoft.Cache/Redis: sku/size"
+                  },
+                  "required": [
+                    "name",
+                    "family",
+                    "capacity"
+                  ]
                 },
-                "capacity": {
-                  "oneOf": [
-                    {
-                      "enum": [ 0, 1, 2, 3, 4, 5, 6 ]
-                    },
-                    {
-                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                    }
-                  ],
-                  "description": "Microsoft.Cache/Redis: sku/capacity"
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                 }
-              },
-              "required": [
-                "name",
-                "family",
-                "capacity"
-              ]
+              ],
+              "description": "Microsoft.Cache/Redis: sku"
             },
             "redisVersion": {
               "oneOf": [

--- a/schemas/2014-04-01-preview/Microsoft.Sql.json
+++ b/schemas/2014-04-01-preview/Microsoft.Sql.json
@@ -21,18 +21,35 @@
           "type": "object",
           "properties": {
             "version": {
-              "enum": [
-                "2.0",
-                "12.0"
+              "oneOf": [
+                {
+                  "enum": [
+                    "2.0",
+                    "12.0"
+                  ]
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Sql/server: Azure SQL DB server version"
             },
             "administratorLogin": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Sql/server: administrator login name"
             },
             "administratorLoginPassword": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Sql/server: administrator login password"
             }
           },
@@ -66,7 +83,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Sql/servers"
     },
     "databasesChild": {
       "type": "object",
@@ -89,7 +107,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Sql/databasesChild"
     },
     "databases": {
       "type": "object",
@@ -112,7 +131,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Sql/databases"
     },
     "firewallrulesChild": {
       "type": "object",
@@ -135,7 +155,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Sql/firewallrulesChild"
     },
     "firewallrules": {
       "type": "object",
@@ -158,7 +179,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Sql/firewallrules"
     }
   },
   "definitions": {

--- a/schemas/2014-04-01-preview/Microsoft.Sql.json
+++ b/schemas/2014-04-01-preview/Microsoft.Sql.json
@@ -376,27 +376,13 @@
       "type": "object",
       "properties": {
         "endIpAddress": {
-          "oneOf": [
-            {
-              "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-            },
-            {
-              "type": "string",
-              "minLength": 1
-            }
-          ],
+          "type": "string",
+          "minLength": 1,
           "description": "Microsoft.Sql/server/firewallrules: ending IP address"
         },
         "startIpAddress": {
-          "oneOf": [
-            {
-              "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-            },
-            {
-              "type": "string",
-              "minLength": 1
-            }
-          ],
+          "type": "string",
+          "minLength": 1,
           "description": "Microsoft.Sql/server/firewallrules: starting IP address"
         }
       }

--- a/schemas/2014-04-01-preview/Microsoft.Sql.json
+++ b/schemas/2014-04-01-preview/Microsoft.Sql.json
@@ -33,23 +33,13 @@
               "description": "Microsoft.Sql/server: Azure SQL DB server version"
             },
             "administratorLogin": {
-              "oneOf": [
-                {
-                  "type": "string",
-                  "minLength": 1
-                },
-                { "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Sql/server: administrator login name"
             },
             "administratorLoginPassword": {
-              "oneOf": [
-                {
-                  "type": "string",
-                  "minLength": 1
-                },
-                { "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Sql/server: administrator login password"
             }
           },

--- a/schemas/2014-04-01-preview/Microsoft.Sql.json
+++ b/schemas/2014-04-01-preview/Microsoft.Sql.json
@@ -33,7 +33,7 @@
               "description": "Microsoft.Sql/server: Azure SQL DB server version"
             },
             "administratorLogin": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "string",
                   "minLength": 1
@@ -43,7 +43,7 @@
               "description": "Microsoft.Sql/server: administrator login name"
             },
             "administratorLoginPassword": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "string",
                   "minLength": 1
@@ -386,11 +386,27 @@
       "type": "object",
       "properties": {
         "endIpAddress": {
-          "type": "string",
+          "oneOf": [
+            {
+              "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ],
           "description": "Microsoft.Sql/server/firewallrules: ending IP address"
         },
         "startIpAddress": {
-          "type": "string",
+          "oneOf": [
+            {
+              "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ],
           "description": "Microsoft.Sql/server/firewallrules: starting IP address"
         }
       }

--- a/schemas/2014-04-01-preview/deploymentTemplate.json
+++ b/schemas/2014-04-01-preview/deploymentTemplate.json
@@ -375,6 +375,12 @@
       "pattern": "^\\[(concat|parameters|variables|reference|resourceId|resourceGroup|subscription|listKeys|listPackage)\\(.*\\).*\\]$",
       "description": "Deployment template expression.  Expressions are enclosed in [] and must start with a function of concat(), parameters(), variables(), reference(), resourceId(), resourceGroup(), subscription(), listKeys(), listPackage()"
     },
+     "numberOrExpression": {
+      "oneOf": [
+        { "type": "number" },
+        { "$ref": "#/definitions/expression" }
+      ]
+    },
     "Iso8601Duration": {
       "type": "string",
       "pattern": "^P(\\d+Y)?(\\d+M)?(\\d+D)?(T(((\\d+H)(\\d+M)?(\\d+(\\.\\d{1,2})?S)?)|((\\d+M)(\\d+(\\.\\d{1,2})?S)?)|((\\d+(\\.\\d{1,2})?S))))?$"

--- a/schemas/2014-04-01/Microsoft.BizTalkServices.json
+++ b/schemas/2014-04-01/Microsoft.BizTalkServices.json
@@ -21,40 +21,47 @@
           "type": "object",
           "properties": {
             "sku": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "oneOf": [
-                    {
-                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                    },
-                    {
-                      "enum": [
-                        "Free"
-                      ]
-                    }
-                  ],
-                  "description": "Edition of the biztalk service."
+              "oneOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                 },
-                "unitCount": {
-                  "oneOf": [
-                    {
-                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "oneOf": [
+                        {
+                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                        },
+                        {
+                          "enum": [
+                            "Free"
+                          ]
+                        }
+                      ],
+                      "description": "Edition of the biztalk service."
                     },
-                    {
-                      "type": "integer",
-                      "minimum": 1,
-                      "maximum": 1
+                    "unitCount": {
+                      "oneOf": [
+                        {
+                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                        },
+                        {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 1
+                        }
+                      ],
+                      "description": "Number of units of the biztalk service."
                     }
-                  ],
-                  "description": "Number of units of the biztalk service."
+                  },
+                  "required": [
+                    "name",
+                    "unitCount"
+                  ]
                 }
-              },
-              "description": "BizTalk SKU",
-              "required": [
-                "name",
-                "unitCount"
-              ]
+              ],
+              "description": "BizTalk SKU"
             }
           },
           "required": [
@@ -104,7 +111,15 @@
           "type": "object",
           "properties": {
             "hostName": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "Microsoft.BizTalkServices/BizTalk/HybridConnection: Hostname of the machine to which hybrid connection is to be established"
             },
             "port": {

--- a/schemas/2014-04-01/Microsoft.BizTalkServices.json
+++ b/schemas/2014-04-01/Microsoft.BizTalkServices.json
@@ -111,7 +111,7 @@
           "type": "object",
           "properties": {
             "hostName": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                 },

--- a/schemas/2014-04-01/Microsoft.BizTalkServices.json
+++ b/schemas/2014-04-01/Microsoft.BizTalkServices.json
@@ -111,15 +111,8 @@
           "type": "object",
           "properties": {
             "hostName": {
-              "oneOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.BizTalkServices/BizTalk/HybridConnection: Hostname of the machine to which hybrid connection is to be established"
             },
             "port": {

--- a/schemas/2014-04-01/Microsoft.Insights.json
+++ b/schemas/2014-04-01/Microsoft.Insights.json
@@ -21,25 +21,13 @@
           "type": "object",
           "properties": {
             "name": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Insights/alertrules: Name of the alert rule."
             },
             "description": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Insights/alertrules: Description of the alert rule that will be included in the alert email."
             },
             "isEnabled": {
@@ -93,10 +81,12 @@
                         },
                         "resourceUri": {
                           "type": "string",
+                          "minLength": 1,
                           "description": "Microsoft.Insights/alertrules: The resource identifier of the resource the rule monitors."
                         },
                         "metricName": {
                           "type": "string",
+                          "minLength": 1,
                           "description": "Microsoft.Insights/alertrules: The name of the metric that defines what the rule monitors."
                         },
                         "metricNamespace": {
@@ -212,7 +202,8 @@
                           "type": "array",
                           "minItems": 0,
                           "items": {
-                            "type": "string"
+                            "type": "string",
+                            "minLength": 1
                           }
                         }
                       ],
@@ -250,15 +241,8 @@
           "type": "object",
           "properties": {
             "applicationId": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Insights/components: applicationId"
             }
           }
@@ -288,36 +272,18 @@
           "type": "object",
           "properties": {
             "provisioningState": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string"
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Insights/webtests: provisioning state."
             },
             "Name": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string"
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Insights/webtests: name of the webtest."
             },
             "Description": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string"
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Insights/webtests: description of the webtest."
             },
             "Enabled": {
@@ -364,15 +330,8 @@
                     "type": "object",
                     "properties": {
                       "Id": {
-                        "anyOf": [
-                          {
-                            "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                          },
-                          {
-                            "type": "string",
-                            "minLength": 1
-                          }
-                        ],
+                        "type": "string",
+                        "minLength": 1,
                         "description": "Microsoft.Insights/webtests: Location id of the webtest"
                       }
                     }
@@ -391,6 +350,7 @@
                   "properties": {
                     "WebTest": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.Insights/webtests: WebTest configuration."
                     }
                   }
@@ -399,15 +359,8 @@
               "description": "Microsoft.Insights/webtests: Configuration for the webtest."
             },
             "SyntheticMonitorId": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Insights/webtests: Synthetic monitor id."
             }
           }
@@ -447,15 +400,8 @@
                     "type": "object",
                     "properties": {
                       "name": {
-                        "anyOf": [
-                          {
-                            "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                          },
-                          {
-                            "type": "string",
-                            "minLength": 1
-                          }
-                        ],
+                        "type": "string",
+                        "minLength": 1,
                         "description": "Microsoft.Insights/autoscalesettings: The name of the profile."
                       },
                       "capacity": {
@@ -511,27 +457,13 @@
                                   "type": "object",
                                   "properties": {
                                     "metricName": {
-                                      "anyOf": [
-                                        {
-                                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                                        },
-                                        {
-                                          "type": "string",
-                                          "minLength": 1
-                                        }
-                                      ],
+                                      "type": "string",
+                                      "minLength": 1,
                                       "description": "Microsoft.Insights/autoscalesettings: The name of the metric that defines what the rule monitors."
                                     },
                                     "metricResourceUri": {
-                                      "anyOf": [
-                                        {
-                                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                                        },
-                                        {
-                                          "type": "string",
-                                          "minLength": 1
-                                        }
-                                      ],
+                                      "type": "string",
+                                      "minLength": 1,
                                       "description": "Microsoft.Insights/autoscalesettings: The resource identifier of the resource the rule monitors."
                                     },
                                     "timeGrain": {
@@ -546,7 +478,7 @@
                                       "description": "Microsoft.Insights/autoscalesettings: The granularity of metrics the rule monitors. Must be one of the predefined values returned from metric definitions for the metric. Must be between 12 hours and 1 minute. ISO 8601 duration format."
                                     },
                                     "statistics": {
-                                      "anyOf": [
+                                      "oneOf": [
                                         {
                                           "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                                         },
@@ -646,8 +578,15 @@
                                       "description": "Microsoft.Insights/autoscalesettings: Whether the scaling action increases or decreases the number of instances."
                                     },
                                     "type": {
-                                      "enum": [
-                                        "ChangeCount"
+                                      "oneOf": [
+                                        {
+                                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                                        },
+                                        {
+                                          "enum": [
+                                            "ChangeCount"
+                                          ]
+                                        }
                                       ],
                                       "description": "Microsoft.Insights/autoscalesettings: The type of action that should occur, this must be set to ChangeCount."
                                     },
@@ -686,39 +625,18 @@
                         "type": "object",
                         "properties": {
                           "timeZone": {
-                            "anyOf": [
-                              {
-                                "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                              },
-                              {
-                                "type": "string",
-                                "minLength": 1
-                              }
-                            ],
+                            "type": "string",
+                            "minLength": 1,
                             "description": "Microsoft.Insights/autoscalesettings: The time zone of the start and end times for the profile."
                           },
                           "start": {
-                            "anyOf": [
-                              {
-                                "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                              },
-                              {
-                                "type": "string",
-                                "minLength": 1
-                              }
-                            ],
+                            "type": "string",
+                            "minLength": 1,
                             "description": "Microsoft.Insights/autoscalesettings: The start time for the profile."
                           },
                           "end": {
-                            "anyOf": [
-                              {
-                                "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                              },
-                              {
-                                "type": "string",
-                                "minLength": 1
-                              }
-                            ],
+                            "type": "string",
+                            "minLength": 1,
                             "description": "Microsoft.Insights/autoscalesettings: The end time for the profile."
                           }
                         },
@@ -737,15 +655,8 @@
                             "type": "object",
                             "properties": {
                               "timeZone": {
-                                "anyOf": [
-                                  {
-                                    "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "minLength": 1
-                                  }
-                                ],
+                                "type": "string",
+                                "minLength": 1,
                                 "description": "Microsoft.Insights/autoscalesettings: The time zone for the hours of the profile."
                               },
                               "days": {
@@ -794,41 +705,25 @@
               "description": "Microsoft.Insights/autoscalesettings: Contains a collection of automatic scaling profiles that specify different scaling parameters for different time periods. A maximum of 20 profiles can be specified."
             },
             "enabled": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
+              "oneOf": [
                 {
                   "type": "boolean"
                 },
                 {
-                  "type": "string"
+                  "type": "string",
+                  "minLength": 1
                 }
               ],
               "description": "Microsoft.Insights/autoscalesettings: Specifies whether automatic scaling is enabled for the resource."
             },
             "name": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Insights/autoscalesettings: The name of the autoscale setting."
             },
             "targetResourceUri": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Insights/autoscalesettings: The resource identifier of the resource that the autoscale setting should be added to."
             }
           }

--- a/schemas/2014-04-01/Microsoft.Insights.json
+++ b/schemas/2014-04-01/Microsoft.Insights.json
@@ -710,8 +710,7 @@
                   "type": "boolean"
                 },
                 {
-                  "type": "string",
-                  "minLength": 1
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                 }
               ],
               "description": "Microsoft.Insights/autoscalesettings: Specifies whether automatic scaling is enabled for the resource."

--- a/schemas/2014-04-01/Microsoft.Insights.json
+++ b/schemas/2014-04-01/Microsoft.Insights.json
@@ -21,11 +21,25 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                }
+              ],
               "description": "Microsoft.Insights/alertrules: Name of the alert rule."
             },
             "description": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                }
+              ],
               "description": "Microsoft.Insights/alertrules: Description of the alert rule that will be included in the alert email."
             },
             "isEnabled": {
@@ -40,23 +54,11 @@
               "description": "Microsoft.Insights/alertrules: Indicates whether the alert rule is enabled."
             },
             "condition": {
-              "type": "object",
-              "properties": {
-                "odata.type": {
-                  "oneOf": [
-                    {
-                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                    },
-                    {
-                      "enum": [
-                        "Microsoft.Azure.Management.Insights.Models.ThresholdRuleCondition",
-                        "Microsoft.Azure.Management.Insights.Models.LocationThresholdRuleCondition"
-                      ]
-                    }
-                  ],
-                  "description": "Microsoft.Insights/alertrules: Type of condition this alert rule uses."
+              "oneOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                 },
-                "dataSource": {
+                {
                   "type": "object",
                   "properties": {
                     "odata.type": {
@@ -66,126 +68,159 @@
                         },
                         {
                           "enum": [
-                            "Microsoft.Azure.Management.Insights.Models.RuleMetricDataSource"
+                            "Microsoft.Azure.Management.Insights.Models.ThresholdRuleCondition",
+                            "Microsoft.Azure.Management.Insights.Models.LocationThresholdRuleCondition"
                           ]
                         }
                       ],
-                      "description": "Microsoft.Insights/alertrules: Type of data source this condition uses."
+                      "description": "Microsoft.Insights/alertrules: Type of condition this alert rule uses."
                     },
-                    "resourceUri": {
-                      "type": "string",
-                      "description": "Microsoft.Insights/alertrules: The resource identifier of the resource the rule monitors."
+                    "dataSource": {
+                      "type": "object",
+                      "properties": {
+                        "odata.type": {
+                          "oneOf": [
+                            {
+                              "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                            },
+                            {
+                              "enum": [
+                                "Microsoft.Azure.Management.Insights.Models.RuleMetricDataSource"
+                              ]
+                            }
+                          ],
+                          "description": "Microsoft.Insights/alertrules: Type of data source this condition uses."
+                        },
+                        "resourceUri": {
+                          "type": "string",
+                          "description": "Microsoft.Insights/alertrules: The resource identifier of the resource the rule monitors."
+                        },
+                        "metricName": {
+                          "type": "string",
+                          "description": "Microsoft.Insights/alertrules: The name of the metric that defines what the rule monitors."
+                        },
+                        "metricNamespace": {
+                          "oneOf": [
+                            {
+                              "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                            },
+                            {
+                              "enum": [
+                                "WindowsAzure.Availability"
+                              ]
+                            }
+                          ],
+                          "description": "Microsoft.Insights/alertrules: Only should be present for availability level metrics, where the value must be WindowsAzure.Availability."
+                        }
+                      },
+                      "description": "Microsoft.Insights/alertrules: The resource from which the rule collects its data."
                     },
-                    "metricName": {
-                      "type": "string",
-                      "description": "Microsoft.Insights/alertrules: The name of the metric that defines what the rule monitors."
-                    },
-                    "metricNamespace": {
+                    "operator": {
                       "oneOf": [
                         {
                           "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                         },
                         {
                           "enum": [
-                            "WindowsAzure.Availability"
+                            "GreaterThan",
+                            "GreaterThanOrEqual",
+                            "LessThan",
+                            "LessThanOrEqual"
                           ]
                         }
                       ],
-                      "description": "Microsoft.Insights/alertrules: Only should be present for availability level metrics, where the value must be WindowsAzure.Availability."
-                    }
-                  },
-                  "description": "Microsoft.Insights/alertrules: The resource from which the rule collects its data."
-                },
-                "operator": {
-                  "oneOf": [
-                    {
-                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                      "description": "Microsoft.Insights/alertrules: The operator used to compare the data and the threshold."
                     },
-                    {
-                      "enum": [
-                        "GreaterThan",
-                        "GreaterThanOrEqual",
-                        "LessThan",
-                        "LessThanOrEqual"
-                      ]
-                    }
-                  ],
-                  "description": "Microsoft.Insights/alertrules: The operator used to compare the data and the threshold."
-                },
-                "threshold": {
-                  "oneOf": [
-                    {
-                      "type": "number",
-                      "minimum": 0
+                    "threshold": {
+                      "oneOf": [
+                        {
+                          "type": "number",
+                          "minimum": 0
+                        },
+                        {
+                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                        }
+                      ],
+                      "description": "Microsoft.Insights/alertrules: The threshold value that activates the alert. Only for ThresholdRuleConditions."
                     },
-                    {
-                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                    }
-                  ],
-                  "description": "Microsoft.Insights/alertrules: The threshold value that activates the alert. Only for ThresholdRuleConditions."
-                },
-                "failedLocationCount": {
-                  "oneOf": [
-                    {
-                      "type": "number",
-                      "minimum": 0
+                    "failedLocationCount": {
+                      "oneOf": [
+                        {
+                          "type": "number",
+                          "minimum": 0
+                        },
+                        {
+                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                        }
+                      ],
+                      "description": "Microsoft.Insights/alertrules: The number of locations that must fail to activate the alert. Only for LocationThresholdRuleConditions."
                     },
-                    {
-                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                    "windowSize": {
+                      "oneOf": [
+                        {
+                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/Iso8601Duration"
+                        },
+                        {
+                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                        }
+                      ],
+                      "description": "Microsoft.Insights/alertrules: The period of time that is used to monitor alert activity based on the threshold. Must be between 5 minutes and 1 day. ISO 8601 duration format."
                     }
-                  ],
-                  "description": "Microsoft.Insights/alertrules: The number of locations that must fail to activate the alert. Only for LocationThresholdRuleConditions."
-                },
-                "windowSize": {
-                  "oneOf": [
-                    {
-                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/Iso8601Duration"
-                    },
-                    {
-                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                    }
-                  ],
-                  "description": "Microsoft.Insights/alertrules: The period of time that is used to monitor alert activity based on the threshold. Must be between 5 minutes and 1 day. ISO 8601 duration format."
+                  }
                 }
-              },
+              ],
               "description": "Microsoft.Insights/alertrules: The condition that results in the alert rule being activated."
             },
             "action": {
-              "type": "object",
-              "properties": {
-                "odata.type": {
-                  "oneOf": [
-                    {
-                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                    },
-                    {
-                      "enum": [
-                        "Microsoft.Azure.Management.Insights.Models.RuleEmailAction"
-                      ]
-                    }
-                  ],
-                  "description": "Microsoft.Insights/alertrules: The type of action that is performed by the alert rule."
+              "oneOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                 },
-                "sendToServiceOwners": {
-                  "oneOf": [
-                    {
-                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                {
+                  "type": "object",
+                  "properties": {
+                    "odata.type": {
+                      "oneOf": [
+                        {
+                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                        },
+                        {
+                          "enum": [
+                            "Microsoft.Azure.Management.Insights.Models.RuleEmailAction"
+                          ]
+                        }
+                      ],
+                      "description": "Microsoft.Insights/alertrules: The type of action that is performed by the alert rule."
                     },
-                    {
-                      "type": "boolean"
+                    "sendToServiceOwners": {
+                      "oneOf": [
+                        {
+                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                        },
+                        {
+                          "type": "boolean"
+                        }
+                      ],
+                      "description": "Microsoft.Insights/alertrules: Whether the administrators (service and co-adiminstrators) of the service should be notified when the alert is activated."
+                    },
+                    "customEmails": {
+                      "oneOf": [
+                        {
+                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                        },
+                        {
+                          "type": "array",
+                          "minItems": 0,
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      ],
+                      "description": "Microsoft.Insights/alertrules: A list of administrator's custom email addresses notifiy of the activation of the alert."
                     }
-                  ],
-                  "description": "Microsoft.Insights/alertrules: Whether the administrators (service and co-adiminstrators) of the service should be notified when the alert is activated."
-                },
-                "customEmails": {
-                  "type": "array",
-                  "minItems": 0,
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Microsoft.Insights/alertrules: A list of administrator's custom email addresses notifiy of the activation of the alert."
+                  }
                 }
-              },
+              ],
               "description": "Microsoft.Insights/alertrules: The action that is performed when the alert rule becomes active, and when an alert condition is resolved."
             }
           }
@@ -195,7 +230,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Insights/alertrules"
     },
     "components": {
       "type": "object",
@@ -214,7 +250,15 @@
           "type": "object",
           "properties": {
             "applicationId": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "Microsoft.Insights/components: applicationId"
             }
           }
@@ -224,7 +268,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Insights/components"
     },
     "webtests": {
       "type": "object",
@@ -243,54 +288,126 @@
           "type": "object",
           "properties": {
             "provisioningState": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "description": "Microsoft.Insights/webtests: provisioning state."
             },
             "Name": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "description": "Microsoft.Insights/webtests: name of the webtest."
             },
             "Description": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "description": "Microsoft.Insights/webtests: description of the webtest."
             },
             "Enabled": {
-              "type": "boolean",
+              "oneOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
               "description": "Microsoft.Insights/webtests: Is the webtest enabled."
             },
             "Frequency": {
-              "type": "number",
+              "oneOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "number"
+                }
+              ],
               "description": "Microsoft.Insights/webtests: Frequency of the webtest."
             },
             "Timeout": {
-              "type": "number",
+              "oneOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "number"
+                }
+              ],
               "description": "Microsoft.Insights/webtests: Timeout for the webtest."
             },
             "Locations": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "Id": {
-                    "type": "string",
-                    "description": "Microsoft.Insights/webtests: Location id of the webtest"
+              "oneOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "Id": {
+                        "anyOf": [
+                          {
+                            "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                          },
+                          {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "Microsoft.Insights/webtests: Location id of the webtest"
+                      }
+                    }
                   }
                 }
-              },
+              ],
               "description": "Microsoft.Insights/webtests: Locations of the webtest."
             },
             "Configuration": {
-              "type": "object",
-              "properties": {
-                "WebTest": {
-                  "type": "string",
-                  "description": "Microsoft.Insights/webtests: WebTest configuration."
+              "oneOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "WebTest": {
+                      "type": "string",
+                      "description": "Microsoft.Insights/webtests: WebTest configuration."
+                    }
+                  }
                 }
-              },
+              ],
               "description": "Microsoft.Insights/webtests: Configuration for the webtest."
             },
             "SyntheticMonitorId": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "Microsoft.Insights/webtests: Synthetic monitor id."
             }
           }
@@ -300,7 +417,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Insights/webtests"
     },
     "autoscalesettings": {
       "type": "object",
@@ -319,276 +437,369 @@
           "type": "object",
           "properties": {
             "profiles": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "Microsoft.Insights/autoscalesettings: The name of the profile."
-                  },
-                  "capacity": {
+              "oneOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "array",
+                  "items": {
                     "type": "object",
                     "properties": {
-                      "minimum": {
-                        "oneOf": [
+                      "name": {
+                        "anyOf": [
                           {
                             "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                           },
                           {
-                            "type": "integer",
-                            "minimum": 0
+                            "type": "string",
+                            "minLength": 1
                           }
                         ],
-                        "description": "Microsoft.Insights/autoscalesettings: The minimum number of instances for the resource."
+                        "description": "Microsoft.Insights/autoscalesettings: The name of the profile."
                       },
-                      "maximum": {
-                        "oneOf": [
-                          {
-                            "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                          },
-                          {
-                            "type": "integer",
-                            "minimum": 0
-                          }
-                        ],
-                        "description": "Microsoft.Insights/autoscalesettings: The maximum number of instances for the resource. The actual maximum number may be limited by the cores that are available."
-                      },
-                      "default": {
-                        "oneOf": [
-                          {
-                            "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                          },
-                          {
-                            "type": "integer",
-                            "minimum": 0
-                          }
-                        ],
-                        "description": "Microsoft.Insights/autoscalesettings: The number of instances that will be set if metrics are not available for evaluation. The default is only used if the current instance count is lower than the default."
-                      }
-                    },
-                    "description": "Microsoft.Insights/autoscalesettings: The number of instances that can be used during this profile."
-                  },
-                  "rules": {
-                    "type": "array",
-                    "items": {
-                      "allOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "metricTrigger": {
-                              "type": "object",
-                              "properties": {
-                                "metricName": {
-                                  "type": "string",
-                                  "description": "Microsoft.Insights/autoscalesettings: The name of the metric that defines what the rule monitors."
-                                },
-                                "metricResourceUri": {
-                                  "type": "string",
-                                  "description": "Microsoft.Insights/autoscalesettings: The resource identifier of the resource the rule monitors."
-                                },
-                                "timeGrain": {
-                                  "oneOf": [
-                                    {
-                                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                                    },
-                                    {
-                                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/Iso8601Duration"
-                                    }
-                                  ],
-                                  "description": "Microsoft.Insights/autoscalesettings: The granularity of metrics the rule monitors. Must be one of the predefined values returned from metric definitions for the metric. Must be between 12 hours and 1 minute. ISO 8601 duration format."
-                                },
-                                "statistics": {
-                                  "enum": [
-                                    "Average",
-                                    "Min",
-                                    "Max",
-                                    "Sum"
-                                  ],
-                                  "description": "Microsoft.Insights/autoscalesettings: How the metrics from multiple instances are combined."
-                                },
-                                "timeWindow": {
-                                  "oneOf": [
-                                    {
-                                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                                    },
-                                    {
-                                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/Iso8601Duration"
-                                    }
-                                  ],
-                                  "description": "Microsoft.Insights/autoscalesettings: The range of time in which instance data is collected. This value must be greater than the delay in metric collection, which can vary from resource-to-resource. Must be between 12 hours and 5 minutes. ISO 8601 duration format."
-                                },
-                                "timeAggregation": {
-                                  "enum": [
-                                    "Average",
-                                    "Minimum",
-                                    "Maximum",
-                                    "Last",
-                                    "Total",
-                                    "Count"
-                                  ],
-                                  "description": "Microsoft.Insights/autoscalesettings: How the data that is collected should be combined over time. The default value is Average."
-                                },
-                                "operator": {
-                                  "enum": [
-                                    "GreaterThan",
-                                    "GreaterThanOrEqual",
-                                    "Equals",
-                                    "NotEquals",
-                                    "LessThan",
-                                    "LessThanOrEqual"
-                                  ],
-                                  "description": "Microsoft.Insights/autoscalesettings: The operator that is used to compare the metric data and the threshold."
-                                },
-                                "threshold": {
-                                  "oneOf": [
-                                    {
-                                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                                    },
-                                    {
-                                      "type": "number",
-                                      "minimum": 0
-                                    }
-                                  ],
-                                  "description": "Microsoft.Insights/autoscalesettings: The threshold of the metric that triggers the scale action."
-                                }
+                      "capacity": {
+                        "type": "object",
+                        "properties": {
+                          "minimum": {
+                            "oneOf": [
+                              {
+                                "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                               },
-                              "description": "Microsoft.Insights/autoscalesettings: The trigger that results in a scaling action."
-                            }
+                              {
+                                "type": "integer",
+                                "minimum": 0
+                              }
+                            ],
+                            "description": "Microsoft.Insights/autoscalesettings: The minimum number of instances for the resource."
+                          },
+                          "maximum": {
+                            "oneOf": [
+                              {
+                                "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                              },
+                              {
+                                "type": "integer",
+                                "minimum": 0
+                              }
+                            ],
+                            "description": "Microsoft.Insights/autoscalesettings: The maximum number of instances for the resource. The actual maximum number may be limited by the cores that are available."
+                          },
+                          "default": {
+                            "oneOf": [
+                              {
+                                "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                              },
+                              {
+                                "type": "integer",
+                                "minimum": 0
+                              }
+                            ],
+                            "description": "Microsoft.Insights/autoscalesettings: The number of instances that will be set if metrics are not available for evaluation. The default is only used if the current instance count is lower than the default."
                           }
                         },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "scaleAction": {
+                        "description": "Microsoft.Insights/autoscalesettings: The number of instances that can be used during this profile."
+                      },
+                      "rules": {
+                        "type": "array",
+                        "items": {
+                          "allOf": [
+                            {
                               "type": "object",
                               "properties": {
-                                "direction": {
-                                  "enum": [
-                                    "Increase",
-                                    "Decrease"
-                                  ],
-                                  "description": "Microsoft.Insights/autoscalesettings: Whether the scaling action increases or decreases the number of instances."
-                                },
-                                "type": {
-                                  "enum": [
-                                    "ChangeCount"
-                                  ],
-                                  "description": "Microsoft.Insights/autoscalesettings: The type of action that should occur, this must be set to ChangeCount."
-                                },
-                                "value": {
-                                  "oneOf": [
-                                    {
-                                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                                "metricTrigger": {
+                                  "type": "object",
+                                  "properties": {
+                                    "metricName": {
+                                      "anyOf": [
+                                        {
+                                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                                        },
+                                        {
+                                          "type": "string",
+                                          "minLength": 1
+                                        }
+                                      ],
+                                      "description": "Microsoft.Insights/autoscalesettings: The name of the metric that defines what the rule monitors."
                                     },
-                                    {
-                                      "type": "integer",
-                                      "minimum": 1
-                                    }
-                                  ],
-                                  "description": "Microsoft.Insights/autoscalesettings: The number of instances that are involved in the scaling action. This value must be 1 or greater. The default value is 1."
-                                },
-                                "cooldown": {
-                                  "oneOf": [
-                                    {
-                                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                                    "metricResourceUri": {
+                                      "anyOf": [
+                                        {
+                                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                                        },
+                                        {
+                                          "type": "string",
+                                          "minLength": 1
+                                        }
+                                      ],
+                                      "description": "Microsoft.Insights/autoscalesettings: The resource identifier of the resource the rule monitors."
                                     },
-                                    {
-                                      "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/Iso8601Duration"
+                                    "timeGrain": {
+                                      "oneOf": [
+                                        {
+                                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                                        },
+                                        {
+                                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/Iso8601Duration"
+                                        }
+                                      ],
+                                      "description": "Microsoft.Insights/autoscalesettings: The granularity of metrics the rule monitors. Must be one of the predefined values returned from metric definitions for the metric. Must be between 12 hours and 1 minute. ISO 8601 duration format."
+                                    },
+                                    "statistics": {
+                                      "anyOf": [
+                                        {
+                                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                                        },
+                                        {
+                                          "enum": [
+                                            "Average",
+                                            "Min",
+                                            "Max",
+                                            "Sum"
+                                          ]
+                                        }
+                                      ],
+                                      "description": "Microsoft.Insights/autoscalesettings: How the metrics from multiple instances are combined."
+                                    },
+                                    "timeWindow": {
+                                      "oneOf": [
+                                        {
+                                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                                        },
+                                        {
+                                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/Iso8601Duration"
+                                        }
+                                      ],
+                                      "description": "Microsoft.Insights/autoscalesettings: The range of time in which instance data is collected. This value must be greater than the delay in metric collection, which can vary from resource-to-resource. Must be between 12 hours and 5 minutes. ISO 8601 duration format."
+                                    },
+                                    "timeAggregation": {
+                                      "oneOf": [
+                                        {
+                                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                                        },
+                                        {
+                                          "enum": [
+                                            "Average",
+                                            "Minimum",
+                                            "Maximum",
+                                            "Last",
+                                            "Total",
+                                            "Count"
+                                          ]
+                                        }
+                                      ],
+                                      "description": "Microsoft.Insights/autoscalesettings: How the data that is collected should be combined over time. The default value is Average."
+                                    },
+                                    "operator": {
+                                      "oneOf": [
+                                        {
+                                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                                        },
+                                        {
+                                          "enum": [
+                                            "GreaterThan",
+                                            "GreaterThanOrEqual",
+                                            "Equals",
+                                            "NotEquals",
+                                            "LessThan",
+                                            "LessThanOrEqual"
+                                          ]
+                                        }
+                                      ],
+                                      "description": "Microsoft.Insights/autoscalesettings: The operator that is used to compare the metric data and the threshold."
+                                    },
+                                    "threshold": {
+                                      "oneOf": [
+                                        {
+                                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                                        },
+                                        {
+                                          "type": "number",
+                                          "minimum": 0
+                                        }
+                                      ],
+                                      "description": "Microsoft.Insights/autoscalesettings: The threshold of the metric that triggers the scale action."
                                     }
-                                  ],
-                                  "description": "Microsoft.Insights/autoscalesettings: The amount of time to wait since the last scaling action before this action occurs. Must be between 1 week and 1 minute. ISO 8601 duration format."
+                                  },
+                                  "description": "Microsoft.Insights/autoscalesettings: The trigger that results in a scaling action."
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "scaleAction": {
+                                  "type": "object",
+                                  "properties": {
+                                    "direction": {
+                                      "oneOf": [
+                                        {
+                                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                                        },
+                                        {
+                                          "enum": [
+                                            "Increase",
+                                            "Decrease"
+                                          ]
+                                        }
+                                      ],
+                                      "description": "Microsoft.Insights/autoscalesettings: Whether the scaling action increases or decreases the number of instances."
+                                    },
+                                    "type": {
+                                      "enum": [
+                                        "ChangeCount"
+                                      ],
+                                      "description": "Microsoft.Insights/autoscalesettings: The type of action that should occur, this must be set to ChangeCount."
+                                    },
+                                    "value": {
+                                      "oneOf": [
+                                        {
+                                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                                        },
+                                        {
+                                          "type": "integer",
+                                          "minimum": 1
+                                        }
+                                      ],
+                                      "description": "Microsoft.Insights/autoscalesettings: The number of instances that are involved in the scaling action. This value must be 1 or greater. The default value is 1."
+                                    },
+                                    "cooldown": {
+                                      "oneOf": [
+                                        {
+                                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                                        },
+                                        {
+                                          "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/Iso8601Duration"
+                                        }
+                                      ],
+                                      "description": "Microsoft.Insights/autoscalesettings: The amount of time to wait since the last scaling action before this action occurs. Must be between 1 week and 1 minute. ISO 8601 duration format."
+                                    }
+                                  }
                                 }
                               }
                             }
-                          }
-                        }
-                      ]
-                    },
-                    "description": "Microsoft.Insights/autoscalesettings: Contains a collection of rules that provide the triggers and parameters for the scaling action. A maximum of 10 rules can be specified."
-                  },
-                  "fixedDate": {
-                    "type": "object",
-                    "properties": {
-                      "timeZone": {
-                        "type": "string",
-                        "description": "Microsoft.Insights/autoscalesettings: The time zone of the start and end times for the profile."
+                          ]
+                        },
+                        "description": "Microsoft.Insights/autoscalesettings: Contains a collection of rules that provide the triggers and parameters for the scaling action. A maximum of 10 rules can be specified."
                       },
-                      "start": {
-                        "type": "string",
-                        "description": "Microsoft.Insights/autoscalesettings: The start time for the profile."
-                      },
-                      "end": {
-                        "description": "Microsoft.Insights/autoscalesettings: The end time for the profile.",
-                        "type": "string"
-                      }
-                    },
-                    "description": "Microsoft.Insights/autoscalesettings: A specific date for the profile. This element is not used if the Recurrence element is used."
-                  },
-                  "recurrence": {
-                    "type": "object",
-                    "properties": {
-                      "frequency": {
-                        "enum": [
-                          "Week"
-                        ],
-                        "description": "Microsoft.Insights/autoscalesettings: How often the schedule profile should take effect. This value must be Week, meaning each week will have the same set of profiles."
-                      },
-                      "schedule": {
+                      "fixedDate": {
                         "type": "object",
                         "properties": {
                           "timeZone": {
-                            "type": "string",
-                            "description": "Microsoft.Insights/autoscalesettings: The time zone for the hours of the profile."
+                            "anyOf": [
+                              {
+                                "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                              },
+                              {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            ],
+                            "description": "Microsoft.Insights/autoscalesettings: The time zone of the start and end times for the profile."
                           },
-                          "days": {
-                            "type": "array",
-                            "items": {
-                              "enum": [
-                                "Sunday",
-                                "Monday",
-                                "Tuesday",
-                                "Wednesday",
-                                "Thursday",
-                                "Friday",
-                                "Saturday"
-                              ]
-                            },
-                            "description": "Microsoft.Insights/autoscalesettings: A collection of days that the profile takes effect on."
+                          "start": {
+                            "anyOf": [
+                              {
+                                "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                              },
+                              {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            ],
+                            "description": "Microsoft.Insights/autoscalesettings: The start time for the profile."
                           },
-                          "hours": {
-                            "type": "array",
-                            "items": {
-                              "type": "integer",
-                              "minimum": 0,
-                              "maximum": 23
-                            },
-                            "description": "Microsoft.Insights/autoscalesettings: A collection of hours at which the profile takes effect at."
-                          },
-                          "minutes": {
-                            "type": "array",
-                            "items": {
-                              "type": "integer",
-                              "minimum": 0,
-                              "maximum": 59
-                            },
-                            "description": "Microsoft.Insights/autoscalesettings: A collection of minutes at which the profile takes effect at."
+                          "end": {
+                            "anyOf": [
+                              {
+                                "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                              },
+                              {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            ],
+                            "description": "Microsoft.Insights/autoscalesettings: The end time for the profile."
                           }
                         },
-                        "description": "Microsoft.Insights/autoscalesettings: The scheduling constraints for when the profile begins."
+                        "description": "Microsoft.Insights/autoscalesettings: A specific date for the profile. This element is not used if the Recurrence element is used."
+                      },
+                      "recurrence": {
+                        "type": "object",
+                        "properties": {
+                          "frequency": {
+                            "enum": [
+                              "Week"
+                            ],
+                            "description": "Microsoft.Insights/autoscalesettings: How often the schedule profile should take effect. This value must be Week, meaning each week will have the same set of profiles."
+                          },
+                          "schedule": {
+                            "type": "object",
+                            "properties": {
+                              "timeZone": {
+                                "anyOf": [
+                                  {
+                                    "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "minLength": 1
+                                  }
+                                ],
+                                "description": "Microsoft.Insights/autoscalesettings: The time zone for the hours of the profile."
+                              },
+                              "days": {
+                                "type": "array",
+                                "items": {
+                                  "enum": [
+                                    "Sunday",
+                                    "Monday",
+                                    "Tuesday",
+                                    "Wednesday",
+                                    "Thursday",
+                                    "Friday",
+                                    "Saturday"
+                                  ]
+                                },
+                                "description": "Microsoft.Insights/autoscalesettings: A collection of days that the profile takes effect on."
+                              },
+                              "hours": {
+                                "type": "array",
+                                "items": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 23
+                                },
+                                "description": "Microsoft.Insights/autoscalesettings: A collection of hours at which the profile takes effect at."
+                              },
+                              "minutes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 59
+                                },
+                                "description": "Microsoft.Insights/autoscalesettings: A collection of minutes at which the profile takes effect at."
+                              }
+                            },
+                            "description": "Microsoft.Insights/autoscalesettings: The scheduling constraints for when the profile begins."
+                          }
+                        },
+                        "description": "Microsoft.Insights/autoscalesettings: The repeating times at which this profile begins. This element is not used if the FixedDate element is used."
                       }
-                    },
-                    "description": "Microsoft.Insights/autoscalesettings: The repeating times at which this profile begins. This element is not used if the FixedDate element is used."
+                    }
                   }
                 }
-              },
+              ],
               "description": "Microsoft.Insights/autoscalesettings: Contains a collection of automatic scaling profiles that specify different scaling parameters for different time periods. A maximum of 20 profiles can be specified."
             },
             "enabled": {
-              "oneOf": [
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
                 {
                   "type": "boolean"
-
                 },
                 {
                   "type": "string"
@@ -597,11 +808,27 @@
               "description": "Microsoft.Insights/autoscalesettings: Specifies whether automatic scaling is enabled for the resource."
             },
             "name": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "Microsoft.Insights/autoscalesettings: The name of the autoscale setting."
             },
             "targetResourceUri": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "Microsoft.Insights/autoscalesettings: The resource identifier of the resource that the autoscale setting should be added to."
             }
           }
@@ -611,7 +838,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Insights/autoscalesettings"
     }
   }
 }

--- a/schemas/2014-04-01/Microsoft.Insights.json
+++ b/schemas/2014-04-01/Microsoft.Insights.json
@@ -298,25 +298,11 @@
               "description": "Microsoft.Insights/webtests: Is the webtest enabled."
             },
             "Frequency": {
-              "oneOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "number"
-                }
-              ],
+              "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/numberOrExpression",
               "description": "Microsoft.Insights/webtests: Frequency of the webtest."
             },
             "Timeout": {
-              "oneOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "number"
-                }
-              ],
+              "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/numberOrExpression",
               "description": "Microsoft.Insights/webtests: Timeout for the webtest."
             },
             "Locations": {

--- a/schemas/2014-04-01/SuccessBricks.ClearDB.json
+++ b/schemas/2014-04-01/SuccessBricks.ClearDB.json
@@ -45,7 +45,8 @@
         "type",
         "apiVersion",
         "plan"
-      ]
+      ],
+      "description": "SuccessBricks.ClearDB/databases"
     }
   }
 }

--- a/schemas/2014-06-01/Microsoft.Web.json
+++ b/schemas/2014-06-01/Microsoft.Web.json
@@ -21,7 +21,15 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "Microsoft.Web/serverfarms: Name of the server farm."
             },
             "sku": {
@@ -80,7 +88,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Web/serverfarms"
     },
     "config": {
       "type": "object",
@@ -100,33 +109,81 @@
           "type": "object",
           "properties": {
             "connectionStrings": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "ConnectionString": {
-                    "type": "string",
-                    "description": "Microsoft.Web/sites/config: connection string"
+              "oneOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "ConnectionString": {
+                        "anyOf": [
+                          {
+                            "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                          },
+                          {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "Microsoft.Web/sites/config: connection string"
+                      },
+                      "Name": {
+                        "anyOf": [
+                          {
+                            "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                          },
+                          {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "Microsoft.Web/sites/config: connection string name"
+                      },
+                      "Type": {
+                        "anyOf": [
+                          {
+                            "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                          },
+                          {
+                            "type": "integer",
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "Microsoft.Web/sites/config: connection string type"
+                      }
+                    }
                   },
-                  "Name": {
-                    "type": "string",
-                    "description": "Microsoft.Web/sites/config: connection string name"
-                  },
-                  "Type": {
-                    "type": "integer",
-                    "description": "Microsoft.Web/sites/config: connection string type"
-                  }
+                  "uniqueItems": true,
+                  "description": "Microsoft.Web/sites/config: Connection strings for database and other external resources."
                 }
-              },
-              "uniqueItems": true,
-              "description": "Microsoft.Web/sites/config: Connection strings for database and other external resources."
+              ],
+              "description": "Microsoft.Web/sites/config: Connection strings"
             },
             "phpVersion": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "Microsoft.Web/sites/config: PHP version (an empty string disables PHP)."
             },
             "netFrameworkVersion": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "Microsoft.Web/sites/config: The .Net Framework version."
             }
           }
@@ -157,19 +214,50 @@
           "type": "object",
           "properties": {
             "packageUri": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "Microsoft.Web/sites/extensions: uri of package"
             },
             "dbType": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "Microsoft.Web/sites/extensions: type of database"
             },
             "connectionString": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "Microsoft.Web/sites/extensions: connection string"
             },
             "setParameters": {
-              "type": "object",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "object"
+                }
+              ],
               "description": "Microsoft.Web/sites/extensions: parameters"
             }
           }
@@ -179,7 +267,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Web/sites/extensions"
     },
     "sites": {
       "type": "object",
@@ -198,82 +287,137 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "Microsoft.Web/sites: The name of web site."
             },
             "serverFarm": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "Microsoft.Web/sites: The name of server farm site belongs to."
             },
             "hostnames": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              ],
               "description": "Microsoft.Web/sites: An array of strings that contains the public hostnames for the site, including custom domains."
             },
             "enabledHostnames": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              ],
               "description": "Microsoft.Web/sites: An array of strings that contains enabled hostnames for the site. By default, these are <SiteName>.azurewebsites.net and <SiteName>.scm.azurewebsites.net."
             },
             "hostNameSslStates": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "Microsoft.Web/sites/hostNameSslStates: The URL of the web site."
-                  },
-                  "sslState": {
-                    "oneOf": [
-                      {
-                        "enum": [
-                          "Disabled",
-                          "IpBasedEnabled",
-                          "SniEnabled"
-                        ]
+              "oneOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "anyOf": [
+                          {
+                            "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                          },
+                          {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "Microsoft.Web/sites/hostNameSslStates: The URL of the web site."
                       },
-                      {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 2
+                      "sslState": {
+                        "oneOf": [
+                          {
+                            "enum": [
+                              "Disabled",
+                              "IpBasedEnabled",
+                              "SniEnabled"
+                            ]
+                          },
+                          {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          {
+                            "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                          }
+                        ],
+                        "description": "Microsoft.Web/sites/hostNameSslStates. The SSL state."
                       },
-                      {
-                        "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                      "thumbprint": {
+                        "anyOf": [
+                          {
+                            "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                          },
+                          {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "Microsoft.Web/sites/hostNameSslStates: A string that contains the thumbprint of the SSL certificate."
+                      },
+                      "ipBasedSslState": {
+                        "oneOf": [
+                          {
+                            "enum": [
+                              "Disabled",
+                              "IpBasedEnabled",
+                              "SniEnabled"
+                            ]
+                          },
+                          {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          {
+                            "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                          }
+                        ],
+                        "description": "Microsoft.Web/sites/hostNameSslStates: IP Based SSL state"
                       }
-                    ],
-                    "description": "Microsoft.Web/sites/hostNameSslStates. The SSL state."
-                  },
-                  "thumbprint": {
-                    "type": "string",
-                    "description": "Microsoft.Web/sites/hostNameSslStates: A string that contains the thumbprint of the SSL certificate."
-                  },
-                  "ipBasedSslState": {
-                    "oneOf": [
-                      {
-                        "enum": [
-                          "Disabled",
-                          "IpBasedEnabled",
-                          "SniEnabled"
-                        ]
-                      },
-                      {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 2
-                      },
-                      {
-                        "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                      }
-                    ],
-                    "description": "Microsoft.Web/sites/hostNameSslStates: IP Based SSL state"
+                    }
                   }
                 }
-              },
+              ],
               "description": "Microsoft.Web/sites: Container for SSL states."
             }
           }
@@ -298,7 +442,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Web/sites"
     },
     "certificates": {
       "type": "object",
@@ -317,11 +462,27 @@
           "type": "object",
           "properties": {
             "pfxBlob": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "Microsoft.Web/certificates: A base64Binary value that contains the PfxBlob of the certificate."
             },
             "password": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
               "description": "Microsoft.Web/certficates: A string that contains the password for the certificate."
             }
           }
@@ -331,7 +492,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Web/certificates"
     }
   }
 }

--- a/schemas/2014-06-01/Microsoft.Web.json
+++ b/schemas/2014-06-01/Microsoft.Web.json
@@ -21,15 +21,8 @@
           "type": "object",
           "properties": {
             "name": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/serverfarms: Name of the server farm."
             },
             "sku": {
@@ -119,31 +112,17 @@
                     "type": "object",
                     "properties": {
                       "ConnectionString": {
-                        "anyOf": [
-                          {
-                            "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                          },
-                          {
-                            "type": "string",
-                            "minLength": 1
-                          }
-                        ],
+                        "type": "string",
+                        "minLength": 1,
                         "description": "Microsoft.Web/sites/config: connection string"
                       },
                       "Name": {
-                        "anyOf": [
-                          {
-                            "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                          },
-                          {
-                            "type": "string",
-                            "minLength": 1
-                          }
-                        ],
+                        "type": "string",
+                        "minLength": 1,
                         "description": "Microsoft.Web/sites/config: connection string name"
                       },
                       "Type": {
-                        "anyOf": [
+                        "oneOf": [
                           {
                             "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                           },
@@ -163,27 +142,13 @@
               "description": "Microsoft.Web/sites/config: Connection strings"
             },
             "phpVersion": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/sites/config: PHP version (an empty string disables PHP)."
             },
             "netFrameworkVersion": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/sites/config: The .Net Framework version."
             }
           }
@@ -214,43 +179,22 @@
           "type": "object",
           "properties": {
             "packageUri": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/sites/extensions: uri of package"
             },
             "dbType": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/sites/extensions: type of database"
             },
             "connectionString": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/sites/extensions: connection string"
             },
             "setParameters": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                 },
@@ -287,31 +231,17 @@
           "type": "object",
           "properties": {
             "name": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/sites: The name of web site."
             },
             "serverFarm": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/sites: The name of server farm site belongs to."
             },
             "hostnames": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                 },
@@ -326,7 +256,7 @@
               "description": "Microsoft.Web/sites: An array of strings that contains the public hostnames for the site, including custom domains."
             },
             "enabledHostnames": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
                 },
@@ -351,15 +281,8 @@
                     "type": "object",
                     "properties": {
                       "name": {
-                        "anyOf": [
-                          {
-                            "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                          },
-                          {
-                            "type": "string",
-                            "minLength": 1
-                          }
-                        ],
+                        "type": "string",
+                        "minLength": 1,
                         "description": "Microsoft.Web/sites/hostNameSslStates: The URL of the web site."
                       },
                       "sslState": {
@@ -383,15 +306,8 @@
                         "description": "Microsoft.Web/sites/hostNameSslStates. The SSL state."
                       },
                       "thumbprint": {
-                        "anyOf": [
-                          {
-                            "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                          },
-                          {
-                            "type": "string",
-                            "minLength": 1
-                          }
-                        ],
+                        "type": "string",
+                        "minLength": 1,
                         "description": "Microsoft.Web/sites/hostNameSslStates: A string that contains the thumbprint of the SSL certificate."
                       },
                       "ipBasedSslState": {
@@ -462,27 +378,13 @@
           "type": "object",
           "properties": {
             "pfxBlob": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/certificates: A base64Binary value that contains the PfxBlob of the certificate."
             },
             "password": {
-              "anyOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/expression"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/certficates: A string that contains the password for the certificate."
             }
           }

--- a/schemas/2014-08-01/Microsoft.Scheduler.json
+++ b/schemas/2014-08-01/Microsoft.Scheduler.json
@@ -21,31 +21,55 @@
           "type": "object",
           "properties": {
             "sku": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "enum": [
-                    "Free",
-                    "Standard",
-                    "Premium"
-                  ]
-                }
-              },
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "Free",
+                            "Standard",
+                            "Premium"
+                          ]
+                        },
+                        { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                      ]
+                    }
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Scheduler/jobCollections: Job Collection sku"
             },
             "quota": {
-              "type": "object",
-              "properties": {
-                "maxJobCount": {
-                  "type": "integer",
-                  "minimum": 1,
-                  "description": "Microsoft.Scheduler/jobCollections/quota: The maximum number of jobs that can be created in this job collection.  Default value based on sku."
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "maxJobCount": {
+                      "oneOf": [
+                        {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                      ],
+                      "description": "Microsoft.Scheduler/jobCollections/quota: The maximum number of jobs that can be created in this job collection.  Default value based on sku."
+                    },
+                    "maxRecurrence": {
+                      "oneOf": [
+                        { "$ref": "#/definitions/recurrenceFrequency" },
+                        { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                      ],
+                      "description": "Microsoft.Scheduler/jobCollections/quota: The maximum recurrence frequency that a job can execute at. Default value based on sku."
+                    }
+                  }
                 },
-                "maxRecurrence": {
-                  "$ref": "#/definitions/recurrenceFrequency",
-                  "description": "Microsoft.Scheduler/jobCollections/quota: The maximum recurrence frequency that a job can execute at. Default value based on sku."
-                }
-              }
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+            "description": "Microsoft.Scheduler/jobCollections/quota"
             }
           },
           "required": [
@@ -92,74 +116,119 @@
           "type": "object",
           "properties": {
             "startTime": {
-              "$ref": "#/definitions/UTC",
+              "oneOf": [
+                { "$ref": "#/definitions/UTC" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Scheduler/jobCollections/jobs: For simple scheduler startTime will be the first occurrence and for complex schedules the job will start no sooner than startTime."
             },
             "recurrence": {
-              "$ref": "#/definitions/recurrence",
+              "oneOf": [
+                { "$ref": "#/definitions/recurrence" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Scheduler/jobCollections/jobs: The recurrence schedule the job will execute."
             },
             "state": {
-              "enum": [
-                "Enabled",
-                "Disabled"
+              "oneOf": [
+                {
+                  "enum": [
+                    "Enabled",
+                    "Disabled"
+                  ]
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Scheduler/jobCollections/jobs: Running state of the job."
             },
             "action": {
-              "anyOf": [
+              "oneOf": [
                 {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "enum": [
-                        "HTTP",
-                        "HTTPS"
-                      ],
-                      "description": "Microsoft.Scheduler/jobCollections/jobs: Type of job action"
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "oneOf": [
+                            {
+                              "enum": [
+                                "HTTP",
+                                "HTTPS"
+                              ]
+                            },
+                            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                          ],
+                          "description": "Microsoft.Scheduler/jobCollections/jobs: Type of job action"
+                        },
+                        "request": {
+                          "oneOf": [
+                            { "$ref": "#/definitions/httpActionRequest" },
+                            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                          ]
+                        },
+                        "retryPolicy": {
+                          "oneOf": [
+                            { "$ref": "#/definitions/retryPolicy" },
+                            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                          ]
+                        },
+                        "errorAction": {
+                          "oneOf": [
+                            { "$ref": "#/definitions/errorAction" },
+                            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                          ]
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "type",
+                        "request"
+                      ]
                     },
-                    "request": {
-                      "$ref": "#/definitions/httpActionRequest"
-                    },
-                    "retryPolicy": {
-                      "$ref": "#/definitions/retryPolicy"
-                    },
-                    "errorAction": {
-                      "$ref": "#/definitions/errorAction"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "oneOf": [
+                            {
+                              "enum": [
+                                "STORAGEQUEUE"
+                              ]
+                            },
+                            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                          ],
+                          "description": "Microsoft.Scheduler/jobCollections/jobs: Type of job action"
+                        },
+                        "queueMessage": {
+                          "oneOf": [
+                            { "$ref": "#/definitions/storageQueueActionQueueMessage" },
+                            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                          ]
+                        },
+                        "retryPolicy": {
+                          "oneOf": [
+                            { "$ref": "#/definitions/retryPolicy" },
+                            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                          ]
+                        },
+                        "errorAction": {
+                          "oneOf": [
+                            { "$ref": "#/definitions/errorAction" },
+                            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                          ]
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "type",
+                        "queueMessage"
+                      ]
                     }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "type",
-                    "request"
-                  ]
+                  ] 
                 },
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "enum": [
-                        "STORAGEQUEUE"
-                      ],
-                      "description": "Microsoft.Scheduler/jobCollections/jobs: Type of job action"
-                    },
-                    "queueMessage": {
-                      "$ref": "#/definitions/storageQueueActionQueueMessage"
-                    },
-                    "retryPolicy": {
-                      "$ref": "#/definitions/retryPolicy"
-                    },
-                    "errorAction": {
-                      "$ref": "#/definitions/errorAction"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "type",
-                    "queueMessage"
-                  ]
-                }
-              ],
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ]
+              ,
               "description": "Microsoft.Scheduler/jobCollections/jobs: Action to perform on the prescribed schedule"
             }
           }
@@ -178,38 +247,56 @@
       "type": "object",
       "properties": {
         "uri": {
-          "type": "string",
-          "maxLength": 2048,
+          "oneOf": [
+            {
+              "type": "string",
+              "maxLength": 2048
+            },
+            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+          ],
           "description": "Microsoft.Scheduler/jobCollections/jobs: URI of the endpoint to call"
         },
         "method": {
-          "anyOf": [
+          "oneOf": [
             {
-              "type": "string"
-            },
-            {
-              "enum": [
-                "GET",
-                "PUT",
-                "POST",
-                "PATCH",
-                "DELETE",
-                "HEAD",
-                "TRACE",
-                "CONNECT",
-                "OPTIONS"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "enum": [
+                    "GET",
+                    "PUT",
+                    "POST",
+                    "PATCH",
+                    "DELETE",
+                    "HEAD",
+                    "TRACE",
+                    "CONNECT",
+                    "OPTIONS"
+                  ]
+                }
               ]
-            }
+            },
+            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
           ],
           "description": "Microsoft.Scheduler/jobCollections/jobs: HTTP method used to communicate with the endpoint"
         },
         "headers": {
-          "type": "object",
+          "oneOf": [
+            { "type": "object" },
+            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+          ],
           "description": "Microsoft.Scheduler/jobCollections/jobs: Dictionary HTTP request headers. Limited to 50 headers."
         },
         "body": {
-          "type": "string",
-          "maxLength": 8192,
+          "oneOf": [
+            {
+              "type": "string",
+              "maxLength": 8192
+            },
+            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+          ],
           "description": "Microsoft.Scheduler/jobCollections/jobs: HTTP request body"
         },
         "authentication": {
@@ -480,23 +567,39 @@
           "type": "object",
           "properties": {
             "count": {
-              "type": "integer",
+              "oneOf": [
+                { "type": "integer" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Scheduler/jobCollections/jobs: Number of times this job should run before completing"
             },
             "endTime": {
-              "$ref": "#/definitions/UTC",
+              "oneOf": [
+                { "$ref": "#/definitions/UTC" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Scheduler/jobCollections/jobs: Job should not execute past this time"
             },
             "interval": {
-              "type": "integer",
-              "minimum": 1,
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Scheduler/jobCollections/jobs: Interval for the frequency that determines how often the job will run"
             },
             "frequency": {
-              "enum": [
-                "Day",
-                "Week",
-                "Month"
+              "oneOf": [
+                {
+                  "enum": [
+                    "Day",
+                    "Week",
+                    "Month"
+                  ]
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Scheduler/jobCollections/jobs: Frequency at which this job will run"
             },
@@ -504,70 +607,98 @@
               "type": "object",
               "properties": {
                 "minutes": {
-                  "anyOf": [
+                  "oneOf": [
                     {
-                      "type": "integer"
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "integer"
+                          }
+                        }
+                      ]
                     },
-                    {
-                      "type": "array",
-                      "items": {
-                        "type": "integer"
-                      }
-                    }
+                    { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
                   ],
                   "description": "Minutes of the hour at which the job will run"
                 },
                 "hours": {
-                  "anyOf": [
+                  "oneOf": [
                     {
-                      "type": "integer"
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "integer"
+                          }
+                        }
+                      ]
                     },
-                    {
-                      "type": "array",
-                      "items": {
-                        "type": "integer"
-                      }
-                    }
+                    { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
                   ],
                   "description": "Hours of the day at which the job will run"
                 },
                 "weekDays": {
-                  "anyOf": [
+                  "oneOf": [
                     {
-                      "$ref": "#/definitions/dayOfWeek"
+                      "anyOf": [
+                        {
+                          "$ref": "#/definitions/dayOfWeek"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/dayOfWeek"
+                          },
+                          "uniqueItems": true,
+                          "maxItems": 7
+                        }
+                      ]
                     },
-                    {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/dayOfWeek"
-                      },
-                      "uniqueItems": true,
-                      "maxItems": 7
-                    }
+                    { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
                   ],
                   "description": "Days of the week the job will run.  Can only be specified with a weekly frequency."
                 },
                 "monthlyOccurrences": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "day": {
-                        "$ref": "#/definitions/dayOfWeek",
-                        "description": "Day of the week the job will run, e.g. {Sunday} is every Sunday of the month."
-                      },
-                      "occurrence": {
-                        "type": "integer",
-                        "minimum": -5,
-                        "maximum": 5,
-                        "description": "Occurrence of the day during the month, e.g. {Sunday, -1} is the last Sunday of the month. Optional."
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "day": {
+                            "oneOf": [
+                              { "$ref": "#/definitions/dayOfWeek" },
+                              { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                            ],
+                            "description": "Day of the week the job will run, e.g. {Sunday} is every Sunday of the month."
+                          },
+                          "occurrence": {
+                            "oneOf": [
+                              {
+                                "type": "integer",
+                                "minimum": -5,
+                                "maximum": 5
+                              },
+                              { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                            ],
+                            "description": "Occurrence of the day during the month, e.g. {Sunday, -1} is the last Sunday of the month. Optional."
+                          }
+                        },
+                        "required": [
+                          "day"
+                        ],
+                        "description": "Determines which days of the month the job will run.  Can only be specified with a monthly frequency."
                       }
                     },
-                    "required": [
-                      "day"
-                    ],
-                    "description": "Determines which days of the month the job will run.  Can only be specified with a monthly frequency."
-                  }
+                    { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                  ]
                 },
                 "monthDays": {
                   "anyOf": [

--- a/schemas/2014-08-01/Microsoft.Scheduler.json
+++ b/schemas/2014-08-01/Microsoft.Scheduler.json
@@ -81,11 +81,7 @@
           "items": {
             "allOf": [
               { "$ref": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#/definitions/resourceBase" },
-              {
-                "anyOf": [
-                  { "$ref": "#/resourceDefinitions/jobs" }
-                ]
-              }
+              { "$ref": "#/resourceDefinitions/jobs" }
             ]
           },
           "description": "Microsoft.Scheduler/jobCollections: Collection of job resources."
@@ -144,7 +140,7 @@
             "action": {
               "oneOf": [
                 {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "type": "object",
                       "properties": {
@@ -247,9 +243,10 @@
       "type": "object",
       "properties": {
         "uri": {
-          "oneOf": [
+          "anyOf": [
             {
               "type": "string",
+              "minLength": 1,
               "maxLength": 2048
             },
             { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
@@ -261,7 +258,8 @@
             {
               "anyOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "minLength": 1
                 },
                 {
                   "enum": [
@@ -310,24 +308,29 @@
                 },
                 "pfx": {
                   "type": "string",
+                  "minLength": 1,
                   "maxLength": 32768,
                   "description": "base64-encoded pfx. Required when providing a different certificate."
                 },
                 "password": {
                   "type": "string",
+                  "minLength": 1,
                   "maxLength": 256,
                   "description": "Certificate password. Required when providing a different certificate."
                 },
                 "certificateThumbprint": {
                   "type": "string",
+                  "minLength": 1,
                   "description": "Thumbprint of the certificate set on the job. Must match the currently configured certificate."
                 },
                 "certificateExpiration": {
                   "type": "string",
+                  "minLength": 1,
                   "description": "Date-time of the expiration of the certificate set on the job. Must match the currently configured certificate."
                 },
                 "certificateSubjectName": {
                   "type": "string",
+                  "minLength": 1,
                   "description": "Subject name of the certificate set on the job. Must match the currently configured certficate."
                 }
               }
@@ -341,21 +344,25 @@
                 },
                 "secret": {
                   "type": "string",
+                  "minLength": 1,
                   "maxLength": 4096,
                   "description": "OAuth secret. Only required when providing different OAuth profile."
                 },
                 "tenant": {
                   "type": "string",
+                  "minLength": 1,
                   "maxLength": 4096,
                   "description": "OAuth tenant id."
                 },
                 "audience": {
                   "type": "string",
+                  "minLength": 1,
                   "maxLength": 2048,
                   "description": "OAuth audience"
                 },
                 "clientId": {
                   "type": "string",
+                  "minLength": 1,
                   "maxLength": 4096,
                   "description": "OAuth client id"
                 }
@@ -375,11 +382,13 @@
                 },
                 "username": {
                   "type": "string",
+                  "minLength": 1,
                   "maxLength": 4096,
                   "description": "Username to use for Basic Authentication"
                 },
                 "password": {
                   "type": "string",
+                  "minLength": 1,
                   "maxLength": 4096,
                   "description": "Password to use for Basic Authentication. Only required when providing a different username."
                 }
@@ -401,6 +410,7 @@
       "properties": {
         "storageAccount": {
           "type": "string",
+          "minLength": 1,
           "description": "Microsoft.Scheduler/jobCollections/jobs: storage account containing the queue to send scheduled messages to"
         },
         "queueName": {
@@ -412,10 +422,12 @@
         },
         "sasToken": {
           "type": "string",
+          "minLength": 1,
           "description": "Microsoft.Scheduler/jobCollections/jobs: SAS Token of storage account that has add messages to queue permissions to the storage account"
         },
         "message": {
           "type": "string",
+          "minLength": 1,
           "maxLength": 8192,
           "description": "Microsoft.Scheduler/jobCollections/jobs: message to send to queue"
         }

--- a/schemas/2014-10-01-preview/Microsoft.Authorization.json
+++ b/schemas/2014-10-01-preview/Microsoft.Authorization.json
@@ -18,29 +18,46 @@
           ]
         },
         "name": {
-          "type": "string",
+          "oneOf": [
+            { "type": "string" },
+            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+          ],
           "description": "Name of the roleAssignment"
         },
         "dependsOn": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "oneOf": [
+            { 
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+          ],
           "description": "Collection of resources this resource depends on"
         },
         "properties": {
           "type": "object",
           "properties": {
             "roleDefinitionId": {
-              "type": "string",
+              "oneOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Authorization/roleAssignments: roleDefinitionId - id of the role to be used in the role assignment"
             },
             "principalId": {
-              "type": "string",
+              "oneOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Authorization/roleAssignments: principalId - specifies the principal Id.  This maps to the id inside the directory and can point to a user, service principal, or security group"
             },
             "scope": {
-              "type": "string",
+              "oneOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Authorization/roleAssignments: scope - specifies the scope at which this role assignment applies to"
             }
           },

--- a/schemas/2014-10-01-preview/Microsoft.Authorization.json
+++ b/schemas/2014-10-01-preview/Microsoft.Authorization.json
@@ -18,10 +18,8 @@
           ]
         },
         "name": {
-          "oneOf": [
-            { "type": "string" },
-            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-          ],
+          "type": "string",
+          "minLength": 1,
           "description": "Name of the roleAssignment"
         },
         "dependsOn": {
@@ -29,7 +27,8 @@
             { 
               "type": "array",
               "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               }
             },
             { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
@@ -40,24 +39,18 @@
           "type": "object",
           "properties": {
             "roleDefinitionId": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Authorization/roleAssignments: roleDefinitionId - id of the role to be used in the role assignment"
             },
             "principalId": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Authorization/roleAssignments: principalId - specifies the principal Id.  This maps to the id inside the directory and can point to a user, service principal, or security group"
             },
             "scope": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Authorization/roleAssignments: scope - specifies the scope at which this role assignment applies to"
             }
           },

--- a/schemas/2015-01-01/Microsoft.Authorization.json
+++ b/schemas/2015-01-01/Microsoft.Authorization.json
@@ -18,14 +18,9 @@
           ]
         },
         "name": {
-              "oneOf": [
-                {
-                  "type": "string",
-                  "maxLength": 64
-                },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ]
-          ,
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
           "description": "Name of the lock"
         },
         "dependsOn": {
@@ -52,13 +47,9 @@
               "description": "Microsoft.Authorization/locks: level - specifies the type of lock to apply to the scope.  CanNotDelete allows modification but prevents deletion, ReadOnly prevents modification or deletion."
             },
             "notes": {
-              "oneOf": [
-                {
-                  "type": "string",
-                  "maxLength": 512
-                },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 512,
               "description": "Microsoft.Authorization/locks: notes - user defined notes for the lock"
             }
           },

--- a/schemas/2015-01-01/Microsoft.Authorization.json
+++ b/schemas/2015-01-01/Microsoft.Authorization.json
@@ -18,8 +18,14 @@
           ]
         },
         "name": {
-          "type": "string",
-          "maxLength": 64,
+              "oneOf": [
+                {
+                  "type": "string",
+                  "maxLength": 64
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ]
+          ,
           "description": "Name of the lock"
         },
         "dependsOn": {
@@ -33,15 +39,26 @@
           "type": "object",
           "properties": {
             "level": {
-              "enum": [
-                "CannotDelete",
-                "ReadOnly"
-              ],
+              "oneOf": [
+                {
+                  "enum": [
+                    "CannotDelete",
+                    "ReadOnly"
+                  ] 
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ]
+              ,
               "description": "Microsoft.Authorization/locks: level - specifies the type of lock to apply to the scope.  CanNotDelete allows modification but prevents deletion, ReadOnly prevents modification or deletion."
             },
             "notes": {
-              "type": "string",
-              "maxLength": 512,
+              "oneOf": [
+                {
+                  "type": "string",
+                  "maxLength": 512
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Authorization/locks: notes - user defined notes for the lock"
             }
           },

--- a/schemas/2015-01-01/Microsoft.Resources.json
+++ b/schemas/2015-01-01/Microsoft.Resources.json
@@ -32,23 +32,44 @@
           "type": "object",
           "properties": {
             "mode": {
-              "enum": [ "Incremental", "Complete" ],
+              "oneOf": [
+                { "enum": [ "Incremental", "Complete" ] },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Deployment mode"
             },
             "templateLink": {
-              "$ref": "#/definitions/templateLink"
+              "oneOf": [
+                { "$ref": "#/definitions/templateLink" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Deployment template link"
             },
             "template": {
-              "type": "string"
+              "oneOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Deployment template"
             },
             "parametersLink": {
-              "$ref": "#/definitions/parametersLink"
+              "oneOf": [
+                { "$ref": "#/definitions/parametersLink" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Deployment parameters link"
             },
             "parameters": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#/definitions/parameter"
-              }
+              "oneOf": [
+                {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#/definitions/parameter"
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Deployment parameters"
             }
           },
           "required": [ "mode" ]
@@ -59,7 +80,8 @@
         "apiVersion",
         "name",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Resources/deployments"
     },
     "links": {
       "type": "object",
@@ -90,12 +112,20 @@
           "type": "object",
           "properties": {
             "targetId": {
-              "type": "string",
+              "oneOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Target resource id to link to"
             },
             "notes": {
-              "type": "string",
-              "maxLength": 512,
+              "oneOf": [
+                {
+                  "type": "string",
+                  "maxLength": 512
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Notes for this link"
             }
           },
@@ -109,7 +139,8 @@
         "apiVersion",
         "name",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Resources/links"
     }
   },
   "definitions": {

--- a/schemas/2015-01-01/Microsoft.Resources.json
+++ b/schemas/2015-01-01/Microsoft.Resources.json
@@ -19,12 +19,14 @@
         },
         "name": {
           "type": "string",
+          "minLength": 1,
           "description": "Name of the deployment"
         },
         "dependsOn": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "description": "Collection of resources this deployment depends on"
         },
@@ -46,10 +48,8 @@
               "description": "Deployment template link"
             },
             "template": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Deployment template"
             },
             "parametersLink": {
@@ -98,13 +98,15 @@
         },
         "name": {
           "type": "string",
+          "minLength": 1,
           "maxLength": 64,
           "description": "Name of the link"
         },
         "dependsOn": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "description": "Collection of resources this link depends on"
         },
@@ -112,20 +114,14 @@
           "type": "object",
           "properties": {
             "targetId": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Target resource id to link to"
             },
             "notes": {
-              "oneOf": [
-                {
-                  "type": "string",
-                  "maxLength": 512
-                },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 512,
               "description": "Notes for this link"
             }
           },
@@ -149,6 +145,7 @@
       "properties": {
         "uri": {
           "type": "string",
+          "minLength": 1,
           "description": "URI referencing the deployment template"
         },
         "contentVersion": {
@@ -165,6 +162,7 @@
       "properties": {
         "uri": {
           "type": "string",
+          "minLength": 1,
           "description": "URI referencing the deployment template parameters"
         },
         "contentVersion": {

--- a/schemas/2015-01-01/deploymentTemplate.json
+++ b/schemas/2015-01-01/deploymentTemplate.json
@@ -426,6 +426,12 @@
       "pattern": "^\\[(concat|parameters|variables|reference|resourceId|resourceGroup|subscription|listKeys|listPackage|base64|providers|copyIndex|padLeft|replace|toLower|toUpper|length|split|add|sub|mul|div|mod|string|int|uniqueString)\\(.*\\).*\\]$",
       "description": "Deployment template expression.  Expressions are enclosed in [] and must start with a function of concat(), parameters(), variables(), reference(), resourceId(), resourceGroup(), subscription(), listKeys(), listPackage(), base64(), providers(), copyIndex(), padLeft(), replace(), toLower(), toUpper(), length(), split(), add(), sub(), mul(), div(), mod(), string(), int(), uniqueString()"
     },
+    "numberOrExpression": {
+      "oneOf": [
+        { "type": "number" },
+        { "$ref": "#/definitions/expression" }
+      ]
+    },
     "Iso8601Duration": {
       "type": "string",
       "pattern": "^P(\\d+Y)?(\\d+M)?(\\d+D)?(T(((\\d+H)(\\d+M)?(\\d+(\\.\\d{1,2})?S)?)|((\\d+M)(\\d+(\\.\\d{1,2})?S)?)|((\\d+(\\.\\d{1,2})?S))))?$"

--- a/schemas/2015-03-01-preview/Microsoft.AppService.json
+++ b/schemas/2015-03-01-preview/Microsoft.AppService.json
@@ -20,45 +20,72 @@
           "type": "object",
           "properties": {
             "gateway": {
-              "$ref": "#/definitions/resourceReference",
+              "oneOf": [
+                { "$ref": "#/definitions/resourceReference" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.AppService/apiapps: Reference to a gateway resource"
             },
             "host": {
-              "$ref": "#/definitions/resourceReference",
+              "oneOf": [
+                { "$ref": "#/definitions/resourceReference" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.AppService/apiapps: Reference to a hosting web site resource"
             },
             "package": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "description": "Microsoft.AppService/apiapps: API App NuGet gallery package id"
-                }
-              }
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "Microsoft.AppService/apiapps: API App NuGet gallery package id"
+                    }
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.AppService/apiapps: API App NuGet gallery package"
             },
             "updatePolicy": {
-              "enum": [
-                "Auto",
-                "Manual",
-                "Inherited"
+              "oneOf": [
+                {
+                  "enum": [
+                    "Auto",
+                    "Manual",
+                    "Inherited"
+                  ],
+                  "default": "Auto"
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
-              "default": "Auto",
               "description": "Microsoft.AppService/apiapps: Update policy for the API App instance"
             },
             "accessLevel": {
-              "enum": [
-                "PublicAnonymous",
-                "Internal",
-                "PublicAuthenticated"
+              "oneOf": [
+                {
+                  "enum": [
+                    "PublicAnonymous",
+                    "Internal",
+                    "PublicAuthenticated"
+                  ],
+                  "default": "Internal"
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
-              "default": "Internal",
               "description": "Microsoft.AppService/apiapps: Access level of the API App instance"
             },
             "dependencies": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/resourceReference"
-              },
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/resourceReference"
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.AppService/apiapps: Collection of references to dependent API Apps instances"
             }
           },
@@ -90,7 +117,10 @@
           "type": "object",
           "properties": {
             "host": {
-              "$ref": "#/definitions/resourceReference",
+              "oneOf": [
+                { "$ref": "#/definitions/resourceReference" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.AppService/gateways: Reference to a hosting web site resource"
             }
           }

--- a/schemas/2015-04-01/Microsoft.NotificationHubs.json
+++ b/schemas/2015-04-01/Microsoft.NotificationHubs.json
@@ -21,12 +21,19 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string",
+              "oneOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.NotificationHubs/namespaces: The name of the namespace."
             },
             "namespaceType": {
-              "enum": [
-                "NotificationHub"
+              "oneOf": [
+                { "enum": [
+                    "NotificationHub"
+                  ]
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.NotificationHubs/namespaces: The type of the namespace"
             }
@@ -74,129 +81,164 @@
           "type": "object",
           "properties": {
             "wnsCredential": {
-              "type": "object",
-              "properties": {
-                "packageSid": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Package SID provided by Windows Live Application Management when registering the application."
+              "oneOf": [
+                { 
+                  "type": "object",
+                  "properties": {
+                    "packageSid": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Package SID provided by Windows Live Application Management when registering the application."
+                    },
+                    "secretKey": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Secret Key associated with the packageSid provided by Windows Live Application Management when registering the application."
+                    },
+                    "windowsLiveEndpoint": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Windows Live Endpoint used to retrieve the Access Token for the application"
+                    }
+                  }
                 },
-                "secretKey": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Secret Key associated with the packageSid provided by Windows Live Application Management when registering the application."
-                },
-                "windowsLiveEndpoint": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Windows Live Endpoint used to retrieve the Access Token for the application"
-                }
-              },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: WNS credentials for a Notification Hub."
             },
             "apnsCredential": {
-              "type": "object",
-              "properties": {
-                "apnsCertificate": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: A certificate (in base 64 format) provided by Apple on the iOS Provisioning Portal"
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "apnsCertificate": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: A certificate (in base 64 format) provided by Apple on the iOS Provisioning Portal"
+                    },
+                    "certificateKey": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Certificate Key provided by the iOS Provisioning Portal when registering the application"
+                    },
+                    "endpoint": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The APNS endpoint to which our service connects. This is one of two values: gateway.sandbox.push.apple.com for the sandbox endpoint or gateway.push.apple.com, for the production endpoint. Any other value is invalid."
+                    }
+                  }
                 },
-                "certificateKey": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Certificate Key provided by the iOS Provisioning Portal when registering the application"
-                },
-                "endpoint": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The APNS endpoint to which our service connects. This is one of two values: gateway.sandbox.push.apple.com for the sandbox endpoint or gateway.push.apple.com, for the production endpoint. Any other value is invalid."
-                }
-              },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: APNS credentials for a Notification Hub."
             },
             "gcmCredential": {
-              "type": "object",
-              "properties": {
-                "googleApiKey": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: Google API key for authenticating with GCM"
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "googleApiKey": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: Google API key for authenticating with GCM"
+                    },
+                    "gcmEndpoint": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The GCM endpoint to which our connects. Valid endpoint: https://android.googleapis.com/gcm/send . Other values are invalid."
+                    }
+                  }
                 },
-                "gcmEndpoint": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The GCM endpoint to which our connects. Valid endpoint: https://android.googleapis.com/gcm/send . Other values are invalid."
-                }
-              },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: GCM credentials for a Notification Hub."
             },
             "mpnsCredential": {
-              "type": "object",
-              "properties": {
-                "mpnsCertificate": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: A certificate (in base 64 format) uploaded to the Windows Phone portal"
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "mpnsCertificate": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: A certificate (in base 64 format) uploaded to the Windows Phone portal"
+                    },
+                    "certificateKey": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Certificate Key provided by the Windows Phone Portal when registering the application"
+                    }
+                  }
                 },
-                "certificateKey": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Certificate Key provided by the Windows Phone Portal when registering the application"
-                }
-              },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: MPNS credentials for a Notification Hub."
             },
             "AdmCredential": {
-              "type": "object",
-              "properties": {
-                "clientId": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: ClientId for authenticating with ADM"
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "clientId": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: ClientId for authenticating with ADM"
+                    },
+                    "clientSecret": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: ClientSecret for authenticating with ADM"
+                    },
+                    "authTokenUrl": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The AuthToken URL. valid endpoint: https://api.amazon.com/auth/O2/token . Other values are invalid."
+                    }
+                  }
                 },
-                "clientSecret": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: ClientSecret for authenticating with ADM"
-                },
-                "authTokenUrl": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The AuthToken URL. valid endpoint: https://api.amazon.com/auth/O2/token . Other values are invalid."
-                }
-              },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: ADM credentials for a Notification Hub."
             },
             "BaiduCredential": {
-              "type": "object",
-              "properties": {
-                "baiduApiKey": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: ApiKey provided by the Baidu portal"
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "baiduApiKey": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: ApiKey provided by the Baidu portal"
+                    },
+                    "baiduSecretKey": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: SecretKey provided by the Baidu portal"
+                    },
+                    "baiduEndPoint": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Baidu endpoint to which our service connects"
+                    }
+                  }
                 },
-                "baiduSecretKey": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: SecretKey provided by the Baidu portal"
-                },
-                "baiduEndPoint": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Baidu endpoint to which our service connects"
-                }
-              },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: Baidu credentials for a Notification Hub."
             },
             "authorizationRules": {
-              "type": "object",
-              "properties": {
-                "keyName": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: Authorization Rule Name"
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "keyName": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: Authorization Rule Name"
+                    },
+                    "primaryKey": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: Authorization Rule Primary Key Value"
+                    },
+                    "secondaryKey": {
+                      "type": "string",
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs:  Authorization Rule Secondary Key Value"
+                    },
+                    "rights": {
+                      "enum": [
+                        "Send",
+                        "Manage",
+                        "Listen"
+                      ],
+                      "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: Authorization Rule Rights"
+                    }
+                  }
                 },
-                "primaryKey": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: Authorization Rule Primary Key Value"
-                },
-                "secondaryKey": {
-                  "type": "string",
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs:  Authorization Rule Secondary Key Value"
-                },
-                "rights": {
-                  "enum": [
-                    "Send",
-                    "Manage",
-                    "Listen"
-                  ],
-                  "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: Authorization Rule Rights"
-                }
-              },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: Authorization Rules for a Notification Hub."
             }
           }

--- a/schemas/2015-04-01/Microsoft.NotificationHubs.json
+++ b/schemas/2015-04-01/Microsoft.NotificationHubs.json
@@ -21,10 +21,8 @@
           "type": "object",
           "properties": {
             "name": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.NotificationHubs/namespaces: The name of the namespace."
             },
             "namespaceType": {
@@ -47,11 +45,7 @@
           "items": {
             "allOf": [
               { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/resourceBase" },
-              {
-                "anyOf": [
-                  { "$ref": "#/resourceDefinitions/notificationHubs" }
-                ]
-              }
+              { "$ref": "#/resourceDefinitions/notificationHubs" }
             ]
           },
           "description": "Microsoft.NotificationHubs/namespaces: Collection of NotificationHubs resources."
@@ -87,14 +81,17 @@
                   "properties": {
                     "packageSid": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Package SID provided by Windows Live Application Management when registering the application."
                     },
                     "secretKey": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Secret Key associated with the packageSid provided by Windows Live Application Management when registering the application."
                     },
                     "windowsLiveEndpoint": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Windows Live Endpoint used to retrieve the Access Token for the application"
                     }
                   }
@@ -110,14 +107,17 @@
                   "properties": {
                     "apnsCertificate": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: A certificate (in base 64 format) provided by Apple on the iOS Provisioning Portal"
                     },
                     "certificateKey": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Certificate Key provided by the iOS Provisioning Portal when registering the application"
                     },
                     "endpoint": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The APNS endpoint to which our service connects. This is one of two values: gateway.sandbox.push.apple.com for the sandbox endpoint or gateway.push.apple.com, for the production endpoint. Any other value is invalid."
                     }
                   }
@@ -133,10 +133,12 @@
                   "properties": {
                     "googleApiKey": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: Google API key for authenticating with GCM"
                     },
                     "gcmEndpoint": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The GCM endpoint to which our connects. Valid endpoint: https://android.googleapis.com/gcm/send . Other values are invalid."
                     }
                   }
@@ -152,10 +154,12 @@
                   "properties": {
                     "mpnsCertificate": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: A certificate (in base 64 format) uploaded to the Windows Phone portal"
                     },
                     "certificateKey": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Certificate Key provided by the Windows Phone Portal when registering the application"
                     }
                   }
@@ -171,14 +175,17 @@
                   "properties": {
                     "clientId": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: ClientId for authenticating with ADM"
                     },
                     "clientSecret": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: ClientSecret for authenticating with ADM"
                     },
                     "authTokenUrl": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The AuthToken URL. valid endpoint: https://api.amazon.com/auth/O2/token . Other values are invalid."
                     }
                   }
@@ -194,14 +201,17 @@
                   "properties": {
                     "baiduApiKey": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: ApiKey provided by the Baidu portal"
                     },
                     "baiduSecretKey": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: SecretKey provided by the Baidu portal"
                     },
                     "baiduEndPoint": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: The Baidu endpoint to which our service connects"
                     }
                   }
@@ -217,14 +227,17 @@
                   "properties": {
                     "keyName": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: Authorization Rule Name"
                     },
                     "primaryKey": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs: Authorization Rule Primary Key Value"
                     },
                     "secondaryKey": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Microsoft.NotificationHubs/namespaces/notificationHubs:  Authorization Rule Secondary Key Value"
                     },
                     "rights": {

--- a/schemas/2015-04-08/Microsoft.DocumentDB.json
+++ b/schemas/2015-04-08/Microsoft.DocumentDB.json
@@ -23,40 +23,57 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string",
-              "pattern": "^[a-z][a-z0-9-]*$",
+              "anyOf": [
+                {
+                  "type": "string",
+                  "pattern": "^[a-z][a-z0-9-]*$"
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.DocumentDB/databaseAccounts: Name of the database account."
             },
             "databaseAccountOfferType": {
-              "enum": [
-                "Standard"
-              ]
-            },
-            "consistencyPolicy": {
-              "type": "object",
-              "properties": {
-                "defaultConsistencyLevel": {
+              "oneOf": [
+                {
                   "enum": [
-                    "Strong",
-                    "Eventual",
-                    "Session",
-                    "BoundedStaleness"
+                    "Standard"
                   ]
                 },
-                "maxStalenessPrefix": {
-                  "maximum": 1000,
-                  "minimum": 10,
-                  "type": "integer"
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.DocumentDB/databaseAccounts: Database account offer type"
+            },
+            "consistencyPolicy": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "defaultConsistencyLevel": {
+                      "enum": [
+                        "Strong",
+                        "Eventual",
+                        "Session",
+                        "BoundedStaleness"
+                      ]
+                    },
+                    "maxStalenessPrefix": {
+                      "maximum": 1000,
+                      "minimum": 10,
+                      "type": "integer"
+                    },
+                    "maxIntervalInSeconds": {
+                      "type": "integer",
+                      "minimum": 5,
+                      "maximum": 600
+                    }
+                  },
+                  "required": [
+                    "defaultConsistencyLevel"
+                  ]
                 },
-                "maxIntervalInSeconds": {
-                  "type": "integer",
-                  "minimum": 5,
-                  "maximum": 600
-                }
-              },
-              "required": [
-                "defaultConsistencyLevel"
-              ]
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.DocumentDB/databaseAccounts: Consistency policy"
             }
           },
           "required": [

--- a/schemas/2015-04-08/Microsoft.DocumentDB.json
+++ b/schemas/2015-04-08/Microsoft.DocumentDB.json
@@ -23,7 +23,7 @@
           "type": "object",
           "properties": {
             "name": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "string",
                   "pattern": "^[a-z][a-z0-9-]*$"

--- a/schemas/2015-05-21-preview/Microsoft.DevTestLab.json
+++ b/schemas/2015-05-21-preview/Microsoft.DevTestLab.json
@@ -39,10 +39,8 @@
           "type": "object",
           "properties": {
             "labId": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.DevTestLab/environments - Lab ID"
             },
             "vms": {

--- a/schemas/2015-05-21-preview/Microsoft.DevTestLab.json
+++ b/schemas/2015-05-21-preview/Microsoft.DevTestLab.json
@@ -38,22 +38,34 @@
         "properties": {
           "type": "object",
           "properties": {
-            "labId": { "type": "string" },
+            "labId": {
+              "oneOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.DevTestLab/environments - Lab ID"
+            },
             "vms": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "required": [ "name", "vmTemplateName", "size" ],
-                "properties": {
-                  "name": { "type": "string" },
-                  "vmTemplateName": { "type": "string" },
-                  "size": { "type": "string" },
-                  "userName": { "type": "string" },
-                  "password": { "type": "string" },
-                  "sshKey": { "type": "string" },
-                  "isAuthenticationWithSshKey": { "type": "boolean" }
-                }
-              }
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [ "name", "vmTemplateName", "size" ],
+                    "properties": {
+                      "name": { "type": "string" },
+                      "vmTemplateName": { "type": "string" },
+                      "size": { "type": "string" },
+                      "userName": { "type": "string" },
+                      "password": { "type": "string" },
+                      "sshKey": { "type": "string" },
+                      "isAuthenticationWithSshKey": { "type": "boolean" }
+                    }
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.DevTestLab/environments - VMs"
             }
           },
           "required": [ "labId", "vms" ]

--- a/schemas/2015-06-01/Microsoft.KeyVault.json
+++ b/schemas/2015-06-01/Microsoft.KeyVault.json
@@ -118,13 +118,23 @@
       "type": "object",
       "properties": {
         "tenantId": {
-          "type": "string",
-          "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+          "oneOf": [
+            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" },
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            }
+          ],
           "description": "Microsoft.KeyVault/vaults: The tenant ID of the Azure Active Directory Tenant containing the objectId in this access policy."
         },
         "objectId": {
-          "type": "string",
-          "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+          "oneOf": [
+            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" },
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            }
+          ],
           "description": "Microsoft.KeyVault/vaults: The object ID of the Azure Active Directory object to apply this access policy to.  For example, the object ID of a Service Principal, or of a User Principal."
         },
         "permissions": {

--- a/schemas/2015-06-01/Microsoft.KeyVault.json
+++ b/schemas/2015-06-01/Microsoft.KeyVault.json
@@ -16,7 +16,8 @@
             }
           }
         }
-      ]
+      ],
+      "description": "Microsoft.KeyVault/vaults/secrets"
     },
     "secretsChild": {
       "allOf": [
@@ -30,7 +31,8 @@
             }
           }
         }
-      ]
+      ],
+      "description": "Microsoft.KeyVault/secretsChild"
     },
     "vaults": {
       "type": "object",
@@ -50,21 +52,40 @@
           "type": "object",
           "properties": {
             "sku": {
-              "$ref": "#/definitions/sku"
+              "oneOf": [
+                { "$ref": "#/definitions/sku" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.KeyVault/vaults: Sku"
             },
             "tenantId": {
-              "type": "string",
-              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.KeyVault/vaults: The tenant ID of the Azure Active Directory Tenant to use for authorization."
             },
             "accessPolicies": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/accessPolicy"
-              }
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/accessPolicy"
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.KeyVault/vaults: Access policies"
             },
             "enabledForDeployment": {
-              "type": "boolean"
+              "oneOf": [
+                { "type": "boolean" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.KeyVault/vaults: Enabled for deployment"
             }
           },
           "required": [
@@ -80,14 +101,16 @@
               { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/resourceBase" },
               { "$ref": "#/resourceDefinitions/secretsChild" }
             ]
-          }
+          },
+          "description": "Microsoft.KeyVault/vaults: Child resources"
         }
       },
       "required": [
         "apiVersion",
         "properties",
         "type"
-      ]
+      ],
+      "description": "Microsoft.KeyVault/vaults"
     }
   },
   "definitions": {

--- a/schemas/2015-08-01-preview/Microsoft.DataConnect.json
+++ b/schemas/2015-08-01-preview/Microsoft.DataConnect.json
@@ -21,7 +21,10 @@
           "type": "object",
           "properties": {
             "description": {
-              "type": "string",
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.DataConnect/connectionManagers: The description of the connectionManager."
             }
           }

--- a/schemas/2015-08-01-preview/Microsoft.DataConnect.json
+++ b/schemas/2015-08-01-preview/Microsoft.DataConnect.json
@@ -21,10 +21,8 @@
           "type": "object",
           "properties": {
             "description": {
-              "anyOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.DataConnect/connectionManagers: The description of the connectionManager."
             }
           }

--- a/schemas/2015-08-01/Microsoft.Cache.json
+++ b/schemas/2015-08-01/Microsoft.Cache.json
@@ -138,14 +138,8 @@
               "description": "Microsoft.Cache/Redis (optional) the ARM resource ID of a Classic Virtual Network for the redis cache to join"
             },
             "subnet": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-                }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Cache/Redis (required with virtualNetwork) the name of an existing subnet for the redis cache to join"
             },
             "staticIP": {

--- a/schemas/2015-08-01/Microsoft.Cache.json
+++ b/schemas/2015-08-01/Microsoft.Cache.json
@@ -33,57 +33,65 @@
           "type": "object",
           "properties": {
             "sku": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "oneOf": [
-                    {
-                      "enum": [
-                        "Basic",
-                        "Standard",
-                        "Premium"
-                      ]
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "Basic",
+                            "Standard",
+                            "Premium"
+                          ]
+                        },
+                        {
+                          "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+                        }
+                      ],
+                      "description": "Microsoft.Cache/Redis/sku: determines features and pricing of the cache",
+                      "default": "Standard"
                     },
-                    {
-                      "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+                    "family": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "C",
+                            "P"
+                          ]
+                        },
+                        {
+                          "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+                        }
+                      ],
+                      "description": "Microsoft.Cache/Redis/sku: along with capacity, determines capacity of the cache",
+                      "default": "C"
+                    },
+                    "capacity": {
+                      "oneOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+                        }
+                      ],
+                      "description": "Microsoft.Cache/Redis: along with family, determines capacity of the cache",
+                      "default": 1
                     }
-                  ],
-                  "description": "Microsoft.Cache/Redis/sku: determines features and pricing of the cache",
-                  "default": "Standard"
+                  },
+                  "required": [
+                    "name",
+                    "family",
+                    "capacity"
+                  ] 
                 },
-                "family": {
-                  "oneOf": [
-                    {
-                      "enum": [
-                        "C",
-                        "P"
-                      ]
-                    },
-                    {
-                      "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-                    }
-                  ],
-                  "description": "Microsoft.Cache/Redis/sku: along with capacity, determines capacity of the cache",
-                  "default": "C"
-                },
-                "capacity": {
-                  "oneOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-                    }
-                  ],
-                  "description": "Microsoft.Cache/Redis: along with family, determines capacity of the cache",
-                  "default": 1
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
                 }
-              },
-              "required": [
-                "name",
-                "family",
-                "capacity"
-              ]
+              ],
+              "description": "Microsoft.Cache/Redis/sku"
             },
             "shardCount": {
               "oneOf": [
@@ -108,7 +116,15 @@
               "description": "Microsoft.Cache/Redis if set to true, enables less secure direct access to redis on port 6379 (WITHOUT SSL tunneling)"
             },
             "redisConfiguration": {
-              "type": "object"
+              "oneOf": [
+                { 
+                  "type": "object"
+                },
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+                }
+              ],
+              "description": "Microsoft.Cache/Redis/redisConfiguration"
             },
             "virtualNetwork": {
               "oneOf": [

--- a/schemas/2015-08-01/Microsoft.Compute.json
+++ b/schemas/2015-08-01/Microsoft.Compute.json
@@ -203,24 +203,18 @@
         "properties": {
           "properties": {
             "publisher": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Compute/extensions - Publisher"
             },
             "type": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Compute/extensions - Type"
             },
             "typeHandlerVersion": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Compute/extensions - Type handler version"
             },
             "settings": {
@@ -264,24 +258,18 @@
         "properties": {
           "properties": {
             "publisher": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Compute/extensionsChild - Publisher"
             },
             "type": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Compute/extensionsChild - Type"
             },
             "typeHandlerVersion": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Compute/extensionsChild - Type handler version"
             },
             "settings": {

--- a/schemas/2015-08-01/Microsoft.Compute.json
+++ b/schemas/2015-08-01/Microsoft.Compute.json
@@ -22,14 +22,14 @@
           "type": "object",
           "properties": {
             "platformUpdateDomainCount": {
-              "anyOf": [
+              "oneOf": [
                 { "type": "number" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Compute/availabilitySets - Platform update domain count"
             },
             "platformFaultDomainCount": {
-              "anyOf": [
+              "oneOf": [
                 { "type": "number" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
@@ -62,35 +62,35 @@
         "properties": {
           "properties": {
             "availabilitySet": {
-              "anyOf": [
+              "oneOf": [
                 { "$ref": "#/definitions/id" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Compute/virtualMachines - Availability set"
             },
             "hardwareProfile": {
-              "anyOf": [
+              "oneOf": [
                 { "$ref": "#/definitions/hardwareProfile" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Compute/virtualMachines - Hardware profile"
             },
             "storageProfile": {
-              "anyOf": [
+              "oneOf": [
                 { "$ref": "#/definitions/storageProfile" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Compute/virtualMachines - Storage profile"
             },
             "osProfile": {
-              "anyOf": [
+              "oneOf": [
                 { "$ref": "#/definitions/osProfile" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Mirosoft.Compute/virtualMachines - Operating system profile"
             },
             "networkProfile": {
-              "anyOf": [
+              "oneOf": [
                 { "$ref": "#/definitions/networkProfile" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
@@ -159,14 +159,14 @@
         "properties": {
           "properties": {
             "upgradePolicy": {
-              "anyOf": [
+              "oneOf": [
                 { "$ref": "#/definitions/upgradePolicy" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Compute/virtualMachineScaleSets - Upgrade policy"
             },
             "virtualMachineProfile": {
-              "anyOf": [
+              "oneOf": [
                 { "$ref": "#/definitions/virtualMachineProfile" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
@@ -203,28 +203,28 @@
         "properties": {
           "properties": {
             "publisher": {
-              "anyOf": [
+              "oneOf": [
                 { "type": "string" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Compute/extensions - Publisher"
             },
             "type": {
-              "anyOf": [
+              "oneOf": [
                 { "type": "string" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Compute/extensions - Type"
             },
             "typeHandlerVersion": {
-              "anyOf": [
+              "oneOf": [
                 { "type": "string" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Compute/extensions - Type handler version"
             },
             "settings": {
-              "anyOf": [
+              "oneOf": [
                 { "type": "object" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
@@ -264,28 +264,28 @@
         "properties": {
           "properties": {
             "publisher": {
-              "anyOf": [
+              "oneOf": [
                 { "type": "string" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Compute/extensionsChild - Publisher"
             },
             "type": {
-              "anyOf": [
+              "oneOf": [
                 { "type": "string" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Compute/extensionsChild - Type"
             },
             "typeHandlerVersion": {
-              "anyOf": [
+              "oneOf": [
                 { "type": "string" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Compute/extensionsChild - Type handler version"
             },
             "settings": {
-              "anyOf": [
+              "oneOf": [
                 { "type": "object" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],

--- a/schemas/2015-08-01/Microsoft.Compute.json
+++ b/schemas/2015-08-01/Microsoft.Compute.json
@@ -22,10 +22,18 @@
           "type": "object",
           "properties": {
             "platformUpdateDomainCount": {
-              "type": "number"
+              "anyOf": [
+                { "type": "number" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Compute/availabilitySets - Platform update domain count"
             },
             "platformFaultDomainCount": {
-              "type": "number"
+              "anyOf": [
+                { "type": "number" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Compute/availabilitySets - Platform fault domain count"
             }
           }
         }
@@ -34,7 +42,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Compute/availabilitySets"
     },
     "virtualMachines": {
       "type": "object",
@@ -53,19 +62,39 @@
         "properties": {
           "properties": {
             "availabilitySet": {
-              "$ref": "#/definitions/id"
+              "anyOf": [
+                { "$ref": "#/definitions/id" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Compute/virtualMachines - Availability set"
             },
             "hardwareProfile": {
-              "$ref": "#/definitions/hardwareProfile"
+              "anyOf": [
+                { "$ref": "#/definitions/hardwareProfile" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Compute/virtualMachines - Hardware profile"
             },
             "storageProfile": {
-              "$ref": "#/definitions/storageProfile"
+              "anyOf": [
+                { "$ref": "#/definitions/storageProfile" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Compute/virtualMachines - Storage profile"
             },
             "osProfile": {
-              "$ref": "#/definitions/osProfile"
+              "anyOf": [
+                { "$ref": "#/definitions/osProfile" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Mirosoft.Compute/virtualMachines - Operating system profile"
             },
             "networkProfile": {
-              "$ref": "#/definitions/networkProfile"
+              "anyOf": [
+                { "$ref": "#/definitions/networkProfile" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Compute/virtualMachines - Network profile"
             }
           },
           "type": "object",
@@ -107,7 +136,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Compute/virtualMachines"
     },
     "virtualMachineScaleSets": {
       "type": "object",
@@ -129,10 +159,18 @@
         "properties": {
           "properties": {
             "upgradePolicy": {
-              "$ref": "#/definitions/upgradePolicy"
+              "anyOf": [
+                { "$ref": "#/definitions/upgradePolicy" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Compute/virtualMachineScaleSets - Upgrade policy"
             },
             "virtualMachineProfile": {
-              "$ref": "#/definitions/virtualMachineProfile"
+              "anyOf": [
+                { "$ref": "#/definitions/virtualMachineProfile" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Compute/virtualMachineScaleSets - Virtual machine policy"
             }
           },
           "type": "object",
@@ -145,7 +183,8 @@
       "required": [
         "sku",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Compute/virtualMachineScaleSets"
     },
     "extensions": {
       "type": "object",
@@ -164,16 +203,32 @@
         "properties": {
           "properties": {
             "publisher": {
-              "type": "string"
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Compute/extensions - Publisher"
             },
             "type": {
-              "type": "string"
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Compute/extensions - Type"
             },
             "typeHandlerVersion": {
-              "type": "string"
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Compute/extensions - Type handler version"
             },
             "settings": {
-              "type": "object"
+              "anyOf": [
+                { "type": "object" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Compute/extensions - Settings"
             }
           },
           "type": "object",
@@ -189,7 +244,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Compute/extensions"
     },
     "extensionsChild": {
       "type": "object",
@@ -208,16 +264,32 @@
         "properties": {
           "properties": {
             "publisher": {
-              "type": "string"
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Compute/extensionsChild - Publisher"
             },
             "type": {
-              "type": "string"
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Compute/extensionsChild - Type"
             },
             "typeHandlerVersion": {
-              "type": "string"
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Compute/extensionsChild - Type handler version"
             },
             "settings": {
-              "type": "object"
+              "anyOf": [
+                { "type": "object" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Compute/extensionsChild - Settings"
             }
           },
           "type": "object",
@@ -233,7 +305,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Compute/extensionsChild"
     }
   },
   "definitions": {

--- a/schemas/2015-08-01/Microsoft.Compute.json
+++ b/schemas/2015-08-01/Microsoft.Compute.json
@@ -22,17 +22,11 @@
           "type": "object",
           "properties": {
             "platformUpdateDomainCount": {
-              "oneOf": [
-                { "type": "number" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/numberOrExpression",
               "description": "Microsoft.Compute/availabilitySets - Platform update domain count"
             },
             "platformFaultDomainCount": {
-              "oneOf": [
-                { "type": "number" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/numberOrExpression",
               "description": "Microsoft.Compute/availabilitySets - Platform fault domain count"
             }
           }

--- a/schemas/2015-08-01/Microsoft.Network.json
+++ b/schemas/2015-08-01/Microsoft.Network.json
@@ -39,10 +39,7 @@
               "description": "Microsoft.Network/publicIPAddresses: Public IP allocation method"
             },
             "idleTimeoutInMinutes": {
-              "oneOf": [
-                { "type": "number" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/numberOrExpression",
               "description": "Microsoft.Network/publicIPAddresses: Idle timeout in minutes"
             },
             "dnsSettings": {

--- a/schemas/2015-08-01/Microsoft.Network.json
+++ b/schemas/2015-08-01/Microsoft.Network.json
@@ -19,16 +19,15 @@
           ]
         },
         "name": {
-          "anyOf": [
-            { "type": "string" },
-            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-          ]
+          "type": "string",
+          "minLength": 1,
+          "description": "Microsoft.Network/publicIPAddresses: Name"
         },
         "properties": {
           "type": "object",
           "properties": {
             "publicIPAllocationMethod": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "enum": [
                     "Dynamic",
@@ -40,14 +39,14 @@
               "description": "Microsoft.Network/publicIPAddresses: Public IP allocation method"
             },
             "idleTimeoutInMinutes": {
-              "anyOf": [
+              "oneOf": [
                 { "type": "number" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Network/publicIPAddresses: Idle timeout in minutes"
             },
             "dnsSettings": {
-              "anyOf": [
+              "oneOf": [
                 { "$ref": "#/definitions/publicIPAddressDnsSettings" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
@@ -88,14 +87,14 @@
           "type": "object",
           "properties": {
             "networkSecurityGroup": {
-              "anyOf": [
+              "oneOf": [
                 { "$ref": "#/definitions/id" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Network/networkInterfaces: Network security group"
             },
             "ipConfigurations": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "array",
                   "items": {
@@ -107,7 +106,7 @@
               "description": "Microsoft.Network/networkInterfaces: IP configurations"
             },
             "dnsSettings": {
-              "anyOf": [
+              "oneOf": [
                 { "$ref": "#/definitions/networkInterfaceDnsSettings" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
@@ -142,27 +141,29 @@
           ]
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "description": "Microsoft.Network/virtualNetworks: Name"
         },
         "properties": {
           "type": "object",
           "properties": {
             "addressSpace": {
-              "anyOf": [
+              "oneOf": [
                 { "$ref": "#/definitions/addressSpace" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Network/virtualNetworks: Address space"
             },
             "dhcpOptions": {
-              "anyOf": [
+              "oneOf": [
                 { "$ref": "#/definitions/dhcpOptions" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Network/virtualNetworks: DHCP options"
             },
             "subnets": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "array",
                   "items": { "$ref": "#/definitions/subnet" }
@@ -207,7 +208,7 @@
           "type": "object",
           "properties": {
             "frontendIPConfigurations": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "array",
                   "items": {
@@ -219,7 +220,7 @@
               "description": "Microsoft.Network/loadBalancers: Frontend IP configurations"
             },
             "backendAddressPools": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "array",
                   "items": {
@@ -231,7 +232,7 @@
               "description": "Microsoft.Network/loadBalancers: Backend address pools"
             },
             "loadBalancingRules": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "array",
                   "items": {
@@ -243,7 +244,7 @@
               "description": "Microsoft.Network/loadBalancers: Load balancing rules"
             },
             "probes": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "array",
                   "items": {
@@ -255,7 +256,7 @@
               "description": "Microsoft.Network/loadBalancers: Probes"
             },
             "inboundNatRules": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "array",
                   "items": {
@@ -267,7 +268,7 @@
               "description": "Microsoft.Network/loadBalancers: Inbound NAT rules"
             },
             "inboundNatPools": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "array",
                   "items": {
@@ -279,7 +280,7 @@
               "description": "Microsoft.Network/loadBalancers: Inbound NAT pools"
             },
             "outboundNatRules": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "array",
                   "items": {
@@ -325,7 +326,7 @@
           "type": "object",
           "properties": {
             "securityRules": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "array",
                   "items": {
@@ -371,7 +372,7 @@
           "type": "object",
           "properties": {
             "routes": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "array",
                   "items": {

--- a/schemas/2015-08-01/Microsoft.Network.json
+++ b/schemas/2015-08-01/Microsoft.Network.json
@@ -19,29 +19,39 @@
           ]
         },
         "name": {
-          "type": "string"
+          "anyOf": [
+            { "type": "string" },
+            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+          ]
         },
         "properties": {
           "type": "object",
           "properties": {
             "publicIPAllocationMethod": {
-              "oneOf": [
+              "anyOf": [
                 {
                   "enum": [
                     "Dynamic",
                     "Static"
                   ]
                 },
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-                }
-              ]
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/publicIPAddresses: Public IP allocation method"
             },
             "idleTimeoutInMinutes": {
-              "type": "number"
+              "anyOf": [
+                { "type": "number" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/publicIPAddresses: Idle timeout in minutes"
             },
             "dnsSettings": {
-              "$ref": "#/definitions/publicIPAddressDnsSettings"
+              "anyOf": [
+                { "$ref": "#/definitions/publicIPAddressDnsSettings" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/publicIPAddresses: DNS settings"
             }
           },
           "required": [
@@ -54,7 +64,8 @@
         "apiVersion",
         "name",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Network/publicIPAddresses"
     },
     "networkInterfaces": {
       "type": "object",
@@ -77,16 +88,30 @@
           "type": "object",
           "properties": {
             "networkSecurityGroup": {
-              "$ref": "#/definitions/id"
+              "anyOf": [
+                { "$ref": "#/definitions/id" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/networkInterfaces: Network security group"
             },
             "ipConfigurations": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ipConfiguration"
-              }
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/ipConfiguration"
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/networkInterfaces: IP configurations"
             },
             "dnsSettings": {
-              "$ref": "#/definitions/networkInterfaceDnsSettings"
+              "anyOf": [
+                { "$ref": "#/definitions/networkInterfaceDnsSettings" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/networkInterfaces: DNS settings"
             }
           },
           "required": [
@@ -99,7 +124,8 @@
         "apiVersion",
         "name",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Network/networkInterfaces"
     },
     "virtualNetworks": {
       "type": "object",
@@ -122,16 +148,28 @@
           "type": "object",
           "properties": {
             "addressSpace": {
-              "$ref": "#/definitions/addressSpace"
+              "anyOf": [
+                { "$ref": "#/definitions/addressSpace" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/virtualNetworks: Address space"
             },
             "dhcpOptions": {
-              "$ref": "#/definitions/dhcpOptions"
+              "anyOf": [
+                { "$ref": "#/definitions/dhcpOptions" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/virtualNetworks: DHCP options"
             },
             "subnets": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/subnet"
-              }
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": { "$ref": "#/definitions/subnet" }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/virtualNetworks: Subnets"
             }
           },
           "required": [
@@ -145,7 +183,8 @@
         "apiVersion",
         "name",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Network/virtualNetworks"
     },
     "loadBalancers": {
       "type": "object",
@@ -168,46 +207,88 @@
           "type": "object",
           "properties": {
             "frontendIPConfigurations": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/frontendIPConfigurations"
-              }
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/frontendIPConfigurations"
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/loadBalancers: Frontend IP configurations"
             },
             "backendAddressPools": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/backendAddressPools"
-              }
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/backendAddressPools"
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/loadBalancers: Backend address pools"
             },
             "loadBalancingRules": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/loadBalancingRules"
-              }
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/loadBalancingRules"
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/loadBalancers: Load balancing rules"
             },
             "probes": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/probes"
-              }
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/probes"
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/loadBalancers: Probes"
             },
             "inboundNatRules": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/inboundNatRules"
-              }
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/inboundNatRules"
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/loadBalancers: Inbound NAT rules"
             },
             "inboundNatPools": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/inboundNatPools"
-              }
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/inboundNatPools"
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/loadBalancers: Inbound NAT pools"
             },
             "outboundNatRules": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/outboundNatRules"
-              }
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/outboundNatRules"
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/loadBalancers: Outbound NAT rules"
             }
           },
           "required": [
@@ -220,7 +301,8 @@
         "apiVersion",
         "name",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Network/loadBalancers"
     },
     "networkSecurityGroups": {
       "type": "object",
@@ -243,10 +325,16 @@
           "type": "object",
           "properties": {
             "securityRules": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/securityRules"
-              }
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/securityRules"
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/networkSecurityGroups: Security rules"
             }
           },
           "required": [
@@ -259,7 +347,8 @@
         "apiVersion",
         "name",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Network/networkSecurityGroups"
     },
     "routeTables": {
       "type": "object",
@@ -282,10 +371,16 @@
           "type": "object",
           "properties": {
             "routes": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/routes"
-              }
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/routes"
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Network/routeTables: Routes"
             }
           },
           "required": [
@@ -298,7 +393,8 @@
         "apiVersion",
         "name",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Network/routeTables"
     }
   },
   "definitions": {

--- a/schemas/2015-08-01/Microsoft.Storage.json
+++ b/schemas/2015-08-01/Microsoft.Storage.json
@@ -22,10 +22,8 @@
           "type": "object",
           "properties": {
             "accountType": {
-              "oneOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Storage/storageAccounts: The type of this account."
             }
           },

--- a/schemas/2015-08-01/Microsoft.Storage.json
+++ b/schemas/2015-08-01/Microsoft.Storage.json
@@ -22,7 +22,11 @@
           "type": "object",
           "properties": {
             "accountType": {
-              "type": "string"
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Storage/storageAccounts: The type of this account."
             }
           },
           "required": [
@@ -34,7 +38,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Storage/storageAccounts"
     }
   }
 }

--- a/schemas/2015-08-01/Microsoft.Storage.json
+++ b/schemas/2015-08-01/Microsoft.Storage.json
@@ -22,7 +22,7 @@
           "type": "object",
           "properties": {
             "accountType": {
-              "anyOf": [
+              "oneOf": [
                 { "type": "string" },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],

--- a/schemas/2015-08-01/Microsoft.Web.json
+++ b/schemas/2015-08-01/Microsoft.Web.json
@@ -18,48 +18,67 @@
           ]
         },
         "sku": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string",
-              "pattern": "^[fdbspFDBSP][1-9]$",
-              "description": "Microsoft.Web/serverfarms: Server farm name. Letter denotes tier and numerical denotes size (small, medium, large). Note: D is for Shared tier"
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "pattern": "^[fdbspFDBSP][1-9]$"
+                    },
+                    { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                  ],
+                  "description": "Microsoft.Web/serverfarms: Server farm name. Letter denotes tier and numerical denotes size (small, medium, large). Note: D is for Shared tier"
+                },
+                "tier": {
+                  "anyOf": [
+                    {
+                      "enum": [
+                        "Free",
+                        "Shared",
+                        "Basic",
+                        "Standard",
+                        "Premium"
+                      ]
+                    },
+                    { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                  ],
+                  "description": "Microsoft.Web/serverfarms: Server farm tier."
+                },
+                "capacity": {
+                  "anyOf": [
+                    { "type": "integer" },
+                    { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                  ],
+                  "description": "Microsoft.Web/serverfarms: Server farm capacity."
+                }
+              },
+              "required": [ "name" ]
             },
-            "tier": {
-              "enum": [
-                "Free",
-                "Shared",
-                "Basic",
-                "Standard",
-                "Premium"
-              ],
-              "description": "Microsoft.Web/serverfarms: Server farm tier."
-            },
-            "capacity": {
-              "type": "integer",
-              "description": "Microsoft.Web/serverfarms: Server farm capacity."
-            }
-          },
-          "description": "Microsoft.Web/serverfarms: Server farm sku.",
-          "required": [ "name" ]
+            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+          ],
+          "description": "Microsoft.Web/serverfarms: Server farm sku."
         },
         "properties": {
           "type": "object",
           "properties": {
             "name": {
-              "type": "string",
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Web/serverfarms: Name of the server farm."
             },
             "numberOfWorkers": {
-              "oneOf": [
-                {
-                  "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-                },
+              "anyOf": [
                 {
                   "type": "integer",
                   "minimum": 0,
                   "maximum": 10
-                }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Web/serverfarms: The instance count, which is the number of virtual machines dedicated to the farm. Supported values are 1-10."
             }
@@ -70,7 +89,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Web/serverfarms"
     },
     "config": {
       "type": "object",
@@ -87,10 +107,15 @@
           ]
         },
         "name": {
-          "enum": [
-            "web",
-            "connectionstrings",
-            "appsettings"
+          "anyOf": [
+            {
+              "enum": [
+                "web",
+                "connectionstrings",
+                "appsettings"
+              ]
+            },
+            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
           ]
         }
       },
@@ -119,19 +144,31 @@
           "type": "object",
           "properties": {
             "packageUri": {
-              "type": "string",
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ], 
               "description": "Microsoft.Web/sites/extensions: uri of package"
             },
             "dbType": {
-              "type": "string",
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Web/sites/extensions: type of database"
             },
             "connectionString": {
-              "type": "string",
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Web/sites/extensions: connection string"
             },
             "setParameters": {
-              "type": "object",
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Web/sites/extensions: parameters"
             }
           }
@@ -141,7 +178,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Web/sites/extensions"
     },
     "sites": {
       "type": "object",
@@ -160,82 +198,109 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string",
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Web/sites: The name of web site."
             },
             "serverFarmId": {
-              "type": "string",
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Web/sites: The resource Id of server farm site belongs to."
             },
             "hostnames": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Web/sites: An array of strings that contains the public hostnames for the site, including custom domains."
             },
             "enabledHostnames": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Web/sites: An array of strings that contains enabled hostnames for the site. By default, these are <SiteName>.azurewebsites.net and <SiteName>.scm.azurewebsites.net."
             },
             "hostNameSslStates": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "Microsoft.Web/sites/hostNameSslStates: The URL of the web site."
-                  },
-                  "sslState": {
-                    "oneOf": [
-                      {
-                        "enum": [
-                          "Disabled",
-                          "IpBasedEnabled",
-                          "SniEnabled"
-                        ]
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "Microsoft.Web/sites/hostNameSslStates: The URL of the web site."
                       },
-                      {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 2
+                      "sslState": {
+                        "oneOf": [
+                          {
+                            "enum": [
+                              "Disabled",
+                              "IpBasedEnabled",
+                              "SniEnabled"
+                            ]
+                          },
+                          {
+                            "oneOf": [
+                                { "type": "integer" },
+                                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                            ],
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          {
+                            "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+                          }
+                        ],
+                        "description": "Microsoft.Web/sites/hostNameSslStates. The SSL state."
                       },
-                      {
-                        "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+                      "thumbprint": {
+                        "anyOf": [
+                          { "type": "string" },
+                          { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                        ],
+                        "description": "Microsoft.Web/sites/hostNameSslStates: A string that contains the thumbprint of the SSL certificate."
+                      },
+                      "ipBasedSslState": {
+                        "anyOf": [
+                          {
+                            "enum": [
+                              "Disabled",
+                              "IpBasedEnabled",
+                              "SniEnabled"
+                            ]
+                          },
+                          {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          {
+                            "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+                          }
+                        ],
+                        "description": "Microsoft.Web/sites/hostNameSslStates: IP Based SSL state"
                       }
-                    ],
-                    "description": "Microsoft.Web/sites/hostNameSslStates. The SSL state."
-                  },
-                  "thumbprint": {
-                    "type": "string",
-                    "description": "Microsoft.Web/sites/hostNameSslStates: A string that contains the thumbprint of the SSL certificate."
-                  },
-                  "ipBasedSslState": {
-                    "oneOf": [
-                      {
-                        "enum": [
-                          "Disabled",
-                          "IpBasedEnabled",
-                          "SniEnabled"
-                        ]
-                      },
-                      {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 2
-                      },
-                      {
-                        "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-                      }
-                    ],
-                    "description": "Microsoft.Web/sites/hostNameSslStates: IP Based SSL state"
+                    }
                   }
-                }
-              },
+                },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Web/sites: Container for SSL states."
             }
           }
@@ -271,7 +336,8 @@
         "type",
         "apiVersion",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Web/sites"
     },
     "certificates": {
       "type": "object",
@@ -290,11 +356,17 @@
           "type": "object",
           "properties": {
             "pfxBlob": {
-              "type": "string",
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Web/certificates: A base64Binary value that contains the PfxBlob of the certificate."
             },
             "password": {
-              "type": "string",
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Web/certficates: A string that contains the password for the certificate."
             }
           }
@@ -303,7 +375,8 @@
       "required": [
         "name",
         "properties"
-      ]
+      ],
+      "description": "Microsoft.Web/certificates"
     }
   },
   "definitions": {
@@ -317,11 +390,17 @@
           "type": "object",
           "properties": {
             "phpVersion": {
-              "type": "string",
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Web/sites/config: PHP version (an empty string disables PHP)."
             },
             "netFrameworkVersion": {
-              "type": "string",
+              "anyOf": [
+                { "type": "string" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
               "description": "Microsoft.Web/sites/config: The .Net Framework version."
             }
           }
@@ -348,14 +427,14 @@
             ],
             "properties": {
               "value": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+                ],
                 "description": "Microsoft.Web/sites/config/connectionstrings: Connection string to database."
               },
               "type": {
-                "oneOf": [
-                  {
-                    "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-                  },
+                "anyOf": [
                   {
                     "enum": [
                       "MySql",
@@ -363,7 +442,8 @@
                       "SQLAzure",
                       "Custom"
                     ]
-                  }
+                  },
+                  { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
                 ],
                 "description": "Microsoft.Web/sites/config/connectionstrings: Type of database."
               }
@@ -380,12 +460,18 @@
       "type": "object",
       "properties": {
         "name": {
-          "enum": [ "appsettings" ]
+          "anyOf": [
+            { "enum": [ "appsettings" ] },
+            { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+          ]
         },
         "properties": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "anyOf": [
+              { "type": "string" },
+              { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+            ]
           }
         }
       },

--- a/schemas/2015-08-01/Microsoft.Web.json
+++ b/schemas/2015-08-01/Microsoft.Web.json
@@ -18,12 +18,12 @@
           ]
         },
         "sku": {
-          "anyOf": [
+          "oneOf": [
             {
               "type": "object",
               "properties": {
                 "name": {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "type": "string",
                       "pattern": "^[fdbspFDBSP][1-9]$"
@@ -33,7 +33,7 @@
                   "description": "Microsoft.Web/serverfarms: Server farm name. Letter denotes tier and numerical denotes size (small, medium, large). Note: D is for Shared tier"
                 },
                 "tier": {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "enum": [
                         "Free",
@@ -48,7 +48,7 @@
                   "description": "Microsoft.Web/serverfarms: Server farm tier."
                 },
                 "capacity": {
-                  "anyOf": [
+                  "oneOf": [
                     { "type": "integer" },
                     { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
                   ],
@@ -65,14 +65,12 @@
           "type": "object",
           "properties": {
             "name": {
-              "anyOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/serverfarms: Name of the server farm."
             },
             "numberOfWorkers": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "integer",
                   "minimum": 0,
@@ -107,7 +105,7 @@
           ]
         },
         "name": {
-          "anyOf": [
+          "oneOf": [
             {
               "enum": [
                 "web",
@@ -144,31 +142,23 @@
           "type": "object",
           "properties": {
             "packageUri": {
-              "anyOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ], 
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/sites/extensions: uri of package"
             },
             "dbType": {
-              "anyOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/sites/extensions: type of database"
             },
             "connectionString": {
-              "anyOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/sites/extensions: connection string"
             },
             "setParameters": {
-              "anyOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/sites/extensions: parameters"
             }
           }
@@ -198,25 +188,22 @@
           "type": "object",
           "properties": {
             "name": {
-              "anyOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/sites: The name of web site."
             },
             "serverFarmId": {
-              "anyOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/sites: The resource Id of server farm site belongs to."
             },
             "hostnames": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                   }
                 },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
@@ -224,11 +211,12 @@
               "description": "Microsoft.Web/sites: An array of strings that contains the public hostnames for the site, including custom domains."
             },
             "enabledHostnames": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                   }
                 },
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
@@ -236,7 +224,7 @@
               "description": "Microsoft.Web/sites: An array of strings that contains enabled hostnames for the site. By default, these are <SiteName>.azurewebsites.net and <SiteName>.scm.azurewebsites.net."
             },
             "hostNameSslStates": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "array",
                   "items": {
@@ -244,6 +232,7 @@
                     "properties": {
                       "name": {
                         "type": "string",
+                        "minLength": 1,
                         "description": "Microsoft.Web/sites/hostNameSslStates: The URL of the web site."
                       },
                       "sslState": {
@@ -256,10 +245,7 @@
                             ]
                           },
                           {
-                            "oneOf": [
-                                { "type": "integer" },
-                                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-                            ],
+                            "type": "integer",
                             "minimum": 0,
                             "maximum": 2
                           },
@@ -270,14 +256,12 @@
                         "description": "Microsoft.Web/sites/hostNameSslStates. The SSL state."
                       },
                       "thumbprint": {
-                        "anyOf": [
-                          { "type": "string" },
-                          { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-                        ],
+                        "type": "string",
+                        "minLength": 1,
                         "description": "Microsoft.Web/sites/hostNameSslStates: A string that contains the thumbprint of the SSL certificate."
                       },
                       "ipBasedSslState": {
-                        "anyOf": [
+                        "oneOf": [
                           {
                             "enum": [
                               "Disabled",
@@ -356,17 +340,13 @@
           "type": "object",
           "properties": {
             "pfxBlob": {
-              "anyOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/certificates: A base64Binary value that contains the PfxBlob of the certificate."
             },
             "password": {
-              "anyOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/certficates: A string that contains the password for the certificate."
             }
           }
@@ -390,17 +370,13 @@
           "type": "object",
           "properties": {
             "phpVersion": {
-              "anyOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/sites/config: PHP version (an empty string disables PHP)."
             },
             "netFrameworkVersion": {
-              "anyOf": [
-                { "type": "string" },
-                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-              ],
+              "type": "string",
+              "minLength": 1,
               "description": "Microsoft.Web/sites/config: The .Net Framework version."
             }
           }
@@ -427,14 +403,12 @@
             ],
             "properties": {
               "value": {
-                "anyOf": [
-                  { "type": "string" },
-                  { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-                ],
+                "type": "string",
+                "minLength": 1,
                 "description": "Microsoft.Web/sites/config/connectionstrings: Connection string to database."
               },
               "type": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "enum": [
                       "MySql",
@@ -460,7 +434,7 @@
       "type": "object",
       "properties": {
         "name": {
-          "anyOf": [
+          "oneOf": [
             { "enum": [ "appsettings" ] },
             { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
           ]
@@ -468,10 +442,8 @@
         "properties": {
           "type": "object",
           "additionalProperties": {
-            "anyOf": [
-              { "type": "string" },
-              { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-            ]
+            "type": "string",
+            "minLength": 1
           }
         }
       },

--- a/tests/2014-08-01/Microsoft.Scheduler.tests.json
+++ b/tests/2014-08-01/Microsoft.Scheduler.tests.json
@@ -1,0 +1,24 @@
+{
+  "tests": [
+
+    {
+      "name": "jobCollections.properties.resources - Empty array",
+      "definition": "http://schema.management.azure.com/schemas/2014-08-01/Microsoft.Scheduler.json#/resourceDefinitions/jobCollections/properties/resources",
+      "json": [ ]
+    },
+
+    {
+      "name": "jobCollections.properties.resources - Array with one job resource",
+      "definition": "http://schema.management.azure.com/schemas/2014-08-01/Microsoft.Scheduler.json#/resourceDefinitions/jobCollections/properties/resources",
+      "json": [
+        {
+          "name": "Test Job Name",
+          "type": "Microsoft.Scheduler/jobCollections/jobs",
+          "apiVersion": "2014-08-01",
+          "properties": { }
+        }
+      ]
+    }
+
+  ]
+}

--- a/tests/2015-01-01/deploymentTemplate.tests.json
+++ b/tests/2015-01-01/deploymentTemplate.tests.json
@@ -1,0 +1,65 @@
+{
+  "tests": [
+    
+    {
+      "name": "apiVersion - Non-string",
+      "definition": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/apiVersion",
+      "expectedErrors": [
+        {
+          "message": "Invalid type: number (expected string)",
+          "dataPath": "/"
+        }
+      ],
+      "json": 1.0
+    },
+    
+    {
+      "name": "apiVersion - Doesn't match the pattern",
+      "definition": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/apiVersion",
+      "expectedErrors": [
+        {
+          "message": "String does not match pattern: (^((\\d\\d\\d\\d-\\d\\d-\\d\\d)|([0-9]+(\\.[0-9]+)?))(-[a-zA-Z][a-zA-Z0-9]*)?$)",
+          "dataPath": "/"
+        }
+      ],
+      "json": "Redmond, WA"
+    },
+    
+    {
+      "name": "apiVersion - Single word",
+      "definition": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/apiVersion",
+      "expectedErrors": [
+        {
+          "message": "String does not match pattern: (^((\\d\\d\\d\\d-\\d\\d-\\d\\d)|([0-9]+(\\.[0-9]+)?))(-[a-zA-Z][a-zA-Z0-9]*)?$)",
+          "dataPath": "/"
+        }
+      ],
+      "json": "spam"
+    },
+    
+    {
+      "name": "apiVersion - Valid api version without textual ending",
+      "definition": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/apiVersion",
+      "json": "2015-07-19"
+    },
+    
+    {
+      "name": "apiVersion - Valid api version with textual ending",
+      "definition": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/apiVersion",
+      "json": "2015-07-19-preview"
+    },
+    
+    {
+      "name": "apiVersion - Api version with multiple dashed textual ending",
+      "definition": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/apiVersion",
+      "expectedErrors": [
+        {
+          "message": "String does not match pattern: (^((\\d\\d\\d\\d-\\d\\d-\\d\\d)|([0-9]+(\\.[0-9]+)?))(-[a-zA-Z][a-zA-Z0-9]*)?$)",
+          "dataPath": "/"
+        }
+      ],
+      "json": "2015-07-19-preview-again"
+    }
+    
+  ]
+}

--- a/tests/2015-04-08/Microsoft.DocumentDB.tests.json
+++ b/tests/2015-04-08/Microsoft.DocumentDB.tests.json
@@ -89,7 +89,7 @@
       "name": "databaseAccounts - resource with invalid name property",
       "expectedErrors": [
         {
-          "message": "Data does not match any schemas from \"anyOf\"",
+          "message": "Data does not match any schemas from \"oneOf\"",
           "dataPath": "/properties/name",
           "schemaPath": "/properties/properties/properties/name/pattern"
         }

--- a/tests/2015-04-08/Microsoft.DocumentDB.tests.json
+++ b/tests/2015-04-08/Microsoft.DocumentDB.tests.json
@@ -68,7 +68,7 @@
       "name": "databaseAccounts - resource without defaultConsistencyLevel property",
       "expectedErrors": [
         {
-          "message": "Missing required property: defaultConsistencyLevel",
+          "message": "Data does not match any schemas from \"oneOf\"",
           "dataPath": "/properties/consistencyPolicy",
           "schemaPath": "/properties/properties/properties/consistencyPolicy/required/0"
         }
@@ -89,7 +89,7 @@
       "name": "databaseAccounts - resource with invalid name property",
       "expectedErrors": [
         {
-          "message": "String does not match pattern: ^[a-z][a-z0-9-]*$",
+          "message": "Data does not match any schemas from \"anyOf\"",
           "dataPath": "/properties/name",
           "schemaPath": "/properties/properties/properties/name/pattern"
         }
@@ -108,7 +108,7 @@
       "name": "databaseAccounts resource with invalid databaseAccountOfferType property",
       "expectedErrors": [
         {
-          "message": "No enum match for: \"Invalid\"",
+          "message": "Data does not match any schemas from \"oneOf\"",
           "dataPath": "/properties/databaseAccountOfferType",
           "schemaPath": "/properties/properties/properties/databaseAccountOfferType/type"
         }

--- a/tests/2015-08-01-preview/Microsoft.DataConnect.tests.json
+++ b/tests/2015-08-01-preview/Microsoft.DataConnect.tests.json
@@ -1,0 +1,65 @@
+{
+  "tests": [
+
+    {
+      "name": "connectionManagers - Empty JSON",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01-preview/Microsoft.DataConnect.json#/resourceDefinitions/connectionManagers",
+      "expectedErrors": [
+        {
+          "message": "Missing required property: type",
+          "dataPath": "/"
+        },
+        {
+          "message": "Missing required property: apiVersion",
+          "dataPath": "/"
+        },
+        {
+          "message": "Missing required property: properties",
+          "dataPath": "/"
+        }
+      ],
+      "json": { }
+    },
+
+    {
+      "name": "connectionManagers - Empty properties",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01-preview/Microsoft.DataConnect.json#/resourceDefinitions/connectionManagers",
+      "json": {
+        "type": "Microsoft.DataConnect/connectionManagers",
+        "apiVersion": "2015-08-01-preview",
+        "properties": { }
+      }
+    },
+
+    {
+      "name": "connectionManagers - Empty description property",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01-preview/Microsoft.DataConnect.json#/resourceDefinitions/connectionManagers",
+      "expectedErrors": [
+        {
+          "message": "String is too short (0 chars), minimum 1",
+          "dataPath": "/properties/description"
+        }
+      ],
+      "json": {
+        "type": "Microsoft.DataConnect/connectionManagers",
+        "apiVersion": "2015-08-01-preview",
+        "properties": {
+          "description": ""
+        }
+      }
+    },
+
+    {
+      "name": "connectionManagers - Non-empty description property",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01-preview/Microsoft.DataConnect.json#/resourceDefinitions/connectionManagers",
+      "json": {
+        "type": "Microsoft.DataConnect/connectionManagers",
+        "apiVersion": "2015-08-01-preview",
+        "properties": {
+          "description": "Test description"
+        }
+      }
+    }
+
+  ]
+}

--- a/tests/2015-08-01/Microsoft.Compute.tests.json
+++ b/tests/2015-08-01/Microsoft.Compute.tests.json
@@ -1,7 +1,7 @@
 {
     "tests": [
         {
-            "name": "Minimal AvailabilitySets resource",
+            "name": "availabilitySets - Empty properties",
             "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/availabilitySets",
             "json": {
                 "type": "Microsoft.Compute/availabilitySets",
@@ -12,7 +12,7 @@
         },
 
         {
-            "name": "AvailabilitySets resource without type and apiVersion",
+            "name": "availabilitySets - Without type and apiVersion",
             "expectedErrors": [
                 {
                     "message": "Missing required property: type",
@@ -31,7 +31,7 @@
         },
 
         {
-            "name": "Minimal VirtualMachines resource",
+            "name": "virtualMachines - Minimal",
             "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/virtualMachines",
             "json": {
                 "apiVersion": "2015-05-01-preview",
@@ -65,7 +65,7 @@
         },
 
         {
-            "name": "Minimal Extensions resource",
+            "name": "extensions - Minimal",
             "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/extensions",
             "json": {
                 "type": "Microsoft.Compute/virtualMachines/extensions",
@@ -80,7 +80,7 @@
         },
 
         {
-            "name": "Minimal ExtensionsChild resource",
+            "name": "extensionsChild - Minimal",
             "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/extensionsChild",
             "json": {
                 "type": "extensions",

--- a/tests/2015-08-01/Microsoft.Compute.tests.json
+++ b/tests/2015-08-01/Microsoft.Compute.tests.json
@@ -1,97 +1,122 @@
 {
-    "tests": [
-        {
-            "name": "availabilitySets - Empty properties",
-            "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/availabilitySets",
-            "json": {
-                "type": "Microsoft.Compute/availabilitySets",
-                "apiVersion": "2015-05-01-preview",
-                "properties": {
-                }
-            }
-        },
-
-        {
-            "name": "availabilitySets - Without type and apiVersion",
-            "expectedErrors": [
-                {
-                    "message": "Missing required property: type",
-                    "dataPath": "/"
-                },
-                {
-                    "message": "Missing required property: apiVersion",
-                    "dataPath": "/"
-                }
-            ],
-            "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/availabilitySets",
-            "json": {
-                "properties": {
-                }
-            }
-        },
-
-        {
-            "name": "virtualMachines - Minimal",
-            "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/virtualMachines",
-            "json": {
-                "apiVersion": "2015-05-01-preview",
-                "type": "Microsoft.Compute/virtualMachines",
-                "name": "[variables('vmName')]",
-                "location": "[variables('location')]",
-                "properties": {
-                    "hardwareProfile": {
-                        "vmSize": "[variables('vmSize')]"
-                    },
-                    "storageProfile": {
-                        "imageReference": {
-                            "publisher": "[variables('imagePublisher')]",
-                            "offer": "[variables('imageOffer')]",
-                            "sku": "[parameters('windowsOSVersion')]",
-                            "version": "latest"
-                        },
-                        "osDisk": {
-                            "name": "osdisk",
-                            "vhd": {
-                                "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
-                            },
-                            "createOption": "FromImage"
-                        }
-                    },
-                    "networkProfile": {
-                        "networkInterfaces": [ ]
-                    }
-                }
-            }
-        },
-
-        {
-            "name": "extensions - Minimal",
-            "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/extensions",
-            "json": {
-                "type": "Microsoft.Compute/virtualMachines/extensions",
-                "apiVersion": "2015-05-01-preview",
-                "properties": {
-                    "publisher": "Test Publisher",
-                    "type": "Test Type",
-                    "typeHandlerVersion": "Test Type Handler Version",
-                    "settings": { }
-                }
-            }
-        },
-
-        {
-            "name": "extensionsChild - Minimal",
-            "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/extensionsChild",
-            "json": {
-                "type": "extensions",
-                "apiVersion": "2015-06-15",
-                "properties": {
-                    "publisher": "Test Publisher",
-                    "type": "Test Type",
-                    "typeHandlerVersion": "Test Type Handler Version",
-                    "settings": { }
-                }
-            }
+  "tests": [
+    {
+      "name": "availabilitySets - Empty properties",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/availabilitySets",
+      "json": {
+        "type": "Microsoft.Compute/availabilitySets",
+        "apiVersion": "2015-05-01-preview",
+        "properties": {
         }
-    ]
+      }
+    },
+
+    {
+      "name": "availabilitySets - Without type and apiVersion",
+      "expectedErrors": [
+        {
+          "message": "Missing required property: type",
+          "dataPath": "/"
+        },
+        {
+          "message": "Missing required property: apiVersion",
+          "dataPath": "/"
+        }
+      ],
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/availabilitySets",
+      "json": {
+        "properties": {
+        }
+      }
+    },
+
+    {
+      "name": "availabilitySets/properties/properties/properties/platformUpdateDomainCount - Number value",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/availabilitySets/properties/properties/properties/platformUpdateDomainCount",
+      "json": 52
+    },
+
+    {
+      "name": "availabilitySets/properties/properties/properties/platformUpdateDomainCount - Expression value",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/availabilitySets/properties/properties/properties/platformUpdateDomainCount",
+      "json": "[add(5, 10)]"
+    },
+
+    {
+      "name": "availabilitySets/properties/properties/properties/platformUpdateDomainCount - Invalid string value",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/availabilitySets/properties/properties/properties/platformUpdateDomainCount",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/"
+        }
+      ],
+      "json": "spam"
+    },
+
+
+    {
+      "name": "virtualMachines - Minimal",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/virtualMachines",
+      "json": {
+        "apiVersion": "2015-05-01-preview",
+        "type": "Microsoft.Compute/virtualMachines",
+        "name": "[variables('vmName')]",
+        "location": "[variables('location')]",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "[variables('vmSize')]"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "[variables('imagePublisher')]",
+              "offer": "[variables('imageOffer')]",
+              "sku": "[parameters('windowsOSVersion')]",
+              "version": "latest"
+            },
+            "osDisk": {
+              "name": "osdisk",
+              "vhd": {
+                "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+              },
+              "createOption": "FromImage"
+            }
+          },
+          "networkProfile": {
+            "networkInterfaces": [ ]
+          }
+        }
+      }
+    },
+
+    {
+      "name": "extensions - Minimal",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/extensions",
+      "json": {
+        "type": "Microsoft.Compute/virtualMachines/extensions",
+        "apiVersion": "2015-05-01-preview",
+        "properties": {
+          "publisher": "Test Publisher",
+          "type": "Test Type",
+          "typeHandlerVersion": "Test Type Handler Version",
+          "settings": { }
+        }
+      }
+    },
+
+    {
+      "name": "extensionsChild - Minimal",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/extensionsChild",
+      "json": {
+        "type": "extensions",
+        "apiVersion": "2015-06-15",
+        "properties": {
+          "publisher": "Test Publisher",
+          "type": "Test Type",
+          "typeHandlerVersion": "Test Type Handler Version",
+          "settings": { }
+        }
+      }
+    }
+  ]
 }

--- a/tests/2015-08-01/Microsoft.Compute.tests.json
+++ b/tests/2015-08-01/Microsoft.Compute.tests.json
@@ -71,9 +71,9 @@
                 "type": "Microsoft.Compute/virtualMachines/extensions",
                 "apiVersion": "2015-05-01-preview",
                 "properties": {
-                    "publisher": "",
-                    "type": "",
-                    "typeHandlerVersion": "",
+                    "publisher": "Test Publisher",
+                    "type": "Test Type",
+                    "typeHandlerVersion": "Test Type Handler Version",
                     "settings": { }
                 }
             }
@@ -86,9 +86,9 @@
                 "type": "extensions",
                 "apiVersion": "2015-06-15",
                 "properties": {
-                    "publisher": "",
-                    "type": "",
-                    "typeHandlerVersion": "",
+                    "publisher": "Test Publisher",
+                    "type": "Test Type",
+                    "typeHandlerVersion": "Test Type Handler Version",
                     "settings": { }
                 }
             }

--- a/tests/2015-08-01/Microsoft.Storage.tests.json
+++ b/tests/2015-08-01/Microsoft.Storage.tests.json
@@ -7,7 +7,7 @@
                 "type": "Microsoft.Storage/storageAccounts",
                 "apiVersion": "2015-05-01-preview",
                 "properties": {
-                    "accountType": ""
+                    "accountType": "Test Account Type"
                 }
             }
         },

--- a/tests/2015-08-01/Microsoft.Storage.tests.json
+++ b/tests/2015-08-01/Microsoft.Storage.tests.json
@@ -1,7 +1,7 @@
 {
     "tests": [
         {
-            "name": "Minimal storageAccounts resource",
+            "name": "storageAccounts - Minimal",
             "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Storage.json#/resourceDefinitions/storageAccounts",
             "json": {
                 "type": "Microsoft.Storage/storageAccounts",
@@ -13,7 +13,7 @@
         },
 
         {
-            "name": "StorageAccounts resource without accountType property",
+            "name": "storageAccounts - Without accountType property",
             "expectedErrors": [
                 {
                     "message": "Missing required property: accountType",
@@ -30,7 +30,7 @@
         },
 
         {
-            "name": "StorageAccounts resource without properties property",
+            "name": "storageAccounts - Without properties property",
             "expectedErrors": [
                 {
                     "message": "Missing required property: properties",

--- a/tests/2015-08-01/Microsoft.Web.tests.json
+++ b/tests/2015-08-01/Microsoft.Web.tests.json
@@ -1,7 +1,7 @@
 {
     "tests": [
         {
-            "name": "Minimal ServerFarms resource",
+            "name": "serverFarms - Minimal",
             "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Web.json#/resourceDefinitions/serverfarms",
             "json": {
                 "name": "ServerFarmName",
@@ -12,7 +12,7 @@
         },
 
         {
-            "name": "ServerFarms resource without apiVersion",
+            "name": "serverFarms - Without apiVersion",
             "expectedErrors": [
                 {
                     "message": "Missing required property: apiVersion",
@@ -28,7 +28,7 @@
         },
 
         {
-            "name": "Minimal Config resource",
+            "name": "config - Minimal",
             "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Web.json#/resourceDefinitions/config",
             "json": {
                 "type": "Microsoft.Web/sites/config",
@@ -38,7 +38,7 @@
         },
 
         {
-            "name": "Minimal Sites resource",
+            "name": "sites - Minimal",
             "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Web.json#/resourceDefinitions/sites",
             "json": {
                 "name": "WebAppName",

--- a/tools/ResourceMetaSchema.json
+++ b/tools/ResourceMetaSchema.json
@@ -111,10 +111,8 @@
         "anyOf": [
           {
             "properties": {
-              "type": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/simpleTypes" },
-              "additionalProperties": { "$ref": "#/definitions/resourceProperty" }
-            },
-            "required": [ "type" ]
+              "type": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/simpleTypes" }
+            }
           },
           {
             "properties": {
@@ -125,12 +123,6 @@
           {
             "properties": {
               "$ref": { "format": "uri" }
-            },
-            "required": [ "$ref" ]
-          },
-          {
-            "properties": {
-              "$ref": { "enum": [ "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" ] }
             },
             "required": [ "$ref" ]
           }

--- a/tools/ResourceMetaSchema.json
+++ b/tools/ResourceMetaSchema.json
@@ -97,8 +97,12 @@
           "format": "uri"
         },
         "items": { "$ref": "http://json-schema.org/draft-04/schema#/properties/items" },
-        "anyOf": { "$ref": "#/definitions/resourcePropertyDefinitionOptions" },
         "oneOf": { "$ref": "#/definitions/resourcePropertyDefinitionOptions" },
+        "type": { "enum": [ "string" ] },
+        "minLength": {
+          "type": "integer",
+          "minimum": 1
+        },
         "description": { "$ref": "#/definitions/description" }
       },
       "required": [ "description" ],
@@ -109,11 +113,12 @@
       "uniqueItems": true,
       "items": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
           {
             "properties": {
               "type": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/simpleTypes" }
-            }
+            },
+            "required": [ "type" ]
           },
           {
             "properties": {
@@ -126,19 +131,22 @@
               "$ref": { "format": "uri" }
             },
             "required": [ "$ref" ]
+          },
+          {
+            "properties": {
+              "oneOf": { "$ref": "#/definitions/resourcePropertyDefinitionOptions" },
+              "anyOf": { "$ref": "#/definitions/resourcePropertyDefinitionOptions" }
+            },
+            "minProperties": 1,
+            "maxProperties": 1,
+            "additionalProperties": false
           }
         ]
       },
       "minItems": 2
     },
     "childResources": {
-      "type": "object",
-      "required": [ "type", "items", "description" ],
-      "properties": {
-        "type": { "enum": [ "array" ] },
-        "description": { "$ref": "#/definitions/description" },
-        "items": { "type": "object" }
-      }
+      "type": "object"
     },
     "description": {
       "type": "string",

--- a/tools/ResourceMetaSchema.json
+++ b/tools/ResourceMetaSchema.json
@@ -95,73 +95,48 @@
           "type": "string",
           "format": "uri"
         },
-        "anyOf": {
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "anyOf": [
-              {
-                "properties": {
-                  "type": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/simpleTypes" }
-                },
-                "required": [ "type" ]
-              },
-              {
-                "properties": {
-                  "enum": { "$ref": "http://json-schema.org/draft-04/schema#/properties/enum" }
-                }
-              },
-              {
-                "properties": {
-                  "$ref": { "format": "uri" }
-                }
-              },
-              {
-                "properties": {
-                  "$ref": { "enum": [ "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" ] }
-                }
-              }
-            ]
-          },
-          "minLength": 2,
-          "maxLength": 2
-        },
-        "oneOf": {
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "anyOf": [
-              {
-                "properties": {
-                  "type": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/simpleTypes" }
-                },
-                "required": [ "type" ]
-              },
-              {
-                "properties": {
-                  "enum": { "$ref": "http://json-schema.org/draft-04/schema#/properties/enum" }
-                }
-              },
-              {
-                "properties": {
-                  "$ref": { "format": "uri" }
-                }
-              },
-              {
-                "properties": {
-                  "$ref": { "enum": [ "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" ] }
-                }
-              }
-            ]
-          },
-          "minLength": 2,
-          "maxLength": 2
-        },
         "items": { "$ref": "http://json-schema.org/draft-04/schema#/properties/items" },
+        "anyOf": { "$ref": "#/definitions/resourcePropertyDefinitionOptions" },
+        "oneOf": { "$ref": "#/definitions/resourcePropertyDefinitionOptions" },
         "description": { "$ref": "#/definitions/description" }
       },
       "required": [ "description" ],
       "additionalProperties": false
+    },
+    "resourcePropertyDefinitionOptions": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "anyOf": [
+          {
+            "properties": {
+              "type": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/simpleTypes" },
+              "additionalProperties": { "$ref": "#/definitions/resourceProperty" }
+            },
+            "required": [ "type" ]
+          },
+          {
+            "properties": {
+              "enum": { "$ref": "http://json-schema.org/draft-04/schema#/properties/enum" }
+            },
+            "required": [ "enum" ]
+          },
+          {
+            "properties": {
+              "$ref": { "format": "uri" }
+            },
+            "required": [ "$ref" ]
+          },
+          {
+            "properties": {
+              "$ref": { "enum": [ "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" ] }
+            },
+            "required": [ "$ref" ]
+          }
+        ]
+      },
+      "minItems": 2
     },
     "childResources": {
       "type": "object",
@@ -180,6 +155,7 @@
       "anyOf": [
         { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" },
         {
+          "type": "array",
           "minLength": 0
         }
       ]
@@ -189,13 +165,18 @@
       "properties": {
         "enum": {
           "type": "array",
-          "items": { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/apiVersion" },
+          "items": {
+            "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/apiVersion"
+          },
           "minItems": 1,
-          "uniqueItems": true,
-          "additionalItems": false
+          "uniqueItems": true
+        },
+        "$ref": {
+          "type": "string",
+          "format": "uri"
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     }
   }
 }

--- a/tools/ResourceMetaSchema.json
+++ b/tools/ResourceMetaSchema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-
+  "title": "Azure Resource Meta-schema",
+      
   "allOf": [
     {
       "$ref": "http://json-schema.org/draft-04/schema#"
@@ -12,7 +13,6 @@
 
   "definitions": {
     "resourceMetaSchema": {
-      "title": "Azure Resource Meta-schema",
       "type": "object",
       "properties": {
         "id": { "type": "string" },
@@ -29,6 +29,7 @@
         },
         "definitions": {
           "type": "object",
+          "properties": { },
           "minProperties": 1,
           "additionalProperties": { "$ref": "http://json-schema.org/draft-04/schema#" }
         }

--- a/tools/ResourceMetaSchema.json
+++ b/tools/ResourceMetaSchema.json
@@ -122,7 +122,7 @@
               "type": {
                 "allOf": [
                   { "$ref": "http://json-schema.org/draft-04/schema#/definitions/simpleTypes" },
-                  { "not": { "enum": [ "string" ] } }
+                  { "not": { "enum": [ "string", "number" ] } }
                 ]
               }
             },

--- a/tools/ResourceMetaSchema.json
+++ b/tools/ResourceMetaSchema.json
@@ -1,108 +1,201 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
 
-    "allOf": [
-        {
-            "$ref": "http://json-schema.org/draft-04/schema#"
+  "allOf": [
+    {
+      "$ref": "http://json-schema.org/draft-04/schema#"
+    },
+    {
+      "$ref": "#/definitions/resourceMetaSchema"
+    }
+  ],
+
+  "definitions": {
+    "resourceMetaSchema": {
+      "title": "Azure Resource Meta-schema",
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "$schema": {
+          "type": "string",
+          "format": "uri"
         },
-        {
-            "$ref": "#/definitions/resourceMetaSchema"
+        "title": { "type": "string" },
+        "description": { "$ref": "#/definitions/description" },
+        "resourceDefinitions": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": { "$ref": "#/definitions/resource" }
+        },
+        "definitions": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": { "$ref": "http://json-schema.org/draft-04/schema#" }
         }
-    ],
-
-    "definitions": {
-        "resourceMetaSchema": {
-            "title": "Azure Resource Meta-schema",
-            "type": "object",
-            "properties": {
-                "id": { "type": "string" },
-                "$schema": {
-                    "type": "string",
-                    "format": "uri"
-                },
-                "title": { "type": "string" },
-                "description": { "$ref": "#/definitions/description" },
-                "resourceDefinitions": {
-                    "type": "object",
-                    "minProperties": 1,
-                    "additionalProperties": { "$ref": "#/definitions/resource" }
-                },
-                "definitions": {
-                    "type": "object",
-                    "minProperties": 1,
-                    "additionalProperties": { "$ref": "http://json-schema.org/draft-04/schema#" }
-                }
-            },
-            "required": [ "$schema", "title", "description", "resourceDefinitions" ],
-            "additionalProperties": false
-        },
-        "resource": {
-            "type": "object",
-            "properties": {
-                "type": { "enum": [ "object" ] },
-                "description": { "$ref": "#/definitions/description" },
-                "required": { "$ref": "#/definitions/stringArrayEmptyOkay" },
-                "properties": {
-                    "type": "object",
-                    "minProperties": 1,
-                    "properties": {
-                        "type": { },
-                        "apiVersion": { "$ref": "#/definitions/apiVersionProperty" },
-                        "resources": { "$ref": "#/definitions/childResources" },
-                        "properties": { }
-                    },
-                    "required": [ "apiVersion", "type" ],
-                    "additionalProperties": { "$ref": "#/definitions/resourceProperty" }
-                }
-            },
-            "required": [ "description", "properties" ]
-        },
-        "resourceProperty": {
-            "allOf": [
-                { "$ref": "http://json-schema.org/draft-04/schema#" },
-                {
-                    "type": "object",
-                    "properties": {
-                        "description": { "$ref": "#/definitions/description" }
-                    },
-                    "required": [ "description" ],
-                    "additionalProperties": true
-                }
-            ]
-        },
-        "childResources": {
-            "type": "object",
-            "required": [ "type", "items", "description" ],
-            "properties": {
-                "type": { "enum": [ "array" ] },
-                "description": { "$ref": "#/definitions/description" },
-                "items": { "type": "object" }
-            }
-        },
-        "description": {
+      },
+      "required": [ "$schema", "title", "description", "resourceDefinitions" ],
+      "additionalProperties": false
+    },
+    "resource": {
+      "type": "object",
+      "properties": {
+        "type": { "enum": [ "object" ] },
+        "description": { "$ref": "#/definitions/description" },
+        "required": { "$ref": "#/definitions/stringArrayEmptyOkay" },
+        "properties": {
+          "type": "object",
+          "minProperties": 1,
+          "properties": {
+            "type": { "$ref": "#/definitions/resourceTypeProperty" },
+            "apiVersion": { "$ref": "#/definitions/apiVersionProperty" },
+            "resources": { "$ref": "#/definitions/childResources" },
+            "properties": { "$ref": "#/definitions/resourceProperties" }
+          },
+          "required": [ "apiVersion", "type" ]
+        }
+      },
+      "required": [ "description" ]
+    },
+    "resourceTypeProperty": {
+      "type": "object",
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
             "type": "string",
             "minLength": 1
-        },
-        "stringArrayEmptyOkay": {
-            "anyOf": [
-                { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" },
-                {
-                    "minLength": 0
-                }
-            ]
-        },
-        "apiVersionProperty": {
-            "type": "object",
-            "properties": {
-                "enum": {
-                    "type": "array",
-                    "items": { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/apiVersion" },
-                    "minItems": 1,
-                    "uniqueItems": true,
-                    "additionalItems": false
-                }
-            },
-            "additionalProperties": true
+          },
+          "minItems": 1
         }
+      },
+      "required": [ "enum" ],
+      "additionalProperties": false
+    },
+    "resourceProperties": {
+      "type": "object",
+      "properties": {
+        "type": { "enum": [ "object" ] },
+        "$ref": {
+          "type": "string",
+          "format": "uri"
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/definitions/resourceProperty" }
+        },
+        "required": { "$ref": "#/definitions/stringArrayEmptyOkay" },
+        "additionalProperties": { "$ref": "http://json-schema.org/draft-04/schema#/properties/additionalProperties" }
+      },
+      "additionalProperties": false
+    },
+    "resourceProperty": {
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "format": "uri"
+        },
+        "anyOf": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "type": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/simpleTypes" }
+                },
+                "required": [ "type" ]
+              },
+              {
+                "properties": {
+                  "enum": { "$ref": "http://json-schema.org/draft-04/schema#/properties/enum" }
+                }
+              },
+              {
+                "properties": {
+                  "$ref": { "format": "uri" }
+                }
+              },
+              {
+                "properties": {
+                  "$ref": { "enum": [ "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" ] }
+                }
+              }
+            ]
+          },
+          "minLength": 2,
+          "maxLength": 2
+        },
+        "oneOf": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "type": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/simpleTypes" }
+                },
+                "required": [ "type" ]
+              },
+              {
+                "properties": {
+                  "enum": { "$ref": "http://json-schema.org/draft-04/schema#/properties/enum" }
+                }
+              },
+              {
+                "properties": {
+                  "$ref": { "format": "uri" }
+                }
+              },
+              {
+                "properties": {
+                  "$ref": { "enum": [ "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" ] }
+                }
+              }
+            ]
+          },
+          "minLength": 2,
+          "maxLength": 2
+        },
+        "items": { "$ref": "http://json-schema.org/draft-04/schema#/properties/items" },
+        "description": { "$ref": "#/definitions/description" }
+      },
+      "required": [ "description" ],
+      "additionalProperties": false
+    },
+    "childResources": {
+      "type": "object",
+      "required": [ "type", "items", "description" ],
+      "properties": {
+        "type": { "enum": [ "array" ] },
+        "description": { "$ref": "#/definitions/description" },
+        "items": { "type": "object" }
+      }
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "stringArrayEmptyOkay": {
+      "anyOf": [
+        { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" },
+        {
+          "minLength": 0
+        }
+      ]
+    },
+    "apiVersionProperty": {
+      "type": "object",
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/apiVersion" },
+          "minItems": 1,
+          "uniqueItems": true,
+          "additionalItems": false
+        }
+      },
+      "additionalProperties": true
     }
+  }
 }

--- a/tools/ResourceMetaSchema.json
+++ b/tools/ResourceMetaSchema.json
@@ -29,9 +29,8 @@
         },
         "definitions": {
           "type": "object",
-          "properties": { },
           "minProperties": 1,
-          "additionalProperties": { "$ref": "http://json-schema.org/draft-04/schema#" }
+          "additionalProperties": { "$ref": "#/definitions/definition" }
         }
       },
       "required": [ "$schema", "title", "description", "resourceDefinitions" ],
@@ -103,6 +102,10 @@
           "type": "integer",
           "minimum": 1
         },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 1
+        },
         "description": { "$ref": "#/definitions/description" }
       },
       "required": [ "description" ],
@@ -116,9 +119,21 @@
         "oneOf": [
           {
             "properties": {
-              "type": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/simpleTypes" }
+              "type": {
+                "allOf": [
+                  { "$ref": "http://json-schema.org/draft-04/schema#/definitions/simpleTypes" },
+                  { "not": { "enum": [ "string" ] } }
+                ]
+              }
             },
             "required": [ "type" ]
+          },
+          {
+            "properties": {
+              "type": { "enum": [ "string" ] },
+              "pattern": { "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern" }
+            },
+            "required": [ "type", "pattern" ]
           },
           {
             "properties": {
@@ -134,8 +149,7 @@
           },
           {
             "properties": {
-              "oneOf": { "$ref": "#/definitions/resourcePropertyDefinitionOptions" },
-              "anyOf": { "$ref": "#/definitions/resourcePropertyDefinitionOptions" }
+              "oneOf": { "$ref": "#/definitions/resourcePropertyDefinitionOptions" }
             },
             "minProperties": 1,
             "maxProperties": 1,
@@ -178,6 +192,9 @@
         }
       },
       "additionalProperties": false
+    },
+    "definition": {
+      "$ref": "http://json-schema.org/draft-04/schema#"
     }
   }
 }

--- a/tools/ResourceMetaSchema.tests.json
+++ b/tools/ResourceMetaSchema.tests.json
@@ -434,6 +434,15 @@
       ]
     },
     
+    {
+      "name": "resourcePropertyDefinitionOptions - Expression reference and boolean type options",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourcePropertyDefinitionOptions",
+      "json": [
+        { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" },
+        { "type": "boolean" }
+      ]
+    },
+    
     
     {
       "name": "description - Non-string type",

--- a/tools/ResourceMetaSchema.tests.json
+++ b/tools/ResourceMetaSchema.tests.json
@@ -487,7 +487,7 @@
       ],
       "json": {
         "oneOf": [
-          { "type": "string" },
+          { "type": "integer" },
           { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
         ]
       }
@@ -497,10 +497,7 @@
       "name": "resourceProperty - String type",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceProperty",
       "json": {
-        "oneOf": [
-          { "type": "string" },
-          { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-        ],
+        "type": "string",
         "description": "Test description that describes this property."
       }
     },
@@ -508,11 +505,14 @@
     {
       "name": "resourceProperty - Number type without expression option",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceProperty",
+      "expectedErrors": [
+        {
+          "message": "No enum match for: \"number\"",
+          "dataPath": "/type"
+        }
+      ],
       "json": {
-        "oneOf": [
-          { "type": "number" },
-          { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-        ],
+        "type": "number",
         "description": "Test description that describes this property."
       }
     },
@@ -562,13 +562,57 @@
     },
 
     {
-      "name": "resourcePropertyDefinitionOptions - Expression reference and boolean type options",
+      "name": "resourcePropertyDefinitionOptions - Expression reference and boolean type",
       "definition": "./ResourceMetaSchema.json#/definitions/resourcePropertyDefinitionOptions",
       "json": [
         { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" },
         { "type": "boolean" }
       ]
     },
+
+    {
+      "name": "resourcePropertyDefinitionOptions - Two expression references",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourcePropertyDefinitionOptions",
+      "expectedErrors": [
+        {
+          "message": "Array items are not unique (indices 0 and 1)",
+          "dataPath": "/"
+        }
+      ],
+      "json": [
+        { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" },
+        { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+      ]
+    },
+
+    {
+      "name": "resourcePropertyDefinitionOptions - Expression reference and string type",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourcePropertyDefinitionOptions",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/1"
+        }
+      ],
+      "json": [
+        { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" },
+        { "type": "string" }
+      ]
+    },
+
+    {
+      "name": "resourcePropertyDefinitionOptions - Expression reference and string type with pattern",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourcePropertyDefinitionOptions",
+      "json": [
+        { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" },
+        {
+          "type": "string",
+          "pattern": "Regular Expression Pattern"
+        }
+      ]
+    },
+
+
 
 
     {

--- a/tools/ResourceMetaSchema.tests.json
+++ b/tools/ResourceMetaSchema.tests.json
@@ -1,0 +1,395 @@
+{
+  "tests": [
+    
+    {
+      "name": "resource - Empty JSON",
+      "definition": "./ResourceMetaSchema.json#/definitions/resource",
+      "expectedErrors": [
+        {
+          "message": "Missing required property: description",
+          "dataPath": "/"
+        }
+      ],
+      "json": {
+      }
+    },
+    
+    {
+      "name": "resource - Missing properties",
+      "definition": "./ResourceMetaSchema.json#/definitions/resource",
+      "json": {
+        "description": "Test Resource Description"
+      }
+    },
+    
+    {
+      "name": "resource - Missing apiVersion",
+      "definition": "./ResourceMetaSchema.json#/definitions/resource",
+      "expectedErrors": [
+        {
+          "message": "Missing required property: apiVersion",
+          "dataPath": "/properties"
+        }
+      ],
+      "json": {
+        "description": "Test Resource Description",
+        "properties": {
+          "type": { "enum": "Microsoft.Dan/TestType" }
+        }
+      }
+    },
+    
+    {
+      "name": "resource - Missing type",
+      "definition": "./ResourceMetaSchema.json#/definitions/resource",
+      "expectedErrors": [
+        {
+          "message": "Missing required property: type",
+          "dataPath": "/properties"
+        }
+      ],
+      "json": {
+        "description": "Test Resource Description",
+        "properties": {
+          "apiVersion": "2015-12-02"
+        }
+      }
+    },
+    
+    {
+      "name": "resource - Minimal valid",
+      "definition": "./ResourceMetaSchema.json#/definitions/resource",
+      "json": {
+        "description": "Test Resource Description",
+        "properties": {
+          "apiVersion": "2015-12-02",
+          "type": {
+            "enum": [ "Microsoft.Dan/TestResourceType" ]
+          }
+        }
+      }
+    },
+    
+    {
+      "name": "resource - Empty child resources",
+      "definition": "./ResourceMetaSchema.json#/definitions/resource",
+      "json": {
+        "description": "Test Resource Description",
+        "properties": {
+          "apiVersion": "2015-12-02",
+          "type": {
+            "enum": [ "Microsoft.Dan/TestResourceType" ]
+          },
+          "resources": {}
+        }
+      }
+    },
+    
+    {
+      "name": "resource - Empty resource properties",
+      "definition": "./ResourceMetaSchema.json#/definitions/resource",
+      "json": {
+        "description": "Test Resource Description",
+        "properties": {
+          "apiVersion": "2015-12-02",
+          "type": {
+            "enum": [ "Microsoft.Dan/TestResourceType" ]
+          },
+          "properties": {}
+        }
+      }
+    },
+    
+    {
+      "name": "resource - Resource properties with string-valued property",
+      "definition": "./ResourceMetaSchema.json#/definitions/resource",
+      "json": {
+        "description": "Test Resource Description",
+        "properties": {
+          "apiVersion": "2015-12-02",
+          "type": {
+            "enum": [ "Microsoft.Dan/TestResourceType" ]
+          },
+          "properties": {
+            "testPropertyName": "TestName"
+          }
+        }
+      }
+    },
+    
+    {
+      "name": "resource - Resource properties with empty object-valued property",
+      "definition": "./ResourceMetaSchema.json#/definitions/resource",
+      "json": {
+        "description": "Test Resource Description",
+        "properties": {
+          "apiVersion": "2015-12-02",
+          "type": {
+            "enum": [ "Microsoft.Dan/TestResourceType" ]
+          },
+          "properties": {
+            "testPropertyName": {}
+          }
+        }
+      }
+    },
+    
+    
+    {
+      "name": "resourceTypeProperty - Empty JSON",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceTypeProperty",
+      "expectedErrors": [
+        {
+          "message": "Missing required property: enum",
+          "dataPath": "/"
+        }
+      ],
+      "json": {
+      }
+    },
+    
+    {
+      "name": "resourceTypeProperty - Empty enum array",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceTypeProperty",
+      "expectedErrors": [
+        {
+          "message": "Array is too short (0), minimum 1",
+          "dataPath": "/enum"
+        }
+      ],
+      "json": {
+        "enum": []
+      }
+    },
+    
+    {
+      "name": "resourceTypeProperty - Enum array with non-string value",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceTypeProperty",
+      "expectedErrors": [
+        {
+          "message": "Invalid type: number (expected string)",
+          "dataPath": "/enum/0"
+        }
+      ],
+      "json": {
+        "enum": [ 42 ]
+      }
+    },
+    
+    {
+      "name": "resourceTypeProperty - Enum array with empty string value",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceTypeProperty",
+      "expectedErrors": [
+        {
+          "message": "String is too short (0 chars), minimum 1",
+          "dataPath": "/enum/0"
+        }
+      ],
+      "json": {
+        "enum": [ "" ]
+      }
+    },
+    
+    {
+      "name": "resourceTypeProperty - Single enum value",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceTypeProperty",
+      "json": {
+        "enum": [ "Microsoft.Dan/TestResourceType" ]
+      }
+    },
+    
+    {
+      "name": "resourceTypeProperty - Multiple enum values",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceTypeProperty",
+      "json": {
+        "enum": [
+          "Microsoft.Dan/TestResourceType1",
+          "Microsoft.Dan/TestResourceType2",
+          "Microsoft.Dan/TestResourceType3"
+         ]
+      }
+    },
+    
+    {
+      "name": "resourceTypeProperty - Additional property other than enum",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceTypeProperty",
+      "expectedErrors": [
+        {
+          "message": "Additional properties not allowed",
+          "dataPath": "/shouldPass"
+        }
+      ],
+      "json": {
+        "enum": [ "Microsoft.Dan/TestResourceType" ],
+        "shouldPass": false
+      }
+    },
+    
+    
+    {
+      "name": "resourceProperties - Non-object",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceTypeProperty",
+      "expectedErrors": [
+        {
+          "message": "Invalid type: number (expected object)",
+          "dataPath": "/"
+        }
+      ],
+      "json": 42
+    },
+    
+    {
+      "name": "resourceProperties - Empty JSON object",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceProperties",
+      "json": {
+      }
+    },
+    
+    {
+      "name": "resourceProperties - Declared type is string",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceProperties",
+      "expectedErrors": [
+        {
+          "message": "No enum match for: \"string\"",
+          "dataPath": "/type"
+        }
+      ],
+      "json": {
+        "type": "string"
+      }
+    },
+    
+    {
+      "name": "resourceProperties - Declared type is object with no properties",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceProperties",
+      "json": {
+        "type": "object"
+      }
+    },
+    
+    {
+      "name": "resourceProperties - Unrecognized property",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceProperties",
+      "expectedErrors": [
+        {
+          "message": "Additional properties not allowed",
+          "dataPath": "/testPropertyName"
+        }
+      ],
+      "json": {
+        "testPropertyName": 50
+      }
+    },
+    
+    {
+      "name": "resourceProperties - Integer value properties",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceProperties",
+      "expectedErrors": [
+        {
+          "message": "Invalid type: number (expected object)",
+          "dataPath": "/properties"
+        }
+      ],
+      "json": {
+        "type": "object",
+        "properties": 39
+      }
+    },
+    
+    {
+      "name": "resourceProperties - Empty properties object",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceProperties",
+      "json": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    
+    {
+      "name": "resourceProperties - One valid property",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceProperties",
+      "json": {
+        "type": "object",
+        "properties": {
+          "description": { 
+            "type": "string", 
+            "description": "Microsoft.DataConnect/connectionManagers: The description of the connectionManager."  
+          }
+        }
+      }
+    },
+    
+    {
+      "name": "resourceProperties - Multiple valid properties",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceProperties",
+      "json": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Description1"
+          },
+          "description2": {
+            "type": "string",
+            "description": "Description2"
+          }
+        }
+      }
+    },
+    
+    {
+      "name": "resourceProperty - Non-object",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceProperty",
+      "expectedErrors": [
+        {
+          "message": "Invalid type: string (expected object)",
+          "dataPath": "/"
+        }
+      ],
+      "json": "non-object value"
+    },
+    
+    {
+      "name": "resourceProperty - Without description",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceProperty",
+      "expectedErrors": [
+        {
+          "message": "Missing required property: description",
+          "dataPath": "/"
+        }
+      ],
+      "json": {
+        "anyOf": [
+          { "type": "string" },
+          { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+        ]
+      }
+    },
+    
+    {
+      "name": "resourceProperty - String type",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceProperty",
+      "json": { 
+        "anyOf": [
+          { "type": "string" },
+          { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+        ], 
+        "description": "Test description that describes this property."
+      }
+    },
+    
+    {
+      "name": "resourceProperty - Number type without expression option",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceProperty",
+      "expectedErrors": [],
+      "json": {
+        "anyOf": [
+          { "type": "number" },
+          { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+        ],
+        "description": "Test description that describes this property."
+      }
+    }
+    
+  ]
+}

--- a/tools/ResourceMetaSchema.tests.json
+++ b/tools/ResourceMetaSchema.tests.json
@@ -1,6 +1,120 @@
 {
   "tests": [
+
+    {
+      "name": "resourceMetaSchema - Non-object type",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceMetaSchema",
+      "expectedErrors": [
+        {
+          "message": "Invalid type: string (expected object)",
+          "dataPath": "/"
+        }
+      ],
+      "json": "hello"
+    },
+
+    {
+      "name": "resourceMetaSchema - Empty object",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceMetaSchema",
+      "expectedErrors": [
+        {
+          "message": "Missing required property: $schema",
+          "dataPath": "/"
+        },
+        {
+          "message": "Missing required property: title",
+          "dataPath": "/"
+        },
+        {
+          "message": "Missing required property: description",
+          "dataPath": "/"
+        },
+        {
+          "message": "Missing required property: resourceDefinitions",
+          "dataPath": "/"
+        }
+      ],
+      "json": { }
+    },
     
+    {
+      "name": "resourceMetaSchema - Empty description",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceMetaSchema",
+      "expectedErrors": [
+        {
+          "message": "Too few properties defined (0), minimum 1",
+          "dataPath": "/resourceDefinitions"
+        },
+        {
+          "message": "Too few properties defined (0), minimum 1",
+          "dataPath": "/definitions"
+        }
+      ],
+      "json": {
+        "$schema": "http://json-schema.org/draft-04/schema",
+        "title": "Test Title",
+        "description": "",
+        "resourceDefinitions": { },
+        "definitions": { }
+      }
+    },
+
+    {
+      "name": "resourceMetaSchema - Empty definitions",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceMetaSchema",
+      "expectedErrors": [
+        {
+          "message": "Too few properties defined (0), minimum 1",
+          "dataPath": "/resourceDefinitions"
+        },
+        {
+          "message": "Too few properties defined (0), minimum 1",
+          "dataPath": "/definitions"
+        }
+      ],
+      "json": {
+        "$schema": "http://json-schema.org/draft-04/schema",
+        "title": "Test Title",
+        "description": "hello",
+        "resourceDefinitions": { },
+        "definitions": { }
+      }
+    },
+
+    {
+      "name": "resourceMetaSchema - Extra property",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceMetaSchema",
+      "expectedErrors": [
+        {
+          "message": "Additional properties not allowed",
+          "dataPath": "/extraProperty"
+        }
+      ],
+      "json": {
+        "$schema": "http://json-schema.org/draft-04/schema",
+        "title": "Test Title",
+        "description": "hello",
+        "resourceDefinitions": {
+          "mockResource": { }
+        },
+        "extraProperty": "Shouldn't be here"
+      }
+    },
+
+    {
+      "name": "resourceMetaSchema - Empty resource definition",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourceMetaSchema",
+      "json": {
+        "$schema": "http://json-schema.org/draft-04/schema",
+        "title": "Test Title",
+        "description": "hello",
+        "resourceDefinitions": {
+          "mockResource": { }
+        }
+      }
+    },
+
+
     {
       "name": "resource - Empty JSON",
       "definition": "./ResourceMetaSchema.json#/definitions/resource",
@@ -13,7 +127,7 @@
       "json": {
       }
     },
-    
+
     {
       "name": "resource - Missing properties",
       "definition": "./ResourceMetaSchema.json#/definitions/resource",
@@ -21,7 +135,7 @@
         "description": "Test Resource Description"
       }
     },
-    
+
     {
       "name": "resource - Missing apiVersion",
       "definition": "./ResourceMetaSchema.json#/definitions/resource",
@@ -38,7 +152,7 @@
         }
       }
     },
-    
+
     {
       "name": "resource - Missing type",
       "definition": "./ResourceMetaSchema.json#/definitions/resource",
@@ -55,7 +169,7 @@
         }
       }
     },
-    
+
     {
       "name": "resource - Minimal valid",
       "definition": "./ResourceMetaSchema.json#/definitions/resource",
@@ -69,7 +183,7 @@
         }
       }
     },
-    
+
     {
       "name": "resource - Empty child resources",
       "definition": "./ResourceMetaSchema.json#/definitions/resource",
@@ -80,11 +194,11 @@
           "type": {
             "enum": [ "Microsoft.Dan/TestResourceType" ]
           },
-          "resources": {}
+          "resources": { }
         }
       }
     },
-    
+
     {
       "name": "resource - Empty resource properties",
       "definition": "./ResourceMetaSchema.json#/definitions/resource",
@@ -95,11 +209,11 @@
           "type": {
             "enum": [ "Microsoft.Dan/TestResourceType" ]
           },
-          "properties": {}
+          "properties": { }
         }
       }
     },
-    
+
     {
       "name": "resource - Resource properties with string-valued property",
       "definition": "./ResourceMetaSchema.json#/definitions/resource",
@@ -116,7 +230,7 @@
         }
       }
     },
-    
+
     {
       "name": "resource - Resource properties with empty object-valued property",
       "definition": "./ResourceMetaSchema.json#/definitions/resource",
@@ -128,13 +242,13 @@
             "enum": [ "Microsoft.Dan/TestResourceType" ]
           },
           "properties": {
-            "testPropertyName": {}
+            "testPropertyName": { }
           }
         }
       }
     },
-    
-    
+
+
     {
       "name": "resourceTypeProperty - Empty JSON",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceTypeProperty",
@@ -147,7 +261,7 @@
       "json": {
       }
     },
-    
+
     {
       "name": "resourceTypeProperty - Empty enum array",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceTypeProperty",
@@ -158,10 +272,10 @@
         }
       ],
       "json": {
-        "enum": []
+        "enum": [ ]
       }
     },
-    
+
     {
       "name": "resourceTypeProperty - Enum array with non-string value",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceTypeProperty",
@@ -175,7 +289,7 @@
         "enum": [ 42 ]
       }
     },
-    
+
     {
       "name": "resourceTypeProperty - Enum array with empty string value",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceTypeProperty",
@@ -189,7 +303,7 @@
         "enum": [ "" ]
       }
     },
-    
+
     {
       "name": "resourceTypeProperty - Single enum value",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceTypeProperty",
@@ -197,7 +311,7 @@
         "enum": [ "Microsoft.Dan/TestResourceType" ]
       }
     },
-    
+
     {
       "name": "resourceTypeProperty - Multiple enum values",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceTypeProperty",
@@ -206,10 +320,10 @@
           "Microsoft.Dan/TestResourceType1",
           "Microsoft.Dan/TestResourceType2",
           "Microsoft.Dan/TestResourceType3"
-         ]
+        ]
       }
     },
-    
+
     {
       "name": "resourceTypeProperty - Additional property other than enum",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceTypeProperty",
@@ -224,8 +338,8 @@
         "shouldPass": false
       }
     },
-    
-    
+
+
     {
       "name": "resourceProperties - Non-object",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceTypeProperty",
@@ -237,14 +351,14 @@
       ],
       "json": 42
     },
-    
+
     {
       "name": "resourceProperties - Empty JSON object",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceProperties",
       "json": {
       }
     },
-    
+
     {
       "name": "resourceProperties - Declared type is string",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceProperties",
@@ -258,7 +372,7 @@
         "type": "string"
       }
     },
-    
+
     {
       "name": "resourceProperties - Declared type is object with no properties",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceProperties",
@@ -266,7 +380,7 @@
         "type": "object"
       }
     },
-    
+
     {
       "name": "resourceProperties - Unrecognized property",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceProperties",
@@ -280,7 +394,7 @@
         "testPropertyName": 50
       }
     },
-    
+
     {
       "name": "resourceProperties - Integer value properties",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceProperties",
@@ -295,30 +409,30 @@
         "properties": 39
       }
     },
-    
+
     {
       "name": "resourceProperties - Empty properties object",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceProperties",
       "json": {
         "type": "object",
-        "properties": {}
+        "properties": { }
       }
     },
-    
+
     {
       "name": "resourceProperties - One valid property",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceProperties",
       "json": {
         "type": "object",
         "properties": {
-          "description": { 
-            "type": "string", 
-            "description": "Microsoft.DataConnect/connectionManagers: The description of the connectionManager."  
+          "description": {
+            "type": "string",
+            "description": "Microsoft.DataConnect/connectionManagers: The description of the connectionManager."
           }
         }
       }
     },
-    
+
     {
       "name": "resourceProperties - Multiple valid properties",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceProperties",
@@ -336,7 +450,7 @@
         }
       }
     },
-    
+
     {
       "name": "resourceProperty - Non-object",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceProperty",
@@ -348,7 +462,7 @@
       ],
       "json": "non-object value"
     },
-    
+
     {
       "name": "resourceProperty - Without description",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceProperty",
@@ -365,19 +479,19 @@
         ]
       }
     },
-    
+
     {
       "name": "resourceProperty - String type",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceProperty",
-      "json": { 
+      "json": {
         "anyOf": [
           { "type": "string" },
           { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
-        ], 
+        ],
         "description": "Test description that describes this property."
       }
     },
-    
+
     {
       "name": "resourceProperty - Number type without expression option",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceProperty",
@@ -389,8 +503,8 @@
         "description": "Test description that describes this property."
       }
     },
-    
-    
+
+
     {
       "name": "resourcePropertyDefinitionOptions - Non-array type",
       "definition": "./ResourceMetaSchema.json#/definitions/resourcePropertyDefinitionOptions",
@@ -402,7 +516,7 @@
       ],
       "json": 7
     },
-    
+
     {
       "name": "resourcePropertyDefinitionOptions - Empty array",
       "definition": "./ResourceMetaSchema.json#/definitions/resourcePropertyDefinitionOptions",
@@ -412,9 +526,9 @@
           "dataPath": "/"
         }
       ],
-      "json": []
+      "json": [ ]
     },
-    
+
     {
       "name": "resourcePropertyDefinitionOptions - Array with two string values",
       "definition": "./ResourceMetaSchema.json#/definitions/resourcePropertyDefinitionOptions",
@@ -433,7 +547,7 @@
         "there"
       ]
     },
-    
+
     {
       "name": "resourcePropertyDefinitionOptions - Expression reference and boolean type options",
       "definition": "./ResourceMetaSchema.json#/definitions/resourcePropertyDefinitionOptions",
@@ -442,8 +556,8 @@
         { "type": "boolean" }
       ]
     },
-    
-    
+
+
     {
       "name": "description - Non-string type",
       "definition": "./ResourceMetaSchema.json#/definitions/description",
@@ -455,14 +569,14 @@
       ],
       "json": 33
     },
-    
+
     {
       "name": "description - Non-empty string",
       "definition": "./ResourceMetaSchema.json#/definitions/description",
       "json": "I'm a description"
     },
-    
-    
+
+
     {
       "name": "stringArrayEmptyOkay - Non-array type",
       "definition": "./ResourceMetaSchema.json#/definitions/stringArrayEmptyOkay",
@@ -474,20 +588,20 @@
       ],
       "json": 99
     },
-    
+
     {
       "name": "stringArrayEmptyOkay - Empty array",
       "definition": "./ResourceMetaSchema.json#/definitions/stringArrayEmptyOkay",
-      "json": []
+      "json": [ ]
     },
-    
+
     {
       "name": "stringArrayEmptyOkay - Non-empty array",
       "definition": "./ResourceMetaSchema.json#/definitions/stringArrayEmptyOkay",
       "json": [ "a", "b", "c" ]
     },
-    
-    
+
+
     {
       "name": "apiVersionProperty - Non-object",
       "definition": "./ResourceMetaSchema.json#/definitions/apiVersionProperty",
@@ -499,14 +613,14 @@
       ],
       "json": 20
     },
-    
+
     {
       "name": "apiVersionProperty - Empty object",
       "definition": "./ResourceMetaSchema.json#/definitions/apiVersionProperty",
       "json": {
       }
     },
-    
+
     {
       "name": "apiVersionProperty - Properties other than 'enum'",
       "definition": "./ResourceMetaSchema.json#/definitions/apiVersionProperty",
@@ -520,7 +634,7 @@
         "otherProperty": "otherValue"
       }
     },
-    
+
     {
       "name": "apiVersionProperty - Empty enum array",
       "definition": "./ResourceMetaSchema.json#/definitions/apiVersionProperty",
@@ -531,10 +645,10 @@
         }
       ],
       "json": {
-        "enum": []
+        "enum": [ ]
       }
     },
-    
+
     {
       "name": "apiVersionProperty - Value doesn't match API version pattern",
       "definition": "./ResourceMetaSchema.json#/definitions/apiVersionProperty",
@@ -549,7 +663,7 @@
         "enum": [ "spam" ]
       }
     },
-      
+
     {
       "name": "apiVersionProperty - Date api version",
       "definition": "./ResourceMetaSchema.json#/definitions/apiVersionProperty",
@@ -557,7 +671,7 @@
         "enum": [ "2015-01-01" ]
       }
     },
-      
+
     {
       "name": "apiVersionProperty - Duplicated date api version",
       "definition": "./ResourceMetaSchema.json#/definitions/apiVersionProperty",
@@ -571,6 +685,6 @@
         "enum": [ "2015-01-01", "2015-01-01" ]
       }
     }
-    
+
   ]
 }

--- a/tools/ResourceMetaSchema.tests.json
+++ b/tools/ResourceMetaSchema.tests.json
@@ -381,13 +381,185 @@
     {
       "name": "resourceProperty - Number type without expression option",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceProperty",
-      "expectedErrors": [],
       "json": {
         "anyOf": [
           { "type": "number" },
           { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
         ],
         "description": "Test description that describes this property."
+      }
+    },
+    
+    
+    {
+      "name": "resourcePropertyDefinitionOptions - Non-array type",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourcePropertyDefinitionOptions",
+      "expectedErrors": [
+        {
+          "message": "Invalid type: number (expected array)",
+          "dataPath": "/"
+        }
+      ],
+      "json": 7
+    },
+    
+    {
+      "name": "resourcePropertyDefinitionOptions - Empty array",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourcePropertyDefinitionOptions",
+      "expectedErrors": [
+        {
+          "message": "Array is too short (0), minimum 2",
+          "dataPath": "/"
+        }
+      ],
+      "json": []
+    },
+    
+    {
+      "name": "resourcePropertyDefinitionOptions - Array with two string values",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourcePropertyDefinitionOptions",
+      "expectedErrors": [
+        {
+          "message": "Invalid type: string (expected object)",
+          "dataPath": "/0"
+        },
+        {
+          "message": "Invalid type: string (expected object)",
+          "dataPath": "/1"
+        }
+      ],
+      "json": [
+        "hello",
+        "there"
+      ]
+    },
+    
+    
+    {
+      "name": "description - Non-string type",
+      "definition": "./ResourceMetaSchema.json#/definitions/description",
+      "expectedErrors": [
+        {
+          "message": "Invalid type: number (expected string)",
+          "dataPath": "/"
+        }
+      ],
+      "json": 33
+    },
+    
+    {
+      "name": "description - Non-empty string",
+      "definition": "./ResourceMetaSchema.json#/definitions/description",
+      "json": "I'm a description"
+    },
+    
+    
+    {
+      "name": "stringArrayEmptyOkay - Non-array type",
+      "definition": "./ResourceMetaSchema.json#/definitions/stringArrayEmptyOkay",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"anyOf\"",
+          "dataPath": "/"
+        }
+      ],
+      "json": 99
+    },
+    
+    {
+      "name": "stringArrayEmptyOkay - Empty array",
+      "definition": "./ResourceMetaSchema.json#/definitions/stringArrayEmptyOkay",
+      "json": []
+    },
+    
+    {
+      "name": "stringArrayEmptyOkay - Non-empty array",
+      "definition": "./ResourceMetaSchema.json#/definitions/stringArrayEmptyOkay",
+      "json": [ "a", "b", "c" ]
+    },
+    
+    
+    {
+      "name": "apiVersionProperty - Non-object",
+      "definition": "./ResourceMetaSchema.json#/definitions/apiVersionProperty",
+      "expectedErrors": [
+        {
+          "message": "Invalid type: number (expected object)",
+          "dataPath": "/"
+        }
+      ],
+      "json": 20
+    },
+    
+    {
+      "name": "apiVersionProperty - Empty object",
+      "definition": "./ResourceMetaSchema.json#/definitions/apiVersionProperty",
+      "json": {
+      }
+    },
+    
+    {
+      "name": "apiVersionProperty - Properties other than 'enum'",
+      "definition": "./ResourceMetaSchema.json#/definitions/apiVersionProperty",
+      "expectedErrors": [
+        {
+          "message": "Additional properties not allowed",
+          "dataPath": "/otherProperty"
+        }
+      ],
+      "json": {
+        "otherProperty": "otherValue"
+      }
+    },
+    
+    {
+      "name": "apiVersionProperty - Empty enum array",
+      "definition": "./ResourceMetaSchema.json#/definitions/apiVersionProperty",
+      "expectedErrors": [
+        {
+          "message": "Array is too short (0), minimum 1",
+          "dataPath": "/enum"
+        }
+      ],
+      "json": {
+        "enum": []
+      }
+    },
+    
+    {
+      "name": "apiVersionProperty - Value doesn't match API version pattern",
+      "definition": "./ResourceMetaSchema.json#/definitions/apiVersionProperty",
+      "expectedErrors": [
+        {
+          "message": "String does not match pattern: (^((\\d\\d\\d\\d-\\d\\d-\\d\\d)|([0-9]+(\\.[0-9]+)?))(-[a-zA-Z][a-zA-Z0-9]*)?$)",
+          "dataPath": "/enum/0",
+          "schemaPath": "/properties/enum/items/pattern"
+        }
+      ],
+      "json": {
+        "enum": [ "spam" ]
+      }
+    },
+      
+    {
+      "name": "apiVersionProperty - Date api version",
+      "definition": "./ResourceMetaSchema.json#/definitions/apiVersionProperty",
+      "json": {
+        "enum": [ "2015-01-01" ]
+      }
+    },
+      
+    {
+      "name": "apiVersionProperty - Duplicated date api version",
+      "definition": "./ResourceMetaSchema.json#/definitions/apiVersionProperty",
+      "expectedErrors": [
+        {
+          "message": "Array items are not unique (indices 0 and 1)",
+          "dataPath": "/enum"
+        }
+      ],
+      "json": {
+        "enum": [ "2015-01-01", "2015-01-01" ]
       }
     }
     

--- a/tools/ResourceMetaSchema.tests.json
+++ b/tools/ResourceMetaSchema.tests.json
@@ -42,6 +42,11 @@
       "definition": "./ResourceMetaSchema.json#/definitions/resourceMetaSchema",
       "expectedErrors": [
         {
+          "message": "String is too short (0 chars), minimum 1",
+          "dataPath": "/description",
+          "schemaPath": "/properties/description/minLength"
+        },
+        {
           "message": "Too few properties defined (0), minimum 1",
           "dataPath": "/resourceDefinitions"
         },
@@ -91,11 +96,13 @@
         }
       ],
       "json": {
-        "$schema": "http://json-schema.org/draft-04/schema",
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "title": "Test Title",
         "description": "hello",
         "resourceDefinitions": {
-          "mockResource": { }
+          "mockResource": {
+            "description": "Mock Resource Description"
+          }
         },
         "extraProperty": "Shouldn't be here"
       }
@@ -104,6 +111,12 @@
     {
       "name": "resourceMetaSchema - Empty resource definition",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceMetaSchema",
+      "expectedErrors": [
+        {
+          "message": "Missing required property: description",
+          "dataPath": "/resourceDefinitions/mockResource"
+        }
+      ],
       "json": {
         "$schema": "http://json-schema.org/draft-04/schema",
         "title": "Test Title",
@@ -148,7 +161,7 @@
       "json": {
         "description": "Test Resource Description",
         "properties": {
-          "type": { "enum": "Microsoft.Dan/TestType" }
+          "type": { "enum": [ "Microsoft.Dan/TestType" ] }
         }
       }
     },
@@ -165,7 +178,7 @@
       "json": {
         "description": "Test Resource Description",
         "properties": {
-          "apiVersion": "2015-12-02"
+          "apiVersion": { "enum": [ "2015-12-02" ] }
         }
       }
     },
@@ -176,10 +189,8 @@
       "json": {
         "description": "Test Resource Description",
         "properties": {
-          "apiVersion": "2015-12-02",
-          "type": {
-            "enum": [ "Microsoft.Dan/TestResourceType" ]
-          }
+          "apiVersion": { "enum": [ "2015-12-02" ] },
+          "type": { "enum": [ "Microsoft.Dan/TestResourceType" ] }
         }
       }
     },
@@ -190,10 +201,8 @@
       "json": {
         "description": "Test Resource Description",
         "properties": {
-          "apiVersion": "2015-12-02",
-          "type": {
-            "enum": [ "Microsoft.Dan/TestResourceType" ]
-          },
+          "apiVersion": { "enum": [ "2015-12-02" ] },
+          "type": { "enum": [ "Microsoft.Dan/TestResourceType" ] },
           "resources": { }
         }
       }
@@ -205,10 +214,8 @@
       "json": {
         "description": "Test Resource Description",
         "properties": {
-          "apiVersion": "2015-12-02",
-          "type": {
-            "enum": [ "Microsoft.Dan/TestResourceType" ]
-          },
+          "apiVersion": { "enum": [ "2015-12-02" ] },
+          "type": { "enum": [ "Microsoft.Dan/TestResourceType" ] },
           "properties": { }
         }
       }
@@ -217,13 +224,18 @@
     {
       "name": "resource - Resource properties with string-valued property",
       "definition": "./ResourceMetaSchema.json#/definitions/resource",
+      "expectedErrors": [
+        {
+          "message": "Additional properties not allowed",
+          "dataPath": "/properties/properties/testPropertyName",
+          "schemaPath": "/properties/properties/properties/properties/additionalProperties"
+        }
+      ],
       "json": {
         "description": "Test Resource Description",
         "properties": {
-          "apiVersion": "2015-12-02",
-          "type": {
-            "enum": [ "Microsoft.Dan/TestResourceType" ]
-          },
+          "apiVersion": { "enum": [ "2015-12-02" ] },
+          "type": { "enum": [ "Microsoft.Dan/TestResourceType" ] },
           "properties": {
             "testPropertyName": "TestName"
           }
@@ -234,13 +246,17 @@
     {
       "name": "resource - Resource properties with empty object-valued property",
       "definition": "./ResourceMetaSchema.json#/definitions/resource",
+      "expectedErrors": [
+        {
+          "message": "Additional properties not allowed",
+          "dataPath": "/properties/properties/testPropertyName"
+        }
+      ],
       "json": {
         "description": "Test Resource Description",
         "properties": {
-          "apiVersion": "2015-12-02",
-          "type": {
-            "enum": [ "Microsoft.Dan/TestResourceType" ]
-          },
+          "apiVersion": { "enum": [ "2015-12-02" ] },
+          "type": { "enum": [ "Microsoft.Dan/TestResourceType" ] },
           "properties": {
             "testPropertyName": { }
           }
@@ -425,8 +441,7 @@
       "json": {
         "type": "object",
         "properties": {
-          "description": {
-            "type": "string",
+          "testResourceProperty": {
             "description": "Microsoft.DataConnect/connectionManagers: The description of the connectionManager."
           }
         }
@@ -439,12 +454,10 @@
       "json": {
         "type": "object",
         "properties": {
-          "description": {
-            "type": "string",
+          "testResourceProperty1": {
             "description": "Description1"
           },
-          "description2": {
-            "type": "string",
+          "testResourceProperty2": {
             "description": "Description2"
           }
         }
@@ -473,7 +486,7 @@
         }
       ],
       "json": {
-        "anyOf": [
+        "oneOf": [
           { "type": "string" },
           { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
         ]
@@ -484,7 +497,7 @@
       "name": "resourceProperty - String type",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceProperty",
       "json": {
-        "anyOf": [
+        "oneOf": [
           { "type": "string" },
           { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
         ],
@@ -496,7 +509,7 @@
       "name": "resourceProperty - Number type without expression option",
       "definition": "./ResourceMetaSchema.json#/definitions/resourceProperty",
       "json": {
-        "anyOf": [
+        "oneOf": [
           { "type": "number" },
           { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
         ],

--- a/tools/ResourceMetaSchema.tests.json
+++ b/tools/ResourceMetaSchema.tests.json
@@ -612,6 +612,21 @@
       ]
     },
 
+    {
+      "name": "resourcePropertyDefinitionOptions - Expression reference and number type",
+      "definition": "./ResourceMetaSchema.json#/definitions/resourcePropertyDefinitionOptions",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/1"
+        }
+      ],
+      "json": [
+        { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" },
+        { "type": "number" }
+      ]
+    },
+
 
 
 

--- a/tools/Tests/assertTests.js
+++ b/tools/Tests/assertTests.js
@@ -36,6 +36,8 @@ function runTests()
     test.run(function () { assert.Equal([], []); });
     test.run(function () { assert.Equal([1], [1]); });
     test.run(function () { assert.Throws(function () { assert.Equal([1], [1, 2]); }); });
+    test.run(function () { assert.Equal({ "a": { "b": "bValue" } }, { "a": { "b": "bValue" } }); });
+    test.run(function () { assert.Throws(function () { assert.Equal({ "a": { "b": "bValue" } }, { "a": { "b": "notBValue" } }); }); });
 }
 
 if(require.main === module)

--- a/tools/Tests/tv4Tests.js
+++ b/tools/Tests/tv4Tests.js
@@ -45,6 +45,7 @@ function runTests()
     testPass({}, {});
     testPass({}, 5);
     testPass({}, "meta-schema");
+    testPass("hello", { "type": "string" });
     testFail({}, "",
     {
         schemaPath: "",

--- a/tools/Tests/utilitiesTests.js
+++ b/tools/Tests/utilitiesTests.js
@@ -1,0 +1,59 @@
+﻿var assert = require("../assert.js");
+var test = require("../test.js");
+var utilities = require("../utilities.js");
+
+module.exports.runTests = runTests;
+function runTests() {
+    // utilities.toString() tests
+    test.run(function () { assert.Equal("\"test\"", utilities.toString("test")); });
+    test.run(function () { assert.Equal("null", utilities.toString(null)); });
+    test.run(function () { assert.Equal("undefined", utilities.toString(undefined)); });
+    test.run(function () { assert.Equal("27", utilities.toString(27)); });
+    test.run(function () { assert.Equal("[\n  1,\n  2,\n  3,\n  4\n]", utilities.toString([1, 2, 3, 4])); });
+    test.run(function () { assert.Equal("{\n  \"a\": \"aValue\"\n}", utilities.toString({ "a": "aValue" })); });
+    test.run(function () { assert.Equal("{\n  \"a\": {\n    \"b\": \"bValue\"\n  }\n}", utilities.toString({ "a": { "b": "bValue" } })); });
+
+
+    // utilities.getProperty() tests
+    test.run(function () { assert.Equal("aValue", utilities.getProperty("a", { "a": "aValue" })); });
+    test.run(function () { assert.Equal("aValue", utilities.getProperty("#a", { "a": "aValue" })); });
+    test.run(function () { assert.Equal("aValue", utilities.getProperty("/a", { "a": "aValue" })); });
+    test.run(function () { assert.Equal("aValue", utilities.getProperty("#/a", { "a": "aValue" })); });
+    test.run(function () { assert.Equal("aValue", utilities.getProperty("a/b/c", { "a": { "b": { "c": "aValue" } } })); });
+    test.run(function () { assert.Throws(function () { utilities.getProperty("a", {}); }); });
+
+    // utilities.resolveSchemaLocalReferences() tests
+    test.run(function () { assert.Equal("hello", utilities.resolveSchemaLocalReferences("hello", "there")); });
+    test.run(function () { assert.Equal("hello", utilities.resolveSchemaLocalReferences("hello")); })
+    test.run(function () { assert.Equal("hello", utilities.resolveSchemaLocalReferences("hello", null)); })
+
+    test.run(function () {
+        var fullSchemaJson = {
+            "a": "aValue",
+            "aRef": { "$ref": "#/a" }
+        };
+        var resolvedSchemaJson = utilities.resolveSchemaLocalReferences(fullSchemaJson, fullSchemaJson);
+        var expectedResolvedSchemaJson = {
+            "a": "aValue",
+            "aRef": "aValue"
+        }
+        assert.Equal(expectedResolvedSchemaJson, resolvedSchemaJson);
+    });
+
+    test.run(function () {
+        var fullSchemaJson = {
+            "a": {
+                "b": "bValue",
+                "a": { "$ref": "#/a" }
+            }
+        };
+        var resolvedSchemaJson = utilities.resolveSchemaLocalReferences(fullSchemaJson, fullSchemaJson);
+        assert.Equal(fullSchemaJson, resolvedSchemaJson);
+    });
+}
+
+if (require.main === module) {
+    runTests();
+
+    test.showResults();
+}

--- a/tools/Tests/validateJSONTests.js
+++ b/tools/Tests/validateJSONTests.js
@@ -63,7 +63,6 @@ function runTests()
 
     testPass({}, {});
     testPass({}, 5);
-    testPass({}, "meta-schema");
     testErrorLog({}, "", "ERROR: Cannot use an empty schema for validation.");
     
     testErrorLog(null, null, "ERROR: Cannot validate a null json object.");

--- a/tools/Tests/validateJSONTests.js
+++ b/tools/Tests/validateJSONTests.js
@@ -44,7 +44,10 @@ function testErrorLog(json, schema, expectedMessage)
         
         test.run(function()
         {
-            assert.Throws(function() { vrs.validate(json, schema); });
+            var result = vrs.validate(json, schema);
+            assert.NotNull(result);
+            assert.NotNull(result.errors);
+            assert.Equal(1, result.errors.length);
         
             assert.Equal(1, errors.length);
             assert.Equal(expectedMessage, errors[0]);

--- a/tools/assert.js
+++ b/tools/assert.js
@@ -3,7 +3,7 @@ var utilities = require("./utilities.js");
 module.exports.ExpectedActualString = ExpectedActualString;
 function ExpectedActualString(expected, actual, message)
 {
-    return (message ? message : "") + "\nExpected: " + utilities.toString(expected) + "\nActual: " + utilities.toString(actual);
+    return (message ? message : "") + "\nExpected: " + utilities.toString(expected) + "\nActual:   " + utilities.toString(actual);
 }
 
 module.exports.Fail = Fail;
@@ -13,38 +13,38 @@ function Fail(message)
 }
 
 module.exports.True = True;
-function True(condition)
+function True(condition, message)
 {
     if(!(condition === true))
     {
-        Fail(ExpectedActualString(true, condition));
+        Fail(ExpectedActualString(true, condition, message));
     }
 }
 
 module.exports.False = False;
-function False(condition)
+function False(condition, message)
 {
     if(!(condition === false))
     {
-        Fail(ExpectedActualString(false, condition));
+        Fail(ExpectedActualString(false, condition, message));
     }
 }
 
 module.exports.Null = Null;
-function Null(value)
+function Null(value, message)
 {
     if(!(value === null))
     {
-        Fail(ExpectedActualString(null, value));
+        Fail(ExpectedActualString(null, value, message));
     }
 }
 
 module.exports.NotNull = NotNull;
-function NotNull(value)
+function NotNull(value, message)
 {
     if(!(value !== null))
     {
-        Fail(ExpectedActualString("not null", value));
+        Fail(ExpectedActualString("not null", value, message));
     }
 }
 
@@ -54,6 +54,13 @@ function Empty(value, message)
     if(!(value === null || value === undefined || value.length === 0))
     {
         Fail(ExpectedActualString("empty", value, message));
+    }
+}
+
+module.exports.NotEmpty = NotEmpty;
+function NotEmpty(value, message) {
+    if (value === null || value === undefined || value.length === 0) {
+        Fail(ExpectedActualString("not empty", value, message));
     }
 }
 
@@ -69,10 +76,11 @@ function Equal(lhs, rhs, message)
 module.exports.Throws = Throws;
 function Throws(func, errorValidator)
 {
+    var threw = true;
     try
     {
         func();
-        Fail("Provided function should have thrown.");
+        threw = false;
     }
     catch(e)
     {
@@ -81,4 +89,10 @@ function Throws(func, errorValidator)
             errorValidator(e);
         }
     }
+
+    if (!threw)
+    {
+        Fail("Provided function should have thrown.");
+    }
+
 }

--- a/tools/runSchemaTests.js
+++ b/tools/runSchemaTests.js
@@ -19,6 +19,32 @@ testFiles.push("./ResourceMetaSchema.tests.json");
 
 var singleIndent = utilities.repeat(" ", 4);
 
+function getProperty(sourceJSON, propertyPath)
+{
+    var hashIndex = propertyPath.indexOf("#");
+    if (hashIndex !== -1)
+    {
+        propertyPath = propertyPath.substring(hashIndex + 1);
+    }
+    if (propertyPath.startsWith("/")) {
+        propertyPath = propertyPath.substring(1);
+    }
+
+    var result = sourceJSON;
+
+    var propertyPathParts = propertyPath.split("/");
+    for (var propertyPathPartsIndex in propertyPathParts) {
+        var propertyPathPart = propertyPathParts[propertyPathPartsIndex];
+        result = result[propertyPathPart];
+
+        if (!result) {
+            assert.Fail("Could not find definition \"" + propertyPath + "\".");
+        }
+    }
+
+    return result;
+}
+
 for(var testFileIndex in testFiles)
 {
     var testFilePath = testFiles[testFileIndex];
@@ -44,21 +70,12 @@ for(var testFileIndex in testFiles)
             else
             {
                 var definitionSchemaUri = definitionSchemaLocation.substring(0, definitionSchemaLocationHashIndex);
-                definitionSchemaJSON = utilities.readJSONPath(definitionSchemaUri, schemasFolderPath);
+                var definitionSchemaFullJSON = utilities.readJSONPath(definitionSchemaUri, schemasFolderPath);
 
                 var definitionSchemaPath = definitionSchemaLocation.substring(definitionSchemaLocationHashIndex + 1);
-                if (definitionSchemaPath.startsWith("/")) {
-                    definitionSchemaPath = definitionSchemaPath.substring(1);
-                }
-                var definitionSchemaPathParts = definitionSchemaPath.split("/");
-                for (var definitionSchemaPathPartIndex in definitionSchemaPathParts) {
-                    var definitionSchemaPathPart = definitionSchemaPathParts[definitionSchemaPathPartIndex];
-                    definitionSchemaJSON = definitionSchemaJSON[definitionSchemaPathPart];
+                definitionSchemaJSON = getProperty(definitionSchemaFullJSON, definitionSchemaPath);
 
-                    if (!definitionSchemaJSON) {
-                        assert.Fail("Could not find definition \"" + definitionSchemaPath + "\" in schema \"" + definitionSchemaUri + "\"");
-                    }
-                }
+
             }
             
             var result = validator.validate(testObject.json, definitionSchemaJSON, schemasFolderPath);

--- a/tools/runSchemaTests.js
+++ b/tools/runSchemaTests.js
@@ -19,32 +19,6 @@ testFiles.push("./ResourceMetaSchema.tests.json");
 
 var singleIndent = utilities.repeat(" ", 4);
 
-function getProperty(sourceJSON, propertyPath)
-{
-    var hashIndex = propertyPath.indexOf("#");
-    if (hashIndex !== -1)
-    {
-        propertyPath = propertyPath.substring(hashIndex + 1);
-    }
-    if (propertyPath.startsWith("/")) {
-        propertyPath = propertyPath.substring(1);
-    }
-
-    var result = sourceJSON;
-
-    var propertyPathParts = propertyPath.split("/");
-    for (var propertyPathPartsIndex in propertyPathParts) {
-        var propertyPathPart = propertyPathParts[propertyPathPartsIndex];
-        result = result[propertyPathPart];
-
-        if (!result) {
-            assert.Fail("Could not find definition \"" + propertyPath + "\".");
-        }
-    }
-
-    return result;
-}
-
 for(var testFileIndex in testFiles)
 {
     var testFilePath = testFiles[testFileIndex];
@@ -73,9 +47,9 @@ for(var testFileIndex in testFiles)
                 var definitionSchemaFullJSON = utilities.readJSONPath(definitionSchemaUri, schemasFolderPath);
 
                 var definitionSchemaPath = definitionSchemaLocation.substring(definitionSchemaLocationHashIndex + 1);
-                definitionSchemaJSON = getProperty(definitionSchemaFullJSON, definitionSchemaPath);
+                definitionSchemaJSON = utilities.getProperty(definitionSchemaPath, definitionSchemaFullJSON);
 
-
+                definitionSchemaJSON = utilities.resolveSchemaLocalReferences(definitionSchemaJSON, definitionSchemaFullJSON);
             }
             
             var result = validator.validate(testObject.json, definitionSchemaJSON, schemasFolderPath);

--- a/tools/runSchemaTests.js
+++ b/tools/runSchemaTests.js
@@ -15,6 +15,7 @@ utilities.forEachFile(testsFolderPath, function (filePath) {
         testFiles.push(filePath);
     }
 });
+testFiles.push("./ResourceMetaSchema.tests.json");
 
 var singleIndent = utilities.repeat(" ", 4);
 

--- a/tools/runTests.js
+++ b/tools/runTests.js
@@ -6,6 +6,7 @@ var testFiles =
     "Tests/assertTests.js",
     "Tests/tv4Tests.js",
     "Tests/validateJSONTests.js",
+    "Tests/utilitiesTests.js",
 ];
 
 function resolve(filePath)

--- a/tools/utilities.js
+++ b/tools/utilities.js
@@ -2,257 +2,332 @@ var fs = require("fs");
 var path = require("path");
 var syncRequest = require("sync-request")
 
+var assert = require("./assert.js");
+
 var currentFileDirectory = __dirname;
 
 module.exports.getSchemasFolderPath = getSchemasFolderPath;
-function getSchemasFolderPath()
-{
-    return path.join(currentFileDirectory, "../schemas/");
+function getSchemasFolderPath() {
+  return path.join(currentFileDirectory, "../schemas/");
 }
 
 module.exports.getTestsFolderPath = getTestsFolderPath;
-function getTestsFolderPath()
-{
-    return path.join(currentFileDirectory, "../tests/");
+function getTestsFolderPath() {
+  return path.join(currentFileDirectory, "../tests/");
 }
 
 module.exports.pathExists = pathExists;
-function pathExists(path)
-{
-    var result = true;
-    try
-    {
-        fs.statSync(path);    
-    }
-    catch(e)
-    {
-        result = false;
-    }
-    return result;
+function pathExists(path) {
+  var result = true;
+  try {
+    fs.statSync(path);
+  }
+  catch (e) {
+    result = false;
+  }
+  return result;
 }
 
 module.exports.forEachFile = forEachFile;
-function forEachFile(folder, callback)
-{
-    var files = fs.readdirSync(folder);
-    for(var fileIndex in files)
-    {
-        var filePath = path.join(folder, files[fileIndex]);
-        
-        var fileStats = fs.statSync(filePath);
-        if(fileStats.isDirectory())
-        {
-            forEachFile(filePath, callback);
-        }
-        else if(fileStats.isFile())
-        {
-            callback(filePath);
-        }
+function forEachFile(folder, callback) {
+  var files = fs.readdirSync(folder);
+  for (var fileIndex in files) {
+    var filePath = path.join(folder, files[fileIndex]);
+
+    var fileStats = fs.statSync(filePath);
+    if (fileStats.isDirectory()) {
+      forEachFile(filePath, callback);
     }
+    else if (fileStats.isFile()) {
+      callback(filePath);
+    }
+  }
 }
 
 module.exports.getFiles = getFiles;
-function getFiles(folder, filterFunction)
-{
-    var files = [];
-    
-    if(typeof filterFunction === "string")
-    {
-        var fileExtension = filterFunction;
-        filterFunction = function(filePath) { return filePath.endsWith(fileExtension); };
+function getFiles(folder, filterFunction) {
+  var files = [];
+
+  if (typeof filterFunction === "string") {
+    var fileExtension = filterFunction;
+    filterFunction = function (filePath) { return filePath.endsWith(fileExtension); };
+  }
+
+  forEachFile(folder, function (filePath) {
+    if (filterFunction(filePath)) {
+      files.push(filePath);
     }
-    
-    forEachFile(folder, function(filePath)
-    {
-        if(filterFunction(filePath))
-        {
-            files.push(filePath);
-        }
-    });
-    
-    return files;
+  });
+
+  return files;
 }
 
-function stripUTF8BOM(value)
-{
-    return value.replace(/^\uFEFF/, '');
+function stripUTF8BOM(value) {
+  return value.replace(/^\uFEFF/, '');
 }
 
 module.exports.readJSONPath = readJSONPath;
 function readJSONPath(jsonUri, schemaFolderPath) {
-    
-    if(schemaFolderPath && (!schemaFolderPath.endsWith('/') && !schemaFolderPath.endsWith('\\')))
-    {
-        schemaFolderPath += "/";
-    }
-    
-    var retval;
 
-    var azurePrefix = "http://schema.management.azure.com/schemas/";
-    var jsonPath;
-    if (jsonUri.startsWith(azurePrefix) && schemaFolderPath && pathExists(schemaFolderPath)) {
-        jsonPath = jsonUri.replace(azurePrefix, schemaFolderPath);
-    }
-    else {
-        jsonPath = jsonUri;
-    }
-    
-    if (jsonPath.startsWith("http:") || jsonPath.startsWith("https:")) {
-        retval = readJSONUri(jsonPath);
-    }
-    else
-    {
-        retval = readJSONFile(jsonPath);
-    }
+  if (schemaFolderPath && (!schemaFolderPath.endsWith('/') && !schemaFolderPath.endsWith('\\'))) {
+    schemaFolderPath += "/";
+  }
 
-    return retval;
+  var retval;
+
+  var azurePrefix = "http://schema.management.azure.com/schemas/";
+  var jsonPath;
+  if (jsonUri.startsWith(azurePrefix) && schemaFolderPath && pathExists(schemaFolderPath)) {
+    jsonPath = jsonUri.replace(azurePrefix, schemaFolderPath);
+  }
+  else {
+    jsonPath = jsonUri;
+  }
+
+  if (jsonPath.startsWith("http:") || jsonPath.startsWith("https:")) {
+    retval = readJSONUri(jsonPath);
+  }
+  else {
+    retval = readJSONFile(jsonPath);
+  }
+
+  return retval;
 }
 
 module.exports.readJSONFile = readJSONFile;
-function readJSONFile(filePath)
-{
-    var fileContents = fs.readFileSync(filePath, "utf8");
-    var fileContentsWithoutBOM = stripUTF8BOM(fileContents);
-    return JSON.parse(fileContentsWithoutBOM);
+function readJSONFile(filePath) {
+  var fileContents = fs.readFileSync(filePath, "utf8");
+  var fileContentsWithoutBOM = stripUTF8BOM(fileContents);
+  return JSON.parse(fileContentsWithoutBOM);
 }
 
 module.exports.readJSONUri = readJSONUri;
-function readJSONUri(uri)
-{
-    var response = syncRequest("GET", uri);
-    var responseBody = stripUTF8BOM(response.getBody("utf8"));
-    return JSON.parse(responseBody);
+function readJSONUri(uri) {
+  var response = syncRequest("GET", uri);
+  var responseBody = stripUTF8BOM(response.getBody("utf8"));
+  return JSON.parse(responseBody);
 }
 
 module.exports.contains = contains;
-function contains(container, value, comparisonFunction)
-{
-    if(!comparisonFunction)
-    {
-        comparisonFunction = function(lhs, rhs) { return lhs === rhs; };
+function contains(container, value, comparisonFunction) {
+  if (!comparisonFunction) {
+    comparisonFunction = function (lhs, rhs) { return lhs === rhs; };
+  }
+
+  var result = false;
+
+  for (var containerValue in container) {
+    if (comparisonFunction(containerValue, value)) {
+      result = true;
+      break;
     }
-    
-    var result = false;
-    
-    for(var i = 0; i < container.length; ++i)
-    {
-        if(comparisonFunction(container[i], value))
-        {
-            result = true;
-            break;
-        }
-    }
-    
-    return result;
+  }
+
+  return result;
 }
 
 module.exports.unique = unique;
-function unique(array)
-{
-    var result = [];
-    
-    for(var i = 0; i < this.length; ++i)
-    {
-        if(!contains(result, array[i]))
-        {
-            result.push(array[i]);
-        }
+function unique(array) {
+  var result = [];
+
+  for (var i = 0; i < this.length; ++i) {
+    if (!contains(result, array[i])) {
+      result.push(array[i]);
     }
-    
-    return result;
+  }
+
+  return result;
 }
 
 module.exports.repeat = repeat;
-function repeat(value, count)
-{
-    var result = value;
-    for(var i = 1; i < count; ++i)
-    {
-        result += value;
-    }
-    return result;
+function repeat(value, count) {
+  var result = value;
+  for (var i = 1; i < count; ++i) {
+    result += value;
+  }
+  return result;
 }
 
 var singleIndentSpaceCount = 2;
 var singleIndent = repeat(" ", singleIndentSpaceCount);
 
 module.exports.toString = toString;
-function toString(value, indent)
-{
-    if (!indent)
-    {
-        indent = "";
-    }
+function toString(value, indent) {
+  if (!indent) {
+    indent = "";
+  }
 
-    var result;
-    if(Array.isArray(value))
-    {
-        result = indent + "[";
-        var addComma = false;
-        for (var index in value) {
-            if (addComma) {
-                result += ",";
-            }
-            else {
-                addComma = true;
-            }
+  var result;
+  if (Array.isArray(value)) {
+    result = indent + "[";
+    var addComma = false;
+    for (var index in value) {
+      if (addComma) {
+        result += ",";
+      }
+      else {
+        addComma = true;
+      }
 
-            var elementIndent = indent + singleIndent;
-            var elementString = toString(value[index], elementIndent);
-            result += "\n" + elementString;
-        }
-        result += "\n" + indent + "]";
+      var elementIndent = indent + singleIndent;
+      var elementString = toString(value[index], elementIndent);
+      result += "\n" + elementIndent + elementString;
     }
-    else if (typeof value === "object" && value !== null)
-    {
-        result = indent + "{";
-        var addComma = false;
-        for (var propertyName in value) {
-            if (addComma) {
-                result += ",";
-            }
-            else {
-                addComma = true;
-            }
+    result += "\n" + indent + "]";
+  }
+  else if (typeof value === "object" && value !== null) {
+    result = "{";
+    var addComma = false;
+    for (var propertyName in value) {
+      if (addComma) {
+        result += ",";
+      }
+      else {
+        addComma = true;
+      }
 
-            var propertyIndent = indent + singleIndent;
-            var propertyValueString = toString(value[propertyName], propertyIndent);
-            result += "\n" + propertyIndent + "\"" + propertyName + "\": " + propertyValueString;
-        }
-        result += "\n" + indent + "}";
+      var propertyIndent = indent + singleIndent;
+      var propertyValueString = toString(value[propertyName], propertyIndent);
+      result += "\n" + propertyIndent + "\"" + propertyName + "\": " + propertyValueString;
     }
-    else
-    {
-        result = JSON.stringify(value);
+    result += "\n" + indent + "}";
+  }
+  else {
+    if (value === undefined) {
+      result = "undefined";
     }
+    else {
+      result = JSON.stringify(value);
+    }
+  }
 
-    return result;
+  return result;
 }
 
 module.exports.equals = equals;
-function equals(lhs, rhs)
-{
-    var result = (lhs === rhs);
+function equals(lhs, rhs) {
+  var result = (lhs === rhs);
 
-    if(!result && typeof lhs === typeof rhs)
-    {
-        if(typeof lhs === "object")
-        {
-            result = true;
-            for (var lhsPropertyName in lhs) {
-                if (!equals(lhs[lhsPropertyName], rhs[lhsPropertyName])) {
-                    result = false;
-                    break;
-                }
-            }
-            for (var rhsPropertyName in rhs) {
-                if (!equals(lhs[rhsPropertyName], rhs[rhsPropertyName])) {
-                    result = false;
-                    break;
-                }
-            }
+  if (!result && typeof lhs === typeof rhs) {
+    if (typeof lhs === "object") {
+      result = true;
+      for (var lhsPropertyName in lhs) {
+        if (!equals(lhs[lhsPropertyName], rhs[lhsPropertyName])) {
+          result = false;
+          break;
         }
+      }
+      for (var rhsPropertyName in rhs) {
+        if (!equals(lhs[rhsPropertyName], rhs[rhsPropertyName])) {
+          result = false;
+          break;
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+module.exports.getProperty = getProperty;
+function getProperty(propertyPath, sourceJSON) {
+  var hashIndex = propertyPath.indexOf("#");
+  if (hashIndex !== -1) {
+    propertyPath = propertyPath.substring(hashIndex + 1);
+  }
+  if (propertyPath.startsWith("/")) {
+    propertyPath = propertyPath.substring(1);
+  }
+
+  var result = sourceJSON;
+
+  var propertyPathParts = propertyPath.split("/");
+  for (var propertyPathPartsIndex in propertyPathParts) {
+    var propertyPathPart = propertyPathParts[propertyPathPartsIndex];
+    result = result[propertyPathPart];
+
+    if (!result) {
+      assert.Fail("Could not find definition \"" + propertyPath + "\".");
+    }
+  }
+
+  return result;
+}
+
+module.exports.resolveSchemaLocalReferences = resolveSchemaLocalReferences;
+function resolveSchemaLocalReferences(partialSchemaJson, fullSchemaJson, currentPath, resolvedPaths) {
+  var result = partialSchemaJson;
+
+  if (partialSchemaJson && typeof partialSchemaJson === "object" &&
+      fullSchemaJson && typeof fullSchemaJson === "object") {
+
+    if (!currentPath) {
+      currentPath = "#";
     }
 
+    if (!resolvedPaths) {
+      resolvedPaths = {};
+    }
+
+    for (var index in result) {
+      var indexValue = result[index];
+      var indexPath = currentPath + "/" + index;
+
+      if (index === "$ref" && typeof indexValue === "string" && indexValue.startsWith("#/")) {
+
+        if (contains(resolvedPaths, indexValue)) {
+          result[index] = resolvedPaths[indexValue];
+        }
+        else {
+          resolvedPaths[indexValue] = currentPath;
+
+          var referenceObject = clone(getProperty(result[index], fullSchemaJson));
+          result = resolveSchemaLocalReferences(referenceObject, fullSchemaJson, indexPath, resolvedPaths);
+
+          break;
+        }
+      }
+      else {
+        result[index] = resolveSchemaLocalReferences(indexValue, fullSchemaJson, indexPath, resolvedPaths);
+      }
+    }
+  }
+
+  return result;
+}
+
+// This code was borrowed from: http://stackoverflow.com/questions/728360/most-elegant-way-to-clone-a-javascript-object
+module.exports.clone = clone;
+function clone(value) {
+  var result;
+
+  // Handle the 3 simple types, and null or undefined
+  if (null == value || "object" != typeof value) return value;
+
+  // Handle Date
+  if (value instanceof Date) {
+    result = new Date();
+    result.setTime(value.getTime());
     return result;
+  }
+
+  // Handle Array
+  if (value instanceof Array) {
+    result = [];
+    for (var i = 0, len = value.length; i < len; i++) {
+      result[i] = clone(value[i]);
+    }
+    return result;
+  }
+
+  // Handle Object
+  if (value instanceof Object) {
+    result = {};
+    for (var attr in value) {
+      if (value.hasOwnProperty(attr)) result[attr] = clone(value[attr]);
+    }
+    return result;
+  }
+
+  throw new Error("Unable to copy value! Its type (" + typeof value + ") isn't supported.");
 }

--- a/tools/utilities.js
+++ b/tools/utilities.js
@@ -98,7 +98,6 @@ function readJSONPath(jsonUri, schemaFolderPath) {
     }
     
     if (jsonPath.startsWith("http:") || jsonPath.startsWith("https:")) {
-        //console.log("Retrieving " + jsonUri + " from network...");
         retval = readJSONUri(jsonPath);
     }
     else
@@ -112,7 +111,6 @@ function readJSONPath(jsonUri, schemaFolderPath) {
 module.exports.readJSONFile = readJSONFile;
 function readJSONFile(filePath)
 {
-    //console.log("Reading JSON file at file path: \"" + filePath + "\"");
     var fileContents = fs.readFileSync(filePath, "utf8");
     var fileContentsWithoutBOM = stripUTF8BOM(fileContents);
     return JSON.parse(fileContentsWithoutBOM);

--- a/tools/utilities.js
+++ b/tools/utilities.js
@@ -89,14 +89,21 @@ function readJSONPath(jsonUri, schemaFolderPath) {
     var retval;
 
     var azurePrefix = "http://schema.management.azure.com/schemas/";
+    var jsonPath;
     if (jsonUri.startsWith(azurePrefix) && schemaFolderPath && pathExists(schemaFolderPath)) {
-        var jsonFilePath = jsonUri.replace(azurePrefix, schemaFolderPath);
-        //console.log("Retrieving " + jsonUri + " from disk (" + jsonFilePath + ")...");
-        retval = readJSONFile(jsonFilePath);
+        jsonPath = jsonUri.replace(azurePrefix, schemaFolderPath);
     }
     else {
+        jsonPath = jsonUri;
+    }
+    
+    if (jsonPath.startsWith("http:") || jsonPath.startsWith("https:")) {
         //console.log("Retrieving " + jsonUri + " from network...");
-        retval = readJSONUri(jsonUri);
+        retval = readJSONUri(jsonPath);
+    }
+    else
+    {
+        retval = readJSONFile(jsonPath);
     }
 
     return retval;

--- a/tools/utilities.js
+++ b/tools/utilities.js
@@ -173,7 +173,7 @@ function repeat(value, count)
     return result;
 }
 
-var singleIndentSpaceCount = 4;
+var singleIndentSpaceCount = 2;
 var singleIndent = repeat(" ", singleIndentSpaceCount);
 
 module.exports.toString = toString;

--- a/tools/validateJSON.js
+++ b/tools/validateJSON.js
@@ -1,87 +1,87 @@
 var tv4 = require("tv4");
 
 var utilities = require("./utilities.js");
-        
+    
 module.exports.logger = console.log;
 
 function log(message)
 {
-    if(module.exports.logger !== null)
-    {
-        module.exports.logger(message);
-    }
+  if(module.exports.logger !== null)
+  {
+    module.exports.logger(message);
+  }
 }
 
 function logError(message)
 {
-    log("ERROR: " + message);
+  log("ERROR: " + message);
 }
 
 function logUsage()
 {
-    log("USAGE: \"node validateJSON.js <path-to-json-file> <path-to-schema-file> [<path-to-schema-folder>]\"");
+  log("USAGE: \"node validateJSON.js <path-to-json-file> <path-to-schema-file> [<path-to-schema-folder>]\"");
 }
 
 function exit(exitCode)
 {
-    process.exit(exitCode);
+  process.exit(exitCode);
 }
 
 function getCommandLineArgument(commandLineArgumentIndex, errorMessage)
 {
-    var commandLineArgument = process.argv[commandLineArgumentIndex];
-    if(!commandLineArgument && errorMessage)
-    {
-        logError(errorMessage);
-        logUsage();
-        exit(-1);
-    }
-    else
-    {
-        return commandLineArgument;
-    }
+  var commandLineArgument = process.argv[commandLineArgumentIndex];
+  if(!commandLineArgument && errorMessage)
+  {
+    logError(errorMessage);
+    logUsage();
+    exit(-1);
+  }
+  else
+  {
+    return commandLineArgument;
+  }
 }
 
 function getFileContents(filePath)
 {
-    var fs = require("fs");
-    try
+  var fs = require("fs");
+  try
+  {
+    return fs.readFileSync(filePath, "utf8");
+  }
+  catch(error)
+  {
+    if(error.code === "ENOENT")
     {
-        return fs.readFileSync(filePath, "utf8");
+      logError("Could not find file: \"" + error.path + "\"");
     }
-    catch(error)
+    else
     {
-        if(error.code === "ENOENT")
-        {
-            logError("Could not find file: \"" + error.path + "\"");
-        }
-        else
-        {
-            logError("Unrecognized error: " + error);
-        }
-        exit(-1);
+      logError("Unrecognized error: " + error);
     }
+    exit(-1);
+  }
 }
 
 function getErrorMessage(prefix, value, suffix)
 {
-    var errorMessage = prefix;
-    if(value === undefined)
-    {
-        errorMessage += "n";
-    }
-    else if(value === "")
-    {
-        errorMessage += "n empty";
-    }
-    
-    if(value !== "")
-    {
-        errorMessage += " " + value;
-    }
-    errorMessage += " " + suffix;
-    
-    return errorMessage;
+  var errorMessage = prefix;
+  if(value === undefined)
+  {
+    errorMessage += "n";
+  }
+  else if(value === "")
+  {
+    errorMessage += "n empty";
+  }
+  
+  if(value !== "")
+  {
+    errorMessage += " " + value;
+  }
+  errorMessage += " " + suffix;
+  
+  return errorMessage;
 }
 
 /**
@@ -93,95 +93,123 @@ function getErrorMessage(prefix, value, suffix)
 module.exports.validate = validate;
 function validate(json, schema, missingSchemaFolderPath)
 {
-    if(!json)
+  if(!json)
+  {
+    logError(getErrorMessage("Cannot validate a", json, "json object."));
+    return { valid: false, errors: [ { message: "Invalid JSON" } ], missingSchemas: [] };
+  }
+  else if(!schema)
+  {
+    logError(getErrorMessage("Cannot use a", schema, "schema for validation."));
+    return { valid: false, errors: [ { message: "Invalid schema" } ], missingSchemas: [] };
+  }
+  else
+  {
+    if(typeof json === "object")
     {
-        logError(getErrorMessage("Cannot validate a", json, "json object."));
-        return { valid: false, errors: [ { message: "Invalid JSON" } ], missingSchemas: [] };
+      tv4.addSchema(json);
     }
-    else if(!schema)
+    if(typeof schema === "object")
     {
-        logError(getErrorMessage("Cannot use a", schema, "schema for validation."));
-        return { valid: false, errors: [ { message: "Invalid schema" } ], missingSchemas: [] };
+      tv4.addSchema(schema);
     }
-    else
+    addMissingSchemas(tv4.getMissingUris(), missingSchemaFolderPath);
+    
+    var result = convertTv4ValidationResult(tv4.validateMultiple(json, schema));
+    while(result.missingSchemas && result.missingSchemas.length > 0)
     {
-        tv4.addSchema(json);
-        tv4.addSchema(schema);
-        var missingUris = tv4.getMissingUris();
-        while(missingUris && missingUris.length > 0)
-        {
-            var missingUri = missingUris.pop();
-            
-            var missingUriWithJsonEnding = missingUri;
-            if(missingUriWithJsonEnding.endsWith(".json") == false)
-            {
-                missingUriWithJsonEnding += ".json";
-            }
+      addMissingSchemas(result.missingSchemas, missingSchemaFolderPath);
+      
+      result = convertTv4ValidationResult(tv4.validateMultiple(json, schema));
+    }
+    
+    return result;
+  }
+}
 
-            tv4.addSchema(missingUri, utilities.readJSONPath(missingUriWithJsonEnding, missingSchemaFolderPath));
-            
-            missingUris = tv4.getMissingUris();
-        }
-        
-        var validationResult = tv4.validateMultiple(json, schema);
-        var result = { valid: validationResult.valid, errors: [], missingSchemas: validationResult.missing };
-        
-        for(var errorIndex in validationResult.errors)
-        {
-            var currentError = validationResult.errors[errorIndex];
-            var resultError =
-            {
-                message: currentError.message,
-                dataPath: currentError.dataPath,
-                schemaPath: currentError.schemaPath,
-            };
-            if(!resultError.dataPath)
-            {
-                resultError.dataPath = "/";
-            }
-            
-            result.errors.push(resultError);
-        }
-        
-        return result;
+function convertTv4ValidationResult(tv4ValidationResult)
+{
+  var result = { valid: tv4ValidationResult.valid, errors: [], missingSchemas: [] }
+  
+  for(var missingSchemaIndex in tv4ValidationResult.missing)
+  {
+    var missingSchema = tv4ValidationResult.missing[missingSchemaIndex];
+    
+    if(missingSchema && missingSchema.length > 0)
+    {
+      result.missingSchemas.push(missingSchema);
     }
+  }
+  
+  for(var errorIndex in tv4ValidationResult.errors)
+    {
+      var currentError = tv4ValidationResult.errors[errorIndex];
+      var resultError =
+      {
+        message: currentError.message,
+        dataPath: currentError.dataPath,
+        schemaPath: currentError.schemaPath,
+      };
+      if(!resultError.dataPath)
+      {
+        resultError.dataPath = "/";
+      }
+      
+      result.errors.push(resultError);
+    }
+  
+  return result;
+}
+
+function addMissingSchemas(missingUris, missingSchemaFolderPath)
+{
+  while(missingUris && missingUris.length > 0)
+  {
+    var missingUri = missingUris.pop();
+    if(missingUri && missingUri.length > 0)
+    {
+      tv4.addSchema(missingUri, utilities.readJSONPath(missingUri, missingSchemaFolderPath));
+      
+      missingUris = tv4.getMissingUris();
+    }
+  }
 }
 
 module.exports.validateFile = validateFile;
 function validateFile(jsonFilePath, schemaFilePath, missingSchemaFolderPath)
 {
-    var json = utilities.readJSONFile(jsonFilePath);
-    var schemaJson = utilities.readJSONFile(schemaFilePath);
-    
-    return validate(json, schemaJson, missingSchemaFolderPath);
+  var json = utilities.readJSONFile(jsonFilePath);
+  var schemaJson = utilities.readJSONFile(schemaFilePath);
+  
+  return validate(json, schemaJson, missingSchemaFolderPath);
 }
 
 if(require.main === module)
 {
-    // commandLineArguments[0] is node.exe
-    // commandLineArguments[1] is validateJSON.js
-    var jsonFilePath = getCommandLineArgument(2, "The first argument must be the path to the json file to validate.");
-    var schemaFilePath = getCommandLineArgument(3, "The second argument must be the path to the schema file to use for validation.");
-    var missingSchemaFolderPath = getCommandLineArgument(4);
-    
-    var validationResult = validateFile(jsonFilePath, schemaFilePath, missingSchemaFolderPath);
-    if(validationResult && validationResult.valid)
+  // commandLineArguments[0] is node.exe
+  // commandLineArguments[1] is validateJSON.js
+  var jsonFilePath = getCommandLineArgument(2, "The first argument must be the path to the json file to validate.");
+  var schemaFilePath = getCommandLineArgument(3, "The second argument must be the path to the schema file to use for validation.");
+  var missingSchemaFolderPath = getCommandLineArgument(4);
+  
+  var validationResult = validateFile(jsonFilePath, schemaFilePath, missingSchemaFolderPath);
+  if(validationResult && validationResult.valid)
+  {
+    log("JSON validation passed");
+  }
+  else
+  {
+    log("JSON validation failed");
+    for(var errorIndex in validationResult.errors)
     {
-        log("JSON validation passed");
+      if(errorIndex > 0)
+      {
+        log();
+      }
+      
+      log("Error " + errorIndex + ":");
+      log("  Message:   \"" + validationResult.errors[errorIndex].message + "\"");
+      log("  Data Path: " + validationResult.errors[errorIndex].dataPath);
     }
-    else
-    {
-        log("JSON validation failed");
-        for(var errorIndex in validationResult.errors)
-        {
-            if(errorIndex > 0)
-            {
-                log();
-            }
-            
-            log("Error " + errorIndex + ":");
-            log("    Message:   \"" + validationResult.errors[errorIndex].message + "\"");
-            log("    Data Path: " + validationResult.errors[errorIndex].dataPath);
-        }
-    }
+  }
 }

--- a/tools/validateJSON.js
+++ b/tools/validateJSON.js
@@ -1,5 +1,6 @@
 var tv4 = require("tv4");
 
+var assert = require("./assert.js");
 var utilities = require("./utilities.js");
     
 module.exports.logger = console.log;
@@ -110,11 +111,10 @@ function validate(json, schema, missingSchemaFolderPath)
     addMissingSchemas(tv4.getMissingUris(), missingSchemaFolderPath);
     
     var result = convertTv4ValidationResult(tv4.validateMultiple(json, schema));
-    while(result.missingSchemas && result.missingSchemas.length > 0)
+    while (result.missingSchemas && result.missingSchemas.length > 0)
     {
-      addMissingSchemas(result.missingSchemas, missingSchemaFolderPath);
-      
-      result = convertTv4ValidationResult(tv4.validateMultiple(json, schema));
+        addMissingSchemas(result.missingSchemas, missingSchemaFolderPath);
+        result = convertTv4ValidationResult(tv4.validateMultiple(json, schema));
     }
     
     return result;
@@ -123,16 +123,14 @@ function validate(json, schema, missingSchemaFolderPath)
 
 function convertTv4ValidationResult(tv4ValidationResult)
 {
-  var result = { valid: tv4ValidationResult.valid, errors: [], missingSchemas: [] }
+  var result = { valid: tv4ValidationResult.valid, errors: [], missingSchemas: [] };
   
   for(var missingSchemaIndex in tv4ValidationResult.missing)
   {
     var missingSchema = tv4ValidationResult.missing[missingSchemaIndex];
-    
-    if(missingSchema && missingSchema.length > 0)
-    {
-      result.missingSchemas.push(missingSchema);
-    }
+    assert.NotEmpty(missingSchema, "tv4ValidationResult should not have had any empty missing schemas: " + utilities.toString(tv4ValidationResult.missing));
+
+    result.missingSchemas.push(missingSchema);
   }
   
   for(var errorIndex in tv4ValidationResult.errors)

--- a/tools/validateJSON.js
+++ b/tools/validateJSON.js
@@ -105,14 +105,8 @@ function validate(json, schema, missingSchemaFolderPath)
   }
   else
   {
-    if(typeof json === "object")
-    {
-      tv4.addSchema(json);
-    }
-    if(typeof schema === "object")
-    {
-      tv4.addSchema(schema);
-    }
+    tv4.addSchema(json);
+    tv4.addSchema(schema);
     addMissingSchemas(tv4.getMissingUris(), missingSchemaFolderPath);
     
     var result = convertTv4ValidationResult(tv4.validateMultiple(json, schema));

--- a/tools/validateSchemas.js
+++ b/tools/validateSchemas.js
@@ -1,3 +1,4 @@
+var clc = require("cli-color");
 var path = require("path");
 
 var utilities = require("./utilities.js");
@@ -67,16 +68,16 @@ for(var schemaFilePathIndex in schemaFilePaths)
         console.log("    Using schema: \"" + metaSchema.path + "\"");
         if(!validationResult.valid)
         {
-            console.log("        Failed");
+            console.log(clc.red("        Failed"));
             for(var errorIndex in validationResult.errors)
             {
                 var error = validationResult.errors[errorIndex];
-                console.log("        " + (parseInt(errorIndex) + 1) + ". Error at \"" + error.dataPath + "\" - " + error.message);
+                console.log(clc.red("        " + (parseInt(errorIndex) + 1) + ". Error at \"" + error.dataPath + "\" - " + error.message));
             }
         }
         else
         {
-            console.log("        Passed");
+            console.log(clc.green("        Passed"));
         }
     }
 }


### PR DESCRIPTION
Recently we found that many deployment templates were getting schema validation warnings because developers were using expressions ("[add(1, 2)]") instead of the type that the property required ("integer"). To solve this problem, we decided to go through the resource schemas and to add support for expressions to all properties.
I added validation to the ResourceMetaSchema.json file so that every property would be required to support expressions. I've fixed all of the errors that resulted from running "validateSchemas.js", but I'm sure that I missed some properties. This pull request was already getting large, so I decided to take it in chunks. This first pass is adding expression support for many of the properties and adding descriptions where they were missing. In the next pass I'm hoping to catch more of the properties that don't support expressions.