### PR TITLE
add an empty properties node to get rid of unwanted properties.

### DIFF
--- a/schemas/2016-02-01-preview/Microsoft.CognitiveServices.json
+++ b/schemas/2016-02-01-preview/Microsoft.CognitiveServices.json
@@ -71,7 +71,8 @@
         "properties": {
           "oneOf": [
             {
-              "type": "object"
+              "type": "object",
+              "properties": {}
             },
             {
               "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"


### PR DESCRIPTION
Add an empty "properties" node to get rid of unwanted properties: endpoint and provisioningState, the latter one causes deployment failures.