### PR TITLE
Remove minItems requirement from "resources"

### DIFF
--- a/schemas/2014-04-01-preview/deploymentTemplate.json
+++ b/schemas/2014-04-01-preview/deploymentTemplate.json
@@ -137,8 +137,7 @@
             ]
           }
         ]
-      },
-      "minItems": 1
+      }
     },
     "outputs": {
       "type": "object",

--- a/schemas/2015-01-01/deploymentTemplate.json
+++ b/schemas/2015-01-01/deploymentTemplate.json
@@ -162,8 +162,7 @@
             ]
           }
         ]
-      },
-      "minItems": 1
+      }
     },
     "outputs": {
       "type": "object",


### PR DESCRIPTION
I've found several nested templates that don't have any resources, and they're valid situations. I think we should remove this requirement so that users don't get warnings in a valid scenario.