### PR TITLE
"sku", "kind", "plan", "location" fix

### DIFF
--- a/schemas/2014-02-26/microsoft.visualstudio.json
+++ b/schemas/2014-02-26/microsoft.visualstudio.json
@@ -50,7 +50,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "microsoft.visualstudio account"
     },

--- a/schemas/2014-04-01-preview/Microsoft.Cache.json
+++ b/schemas/2014-04-01-preview/Microsoft.Cache.json
@@ -133,7 +133,8 @@
         "name",
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Redis cache resource"
     }

--- a/schemas/2014-04-01-preview/Microsoft.Sql.json
+++ b/schemas/2014-04-01-preview/Microsoft.Sql.json
@@ -72,7 +72,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Sql/servers"
     },

--- a/schemas/2014-04-01/Microsoft.BizTalkServices.json
+++ b/schemas/2014-04-01/Microsoft.BizTalkServices.json
@@ -90,7 +90,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.BizTalkServices/BizTalk resource"
     },

--- a/schemas/2014-04-01/Microsoft.Insights.json
+++ b/schemas/2014-04-01/Microsoft.Insights.json
@@ -220,7 +220,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Insights/alertrules"
     },
@@ -251,7 +252,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Insights/components"
     },
@@ -355,7 +357,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Insights/webtests"
     },
@@ -717,7 +720,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Insights/autoscalesettings"
     }

--- a/schemas/2014-04-01/SuccessBricks.ClearDB.json
+++ b/schemas/2014-04-01/SuccessBricks.ClearDB.json
@@ -44,7 +44,8 @@
       "required": [
         "type",
         "apiVersion",
-        "plan"
+        "plan",
+        "location"
       ],
       "description": "SuccessBricks.ClearDB/databases"
     }

--- a/schemas/2014-06-01/Microsoft.Web.json
+++ b/schemas/2014-06-01/Microsoft.Web.json
@@ -80,7 +80,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Web/serverfarms"
     },
@@ -357,7 +358,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Web/sites"
     },
@@ -393,7 +395,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Web/certificates"
     }

--- a/schemas/2014-08-01/Microsoft.Scheduler.json
+++ b/schemas/2014-08-01/Microsoft.Scheduler.json
@@ -90,7 +90,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Scheduler/jobCollections resource"
     },

--- a/schemas/2015-01-01/deploymentTemplate.json
+++ b/schemas/2015-01-01/deploymentTemplate.json
@@ -207,12 +207,6 @@
         },
         {
           "properties": {
-            "kind": {
-              "type": "string",
-              "maxLength": 64,
-              "pattern": "(^[a-zA-Z0-9_.()-]+$)",
-              "description": "Kind of resource"
-            },
             "location": {
               "$ref": "#/definitions/resourceLocations",
               "description": "Location to deploy resource to"
@@ -221,22 +215,13 @@
               "type": "object",
               "description": "Name-value pairs to add to the resource"
             },
-            "sku": {
-              "$ref": "#/definitions/resourceSku"
-            },
-            "plan": {
-              "$ref": "#/definitions/resourcePlan"
-            },
             "copy": {
               "$ref": "#/definitions/resourceCopy"
             },
             "comments": {
               "type": "string"
             }
-          },
-          "required": [
-            "location"
-          ]
+          }
         }
       ]
     },
@@ -306,6 +291,12 @@
           "description": "Count of the copy"
         }
       }
+    },
+    "resourceKind": {
+      "type": "string",
+      "maxLength": 64,
+      "pattern": "(^[a-zA-Z0-9_.()-]+$)",
+      "description": "Kind of resource"
     },
     "resourcePlan": {
       "type": "object",

--- a/schemas/2015-03-01-preview/Microsoft.AppService.json
+++ b/schemas/2015-03-01-preview/Microsoft.AppService.json
@@ -98,7 +98,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ]
     },
     "gateways": {
@@ -143,7 +144,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ]
     },
     "registrationsChild": {

--- a/schemas/2015-04-08/Microsoft.DocumentDB.json
+++ b/schemas/2015-04-08/Microsoft.DocumentDB.json
@@ -85,7 +85,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ]
     }
   }

--- a/schemas/2015-05-21-preview/Microsoft.DevTestLab.json
+++ b/schemas/2015-05-21-preview/Microsoft.DevTestLab.json
@@ -19,7 +19,7 @@
           ]
         }
       },
-      "required": [ "type", "apiVersion" ]
+      "required": [ "type", "apiVersion", "location" ]
     },
     "environments": {
       "description": "Required properties to create environment in an existing DevTest Lab",
@@ -69,7 +69,7 @@
           "required": [ "labId", "vms" ]
         }
       },
-      "required": [ "type", "apiVersion", "properties" ]
+      "required": [ "type", "apiVersion", "properties", "location" ]
     }
   }
 }

--- a/schemas/2015-08-01-preview/Microsoft.DataConnect.json
+++ b/schemas/2015-08-01-preview/Microsoft.DataConnect.json
@@ -31,7 +31,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.DataConnect/connectionManagers resource"
     }

--- a/schemas/2015-08-01/Microsoft.Cache.json
+++ b/schemas/2015-08-01/Microsoft.Cache.json
@@ -164,7 +164,8 @@
         "name",
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Redis cache resource"
     }

--- a/schemas/2015-08-01/Microsoft.Compute.json
+++ b/schemas/2015-08-01/Microsoft.Compute.json
@@ -35,7 +35,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Compute/availabilitySets"
     },
@@ -129,7 +130,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Compute/virtualMachines"
     },
@@ -175,8 +177,12 @@
         }
       },
       "required": [
+        "name",
+        "apiVersion",
+        "type",
         "sku",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Compute/virtualMachineScaleSets"
     },

--- a/schemas/2015-08-01/Microsoft.Network.json
+++ b/schemas/2015-08-01/Microsoft.Network.json
@@ -59,7 +59,8 @@
         "type",
         "apiVersion",
         "name",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Network/publicIPAddresses"
     },
@@ -119,7 +120,8 @@
         "type",
         "apiVersion",
         "name",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Network/networkInterfaces"
     },
@@ -180,7 +182,8 @@
         "type",
         "apiVersion",
         "name",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Network/virtualNetworks"
     },
@@ -298,7 +301,8 @@
         "type",
         "apiVersion",
         "name",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Network/loadBalancers"
     },
@@ -344,7 +348,8 @@
         "type",
         "apiVersion",
         "name",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Network/networkSecurityGroups"
     },
@@ -390,7 +395,8 @@
         "type",
         "apiVersion",
         "name",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Network/routeTables"
     }

--- a/schemas/2015-08-01/Microsoft.Storage.json
+++ b/schemas/2015-08-01/Microsoft.Storage.json
@@ -35,7 +35,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Storage/storageAccounts"
     }

--- a/schemas/2015-08-01/Microsoft.Web.json
+++ b/schemas/2015-08-01/Microsoft.Web.json
@@ -86,7 +86,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Web/serverfarms"
     },
@@ -319,7 +320,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Web/sites"
     },

--- a/tests/2015-04-08/Microsoft.DocumentDB.tests.json
+++ b/tests/2015-04-08/Microsoft.DocumentDB.tests.json
@@ -6,6 +6,7 @@
       "json": {
         "type": "Microsoft.DocumentDB/databaseAccounts",
         "apiVersion": "2015-04-08",
+        "location": "West Us",
         "properties": {
           "name": "test",
           "databaseAccountOfferType": "Standard"
@@ -18,6 +19,7 @@
       "json": {
         "type": "Microsoft.DocumentDB/databaseAccounts",
         "apiVersion": "2015-04-08",
+        "location": "West Us",
         "properties": {
           "name": "test",
           "databaseAccountOfferType": "Standard",
@@ -39,7 +41,8 @@
       "definition": "http://schema.management.azure.com/schemas/2015-04-08/Microsoft.DocumentDB.json#/resourceDefinitions/databaseAccounts",
       "json": {
         "type": "Microsoft.DocumentDB/databaseAccounts",
-        "apiVersion": "2015-04-08"
+        "apiVersion": "2015-04-08",
+        "location": "West Us"
       }
     },
     {
@@ -60,6 +63,7 @@
       "json": {
         "type": "Microsoft.DocumentDB/databaseAccounts",
         "apiVersion": "2015-04-08",
+        "location": "West Us",
         "properties": {
         }
       }
@@ -77,6 +81,7 @@
       "json": {
         "type": "Microsoft.DocumentDB/databaseAccounts",
         "apiVersion": "2015-04-08",
+        "location": "West Us",
         "properties": {
           "name": "test",
           "databaseAccountOfferType": "Standard",
@@ -98,6 +103,7 @@
       "json": {
         "type": "Microsoft.DocumentDB/databaseAccounts",
         "apiVersion": "2015-04-08",
+        "location": "West Us",
         "properties": {
           "name": "11111",
           "databaseAccountOfferType": "Standard"
@@ -117,6 +123,7 @@
       "json": {
         "type": "Microsoft.DocumentDB/databaseAccounts",
         "apiVersion": "2015-04-08",
+        "location": "West Us",
         "properties": {
           "name": "test",
           "databaseAccountOfferType": "Invalid"

--- a/tests/2015-08-01-preview/Microsoft.DataConnect.tests.json
+++ b/tests/2015-08-01-preview/Microsoft.DataConnect.tests.json
@@ -16,7 +16,11 @@
         {
           "message": "Missing required property: properties",
           "dataPath": "/"
-        }
+        },
+        {
+          "message": "Missing required property: location",
+          "dataPath": "/"
+        }        
       ],
       "json": { }
     },
@@ -27,6 +31,7 @@
       "json": {
         "type": "Microsoft.DataConnect/connectionManagers",
         "apiVersion": "2015-08-01-preview",
+        "location": "West Us",
         "properties": { }
       }
     },
@@ -43,6 +48,7 @@
       "json": {
         "type": "Microsoft.DataConnect/connectionManagers",
         "apiVersion": "2015-08-01-preview",
+        "location": "West Us",
         "properties": {
           "description": ""
         }
@@ -55,6 +61,7 @@
       "json": {
         "type": "Microsoft.DataConnect/connectionManagers",
         "apiVersion": "2015-08-01-preview",
+        "location": "West Us",
         "properties": {
           "description": "Test description"
         }

--- a/tests/2015-08-01/Microsoft.Compute.tests.json
+++ b/tests/2015-08-01/Microsoft.Compute.tests.json
@@ -6,6 +6,7 @@
       "json": {
         "type": "Microsoft.Compute/availabilitySets",
         "apiVersion": "2015-05-01-preview",
+        "location": "West Us",
         "properties": {
         }
       }
@@ -25,6 +26,7 @@
       ],
       "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/availabilitySets",
       "json": {
+        "location": "West Us",
         "properties": {
         }
       }

--- a/tests/2015-08-01/Microsoft.Storage.tests.json
+++ b/tests/2015-08-01/Microsoft.Storage.tests.json
@@ -6,6 +6,7 @@
             "json": {
                 "type": "Microsoft.Storage/storageAccounts",
                 "apiVersion": "2015-05-01-preview",
+                "location": "West Us",
                 "properties": {
                     "accountType": "Test Account Type"
                 }
@@ -24,6 +25,7 @@
             "json": {
                 "type": "Microsoft.Storage/storageAccounts",
                 "apiVersion": "2015-05-01-preview",
+                "location": "West Us",
                 "properties": {
                 }
             }
@@ -40,7 +42,8 @@
             "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Storage.json#/resourceDefinitions/storageAccounts",
             "json": {
                 "type": "Microsoft.Storage/storageAccounts",
-                "apiVersion": "2015-05-01-preview"
+                "apiVersion": "2015-05-01-preview",
+                "location": "West Us"
             }
         }
     ]

--- a/tests/2015-08-01/Microsoft.Web.tests.json
+++ b/tests/2015-08-01/Microsoft.Web.tests.json
@@ -6,6 +6,7 @@
             "json": {
                 "name": "ServerFarmName",
                 "type": "Microsoft.Web/serverfarms",
+                "location": "West Us",
                 "apiVersion": "2015-08-01",
                 "properties": { }
             }
@@ -23,6 +24,7 @@
             "json": {
                 "name": "ServerFarmName",
                 "type": "Microsoft.Web/serverfarms",
+                "location": "West Us",
                 "properties": { }
             }
         },
@@ -43,6 +45,7 @@
             "json": {
                 "name": "WebAppName",
                 "type": "Microsoft.Web/sites",
+                "location": "West Us",
                 "apiVersion": "2015-08-01",
                 "properties": { }
             }


### PR DESCRIPTION
Remove "sku", "kind", "plan" from resourceBase to avoid conflict with RP schema.
Make "locaion" only "required" for first level resource type.