### PR TITLE
Update ResourceMetaSchema so that generated schemas now pass

### DIFF
--- a/tools/ResourceMetaSchema.json
+++ b/tools/ResourceMetaSchema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Azure Resource Meta-schema",
-      
   "allOf": [
     {
       "$ref": "http://json-schema.org/draft-04/schema#"
@@ -10,7 +9,6 @@
       "$ref": "#/definitions/resourceMetaSchema"
     }
   ],
-
   "definitions": {
     "resourceMetaSchema": {
       "type": "object",
@@ -28,37 +26,67 @@
           "type": "string",
           "minLength": 1
         },
-        "description": { "$ref": "#/definitions/description" },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
         "resourceDefinitions": {
           "type": "object",
           "minProperties": 1,
-          "additionalProperties": { "$ref": "#/definitions/resource" }
+          "additionalProperties": {
+            "$ref": "#/definitions/resource"
+          }
         },
-        "definitions": { "$ref": "#/definitions/definitions" }
+        "definitions": {
+          "$ref": "#/definitions/definitions"
+        }
       },
-      "required": [ "$schema", "title", "description", "resourceDefinitions" ],
+      "required": [
+        "$schema",
+        "title",
+        "description",
+        "resourceDefinitions"
+      ],
       "additionalProperties": false
     },
     "resource": {
       "type": "object",
       "properties": {
         "type": {
-          "enum": [ "object" ]
+          "enum": [
+            "object"
+          ]
         },
-        "description": { "$ref": "#/definitions/description" },
-        "required": { "$ref": "#/definitions/stringArrayEmptyOkay" },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "required": {
+          "$ref": "#/definitions/stringArrayEmptyOkay"
+        },
         "properties": {
           "type": "object",
           "properties": {
-            "type": { "$ref": "#/definitions/resourceTypesArray" },
-            "apiVersion": { "$ref": "#/definitions/resourceApiVersions" },
-            "resources": { "$ref": "#/definitions/childResources" },
-            "properties": { "$ref": "#/definitions/resourceSpecificProperties" }
+            "type": {
+              "$ref": "#/definitions/resourceTypesArray"
+            },
+            "apiVersion": {
+              "$ref": "#/definitions/resourceApiVersions"
+            },
+            "resources": {
+              "$ref": "#/definitions/childResources"
+            },
+            "properties": {
+              "$ref": "#/definitions/resourceSpecificProperties"
+            }
           },
-          "required": [ "apiVersion", "type" ]
+          "required": [
+            "apiVersion",
+            "type"
+          ]
         }
       },
-      "required": [ "description" ]
+      "required": [
+        "description"
+      ]
     },
     "description": {
       "type": "string",
@@ -66,15 +94,24 @@
     },
     "stringArrayEmptyOkay": {
       "oneOf": [
-        { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" },
         {
-          "enum": [ [ ] ]
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+        },
+        {
+          "enum": [
+            []
+          ]
         }
       ]
     },
     "resourceTypesArray": {
       "type": "object",
       "properties": {
+        "type": {
+          "enum": [
+            "string"
+          ]
+        },
         "enum": {
           "type": "array",
           "items": {
@@ -85,7 +122,9 @@
           "uniqueItems": true
         }
       },
-      "required": [ "enum" ],
+      "required": [
+        "enum"
+      ],
       "additionalProperties": false
     },
     "resourceApiVersions": {
@@ -99,12 +138,19 @@
               "minLength": 1
             }
           },
-          "required": [ "$ref" ],
+          "required": [
+            "$ref"
+          ],
           "additionalProperties": false
         },
         {
           "type": "object",
           "properties": {
+            "type": {
+              "enum": [
+                "string"
+              ]
+            },
             "enum": {
               "type": "array",
               "items": {
@@ -114,7 +160,9 @@
               "uniqueItems": true
             }
           },
-          "required": [ "enum" ],
+          "required": [
+            "enum"
+          ],
           "additionalProperties": false
         }
       ]
@@ -127,25 +175,67 @@
         {
           "type": "object",
           "properties": {
+            "oneOf": {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "$ref": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "description": {
+              "$ref": "#/definitions/description"
+            }
+          },
+          "required": [
+            "oneOf",
+            "description"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
             "$ref": {
               "type": "string",
               "format": "uri",
               "minLength": 1
             }
           },
-          "required": [ "$ref" ],
+          "required": [
+            "$ref"
+          ],
           "additionalProperties": false
         },
         {
           "type": "object",
           "properties": {
-            "type": { "enum": [ "object" ] },
+            "type": {
+              "enum": [
+                "object"
+              ]
+            },
             "properties": {
               "type": "object",
-              "additionalProperties": { "$ref": "#/definitions/resourceProperty" }
+              "additionalProperties": {
+                "$ref": "#/definitions/resourceProperty"
+              }
             },
-            "required": { "$ref": "#/definitions/stringArrayEmptyOkay" },
-            "additionalProperties": { "$ref": "http://json-schema.org/draft-04/schema#/properties/additionalProperties" }
+            "required": {
+              "$ref": "#/definitions/stringArrayEmptyOkay"
+            },
+            "additionalProperties": {
+              "$ref": "http://json-schema.org/draft-04/schema#/properties/additionalProperties"
+            },
+            "description": {
+              "$ref": "#/definitions/description"
+            }
           },
           "additionalProperties": false
         }
@@ -159,9 +249,17 @@
           "format": "uri",
           "minLength": 1
         },
-        "items": { "$ref": "http://json-schema.org/draft-04/schema#/properties/items" },
-        "oneOf": { "$ref": "#/definitions/resourcePropertyDefinitionOptions" },
-        "type": { "enum": [ "string" ] },
+        "items": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/items"
+        },
+        "oneOf": {
+          "$ref": "#/definitions/resourcePropertyDefinitionOptions"
+        },
+        "type": {
+          "enum": [
+            "string"
+          ]
+        },
         "minLength": {
           "type": "integer",
           "minimum": 1
@@ -170,9 +268,13 @@
           "type": "integer",
           "minimum": 1
         },
-        "description": { "$ref": "#/definitions/description" }
+        "description": {
+          "$ref": "#/definitions/description"
+        }
       },
-      "required": [ "description" ],
+      "required": [
+        "description"
+      ],
       "additionalProperties": false
     },
     "resourcePropertyDefinitionOptions": {
@@ -186,29 +288,55 @@
             "properties": {
               "type": {
                 "allOf": [
-                  { "$ref": "http://json-schema.org/draft-04/schema#/definitions/simpleTypes" },
-                  { "not": { "enum": [ "string", "number" ] } }
+                  {
+                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/simpleTypes"
+                  },
+                  {
+                    "not": {
+                      "enum": [
+                        "string",
+                        "number"
+                      ]
+                    }
+                  }
                 ]
               }
             },
-            "required": [ "type" ]
+            "required": [
+              "type"
+            ]
           },
           {
             "type": "object",
             "properties": {
-              "type": { "enum": [ "string" ] },
-              "pattern": { "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern" }
+              "type": {
+                "enum": [
+                  "string"
+                ]
+              },
+              "pattern": {
+                "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+              }
             },
-            "required": [ "type", "pattern" ],
+            "required": [
+              "type",
+              "pattern"
+            ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "enum": { "$ref": "http://json-schema.org/draft-04/schema#/properties/enum" },
-              "default": { "$ref": "http://json-schema.org/draft-04/schema#/properties/default" }
+              "enum": {
+                "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+              },
+              "default": {
+                "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+              }
             },
-            "required": [ "enum" ],
+            "required": [
+              "enum"
+            ],
             "additionalProperties": false
           },
           {
@@ -220,7 +348,9 @@
                 "minLength": 1
               }
             },
-            "required": [ "$ref" ],
+            "required": [
+              "$ref"
+            ],
             "additionalProperties": false
           },
           {
@@ -230,7 +360,9 @@
                 "$ref": "#/definitions/resourcePropertyDefinitionOptions"
               }
             },
-            "required": [ "oneOf" ],
+            "required": [
+              "oneOf"
+            ],
             "additionalProperties": false
           }
         ]
@@ -240,7 +372,9 @@
     "definitions": {
       "type": "object",
       "minProperties": 1,
-      "additionalProperties": { "$ref": "#/definitions/definition" }
+      "additionalProperties": {
+        "$ref": "#/definitions/definition"
+      }
     },
     "definition": {
       "$ref": "http://json-schema.org/draft-04/schema#"


### PR DESCRIPTION
Most of the changes are formatting changes. The real changes that are necessary are allowing "type": "string" in resource's type property, allowing "type": "string" in resource's apiVersion property, and allowing "oneOf" in resource's properties property.