### PR TITLE
Updating "disablePasswordAuthentication" property type to boolean with Expression support

### DIFF
--- a/schemas/2015-08-01/Microsoft.Compute.json
+++ b/schemas/2015-08-01/Microsoft.Compute.json
@@ -594,7 +594,7 @@
     "linuxConfiguration": {
       "properties": {
         "disablePasswordAuthentication": {
-          "type": "string"
+          "type": "boolean"
         },
         "ssh": {
           "$ref": "#/definitions/ssh"

--- a/schemas/2015-08-01/Microsoft.Compute.json
+++ b/schemas/2015-08-01/Microsoft.Compute.json
@@ -594,7 +594,14 @@
     "linuxConfiguration": {
       "properties": {
         "disablePasswordAuthentication": {
-          "type": "boolean"
+          "oneOf": [
+            {
+              "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
         },
         "ssh": {
           "$ref": "#/definitions/ssh"

--- a/tests/2015-08-01/Microsoft.Compute.tests.json
+++ b/tests/2015-08-01/Microsoft.Compute.tests.json
@@ -119,6 +119,23 @@
           "settings": { }
         }
       }
+    },
+	{
+      "name": "linuxConfiguration/properties/disablePasswordAuthentication - Boolean value",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/definitions/linuxConfiguration/properties/disablePasswordAuthentication",
+      "json": true
+    },
+	{
+      "name": "linuxConfiguration/properties/disablePasswordAuthentication - Invalid value type",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/definitions/linuxConfiguration/properties/disablePasswordAuthentication",
+	  "expectedErrors": [
+        {
+          "message": "Invalid type: number (expected boolean)",
+          "dataPath": "/",
+          "schemaPath": "/type"
+        }
+      ],
+      "json": 12345
     }
   ]
 }

--- a/tests/2015-08-01/Microsoft.Compute.tests.json
+++ b/tests/2015-08-01/Microsoft.Compute.tests.json
@@ -120,15 +120,15 @@
         }
       }
     },
-	{
+    {
       "name": "linuxConfiguration/properties/disablePasswordAuthentication - Boolean value",
       "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/definitions/linuxConfiguration/properties/disablePasswordAuthentication",
       "json": true
     },
-	{
+    {
       "name": "linuxConfiguration/properties/disablePasswordAuthentication - Invalid value type",
       "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/definitions/linuxConfiguration/properties/disablePasswordAuthentication",
-	  "expectedErrors": [
+      "expectedErrors": [
         {
           "message": "Invalid type: number (expected boolean)",
           "dataPath": "/",

--- a/tests/2015-08-01/Microsoft.Compute.tests.json
+++ b/tests/2015-08-01/Microsoft.Compute.tests.json
@@ -130,7 +130,7 @@
       "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/definitions/linuxConfiguration/properties/disablePasswordAuthentication",
       "expectedErrors": [
         {
-          "message": "Invalid type: number (expected boolean)",
+          "message": "Data does not match any schemas from \"oneOf\"",
           "dataPath": "/",
           "schemaPath": "/type"
         }


### PR DESCRIPTION
Updated linuxConfiguration/properties/disablePasswordAuthentication to be a boolean type
Added unit tests for the type validation
Added Expression support on the property