### PR TITLE
Add schemas for Microsoft.DataFactory resources

### DIFF
--- a/schemas/2015-01-01/deploymentTemplate.json
+++ b/schemas/2015-01-01/deploymentTemplate.json
@@ -148,6 +148,10 @@
                   { "$ref": "http://schema.management.azure.com/schemas/2015-10-31/Microsoft.Automation.json#/resourceDefinitions/jobs" },
                   { "$ref": "http://schema.management.azure.com/schemas/2015-10-31/Microsoft.Automation.json#/resourceDefinitions/jobSchedules" },
                   { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.Media.json#/resourceDefinitions/mediaServices" },
+                  { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/dataFactories" },
+                  { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/linkedServices" },
+                  { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/datasets" },
+                  { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/pipelines" },
                   { "$ref": "http://schema.management.azure.com/schemas/2016-02-03/Microsoft.Devices.json#/resourceDefinitions/IotHubs" }
                 ]
               }

--- a/schemas/2015-10-01/Microsoft.DataFactory.json
+++ b/schemas/2015-10-01/Microsoft.DataFactory.json
@@ -1,0 +1,206 @@
+{
+  "id": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.DataFactory",
+  "description": "Microsoft Azure Data Factory Resource Types",
+  "resourceDefinitions": {
+    "dataFactories": {
+      "description": "The top level DataPipeline resource container.",
+      "allOf": [
+        {
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "enum": [ "Microsoft.DataFactory/datafactories" ]
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/dataFactoryCommon"
+        }
+      ]
+    },
+    "linkedServices": {
+      "description": "Defines the information needed for Data Factory to connect to external resources.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/linkedServiceCommon"
+        },
+        {
+          "required": [ "type" ],
+          "properties": {
+            "type": {
+              "enum": [ "Microsoft.Datafactory/datafactories/linkedservices" ]
+            }
+          }
+        }
+      ]
+    },
+    "datasets": {
+      "description": "A named reference/pointer to the data to be used as an input or an output of an Activity. Datasets identify data structures within different data stores including tables, files, folders and documents.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/datasetCommon"
+        },
+        {
+          "required": [ "type" ],
+          "properties": {
+            "type": {
+              "enum": [ "Microsoft.Datafactory/datafactories/datasets" ]
+            }
+          }
+        }
+      ]
+    },
+    "pipelines": {
+      "description": "A logical grouping of Activities. that operate as a unit that together perform a task.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/pipelineCommon"
+        },
+        {
+          "required": [ "type" ],
+          "properties": {
+            "type": {
+              "enum": [ "Microsoft.DataFactory/datafactories/pipelines" ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "dataFactoryCommon": {
+      "allOf": [
+        {
+          "$ref": "http://datafactories.schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.DataFactory.json"
+        },
+        {
+          "type": "object",
+          "required": [ "apiVersion" ],
+          "properties": {
+            "apiVersion": {
+              "enum": [
+                "2015-10-01"
+              ]
+            },
+            "resources": {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/linkedServiceChild"
+                  },
+                  {
+                    "$ref": "#/definitions/datasetChild"
+                  },
+                  {
+                    "$ref": "#/definitions/pipelineChild"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "linkedServiceCommon": {
+      "allOf": [
+        {
+          "required": [ "apiVersion" ],
+          "properties": {
+            "apiVersion": {
+              "enum": [
+                "2015-10-01"
+              ]
+            }
+          }
+        },
+        {
+          "$ref": "http://datafactories.schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.LinkedService.json"
+        }
+      ]
+    },
+    "linkedServiceChild": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/linkedServiceCommon"
+        },
+        {
+          "required": [ "type" ],
+          "properties": {
+            "type": {
+              "enum": [ "linkedservices" ]
+            }
+          }
+        }
+      ]
+    },
+    "datasetCommon": {
+      "allOf": [
+        {
+          "required": [ "apiVersion" ],
+          "properties": {
+            "apiVersion": {
+              "enum": [
+                "2015-10-01"
+              ]
+            }
+          }
+        },
+        {
+          "$ref": "http://datafactories.schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.Dataset.json"
+        }
+      ]
+    },
+    "datasetChild": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/datasetCommon"
+        },
+        {
+          "required": [ "type" ],
+          "properties": {
+            "type": {
+              "enum": [ "datasets" ]
+            }
+          }
+        }
+      ]
+    },
+    "pipelineCommon": {
+      "allOf": [
+        {
+          "required": [ "apiVersion" ],
+          "properties": {
+            "apiVersion": {
+              "enum": [
+                "2015-10-01"
+              ]
+            }
+          }
+        },
+        {
+          "$ref": "http://datafactories.schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.Pipeline.json"
+        }
+      ]
+    },
+    "pipelineChild": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/pipelineCommon"
+        },
+        {
+          "required": [ "type" ],
+          "properties": {
+            "type": {
+              "enum": [ "pipelines" ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/2015-10-01/Microsoft.DataFactory.tests.json
+++ b/tests/2015-10-01/Microsoft.DataFactory.tests.json
@@ -1,0 +1,134 @@
+{
+  "tests": [
+    {
+      "name": "Data Factory: top-level resource only",
+      "definition": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/dataFactories",
+      "json": {
+        "type": "Microsoft.DataFactory/datafactories",
+        "apiVersion": "2015-10-01",
+        "name": "dataFactoryName",
+        "location": "WestUS"
+      }
+    },
+    {
+      "name": "Data Factory: top-level and child resources",
+      "definition": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/dataFactories",
+      "json": {
+        "name": "connectedCarDataFactory",
+        "apiVersion": "2015-10-01",
+        "type": "Microsoft.DataFactory/datafactories",
+        "location": "NorthEurope",
+        "resources": [
+          {
+            "type": "linkedservices",
+            "name": "azureSqlLinkedServiceName",
+            "apiVersion": "2015-10-01",
+            "properties": {
+              "type": "AzureSqlDatabase",
+              "typeProperties": {
+                "connectionString": "[concat('Server=tcp:',parameters('sqlServerName'),'.database.windows.net,1433;Database=connectedcar;User ID=',parameters('sqlServerUserName'),';Password=',parameters('sqlServerPassword'),';Trusted_Connection=False;Encrypt=True;Connection Timeout=30')]"
+              }
+            }
+          },
+          {
+            "type": "datasets",
+            "name": "AggresiveDrivingModelReportName",
+            "apiVersion": "2015-10-01",
+            "properties": {
+              "structure": [
+                {
+                  "name": "vin",
+                  "type": "String"
+                },
+                {
+                  "name": "model",
+                  "type": "String"
+                },
+                {
+                  "name": "timestamp",
+                  "type": "String"
+                },
+                {
+                  "name": "city",
+                  "type": "String"
+                },
+                {
+                  "name": "speed",
+                  "type": "String"
+                },
+                {
+                  "name": "transmission_gear_position",
+                  "type": "String"
+                },
+                {
+                  "name": "brake_pedal_status",
+                  "type": "String"
+                },
+                {
+                  "name": "Year",
+                  "type": "String"
+                },
+                {
+                  "name": "Month",
+                  "type": "String"
+                }
+              ],
+              "type": "AzureSqlTable",
+              "linkedServiceName": "AzureSqlLinkedService",
+              "typeProperties": {
+                "tableName": "AggresiveDrivingModelReport"
+              },
+              "availability": {
+                "frequency": "Month",
+                "interval": 1,
+                "style": "StartOfInterval"
+              }
+            }
+          },
+          {
+            "type":  "pipelines",
+            "name": "PartitionCarEventsPipelineName",
+            "apiVersion": "2015-10-01",
+            "properties": {
+              "description": "This is a sample pipeline to prepare the car events data for further processing",
+              "activities": [
+                {
+                  "name": "BlobPartitionHiveActivity",
+                  "inputs": [
+                    {
+                      "name": "RawCarEventsTable"
+                    }
+                  ],
+                  "outputs": [
+                    {
+                      "name": "PartitionedCarEventsTable"
+                    }
+                  ],
+                  "linkedServiceName": "hdInsightLinkedServiceName",
+                  "type": "HDInsightHive",
+                  "typeProperties": {
+                    "scriptPath": "connectedcar\\scripts\\partitioncarevents.hql",
+                    "scriptLinkedService": "StorageLinkedService",
+                    "defines": {
+                      "RAWINPUT": "[concat('wasb://connectedcar@',parameters('storageAccountName'),'.blob.core.windows.net/rawcarevents/')]",
+                      "PARTITIONEDOUTPUT": "[concat('wasb://connectedcar@',parameters('storageAccountName'),'.blob.core.windows.net/partitionedcarevents/')]",
+                      "Year": "$$Text.Format('{0:yyyy}',SliceStart)",
+                      "Month": "$$Text.Format('{0:%M}',SliceStart)",
+                      "Day": "$$Text.Format('{0:%d}',SliceStart)"
+                    }
+                  },
+                  "policy": {
+                    "concurrency": 1,
+                    "executionPriorityOrder": "NewestFirst",
+                    "retry": 2,
+                    "timeout": "01:00:00"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
  * Adds schemas for data factories (the top-level resource in the
    Microsoft.DataFactory namespace) and its child resources (linked
    services, datasets and pipelines).
  * Deployment template schemas reference existing schemas in storage
    owned by the Azure Data Factory team, as those schemas contain the
    full definitions of resources in the service.
  * Since the external schemas referenced in the deployment template
    schemas are being used for other JSON authoring experiences (i.e.
    in Visual Studio and the Azure portal), we are not supporting
    template expressions at this time. This commit is aimed at
    supporting the "export resource" feature.