### PR TITLE
Update Microsoft.Web.json

### DIFF
--- a/schemas/2015-08-01/Microsoft.Web.json
+++ b/schemas/2015-08-01/Microsoft.Web.json
@@ -158,8 +158,14 @@
               "description": "Microsoft.Web/sites/extensions: connection string"
             },
             "setParameters": {
-              "type": "string",
-              "minLength": 1,
+              "oneOf": [
+                {
+                  "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+                },
+                {
+                  "type": "object"
+                }
+              ],
               "description": "Microsoft.Web/sites/extensions: parameters"
             }
           }


### PR DESCRIPTION
Fix setParameters property to be an object and allow an expression.  This was already fixed in 2014-06-01 version of Microsoft.Web.json.