### PR TITLE
Add schemas for Microsoft.DataFactory resources

### DIFF
--- a/schemas/2014-04-01-preview/deploymentTemplate.json
+++ b/schemas/2014-04-01-preview/deploymentTemplate.json
@@ -150,6 +150,10 @@
                   { "$ref": "http://schema.management.azure.com/schemas/2015-10-31/Microsoft.Automation.json#/resourceDefinitions/jobSchedules" },
                   { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.Media.json#/resourceDefinitions/mediaServices" },
                   { "$ref": "http://schema.management.azure.com/schemas/2016-02-03/Microsoft.Devices.json#/resourceDefinitions/IotHubs" },
+                  { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/dataFactories" },
+                  { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/linkedServices" },
+                  { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/datasets" },
+                  { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/pipelines" },
                   { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/Sendgrid.Email.json#/resourceDefinitions/accounts" },
                   { "$ref": "#/definitions/resourceGeneric" }
                 ]

--- a/schemas/2015-01-01/deploymentTemplate.json
+++ b/schemas/2015-01-01/deploymentTemplate.json
@@ -148,6 +148,10 @@
                   { "$ref": "http://schema.management.azure.com/schemas/2015-10-31/Microsoft.Automation.json#/resourceDefinitions/jobs" },
                   { "$ref": "http://schema.management.azure.com/schemas/2015-10-31/Microsoft.Automation.json#/resourceDefinitions/jobSchedules" },
                   { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.Media.json#/resourceDefinitions/mediaServices" },
+                  { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/dataFactories" },
+                  { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/linkedServices" },
+                  { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/datasets" },
+                  { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/pipelines" },
                   { "$ref": "http://schema.management.azure.com/schemas/2016-02-03/Microsoft.Devices.json#/resourceDefinitions/IotHubs" }
                 ]
               }

--- a/schemas/2015-10-01/Microsoft.DataFactory.json
+++ b/schemas/2015-10-01/Microsoft.DataFactory.json
@@ -1,0 +1,4147 @@
+{
+  "id": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.DataFactory",
+  "description": "Microsoft Azure Data Factory Resource Types",
+  "resourceDefinitions": {
+    "dataFactories": {
+      "description": "The top level DataPipeline resource container.",
+      "type": "object",
+      "required": [
+        "name",
+        "location",
+        "type",
+        "apiVersion"
+      ],
+      "properties": {
+        "type": {
+          "enum": [ "Microsoft.DataFactory/datafactories" ]
+        },
+        "apiVersion": {
+          "enum": [
+            "2015-10-01"
+          ]
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/linkedServiceChild"
+              },
+              {
+                "$ref": "#/definitions/datasetChild"
+              },
+              {
+                "$ref": "#/definitions/pipelineChild"
+              }
+            ]
+          }
+        },
+        "id": {
+          "description": "Resource id of the data factory.  The Id property is set by the server and readonly on the client side.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the data factory.",
+          "type": "string",
+          "maxLength": 63,
+          "pattern": "^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$"
+        },
+        "location": {
+          "description": "Data center location of the data factory.",
+          "type": "string"
+        },
+        "tags": {
+          "description": "Tags of the data factory.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "properties": {
+          "description": "Properties of the data factory.",
+          "type": "object",
+          "properties": { },
+          "additionalProperties": false
+        }
+      }
+    },
+    "linkedServices": {
+      "description": "Defines the information needed for Data Factory to connect to external resources.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/linkedServiceCommon"
+        },
+        {
+          "required": [ "type" ],
+          "properties": {
+            "type": {
+              "enum": [ "Microsoft.Datafactory/datafactories/linkedservices" ]
+            }
+          }
+        }
+      ]
+    },
+    "datasets": {
+      "description": "A named reference/pointer to the data to be used as an input or an output of an Activity. Datasets identify data structures within different data stores including tables, files, folders and documents.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/datasetCommon"
+        },
+        {
+          "required": [ "type" ],
+          "properties": {
+            "type": {
+              "enum": [ "Microsoft.Datafactory/datafactories/datasets" ]
+            }
+          }
+        }
+      ]
+    },
+    "pipelines": {
+      "description": "A logical grouping of Activities. that operate as a unit that together perform a task.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/pipelineCommon"
+        },
+        {
+          "required": [ "type" ],
+          "properties": {
+            "type": {
+              "enum": [ "Microsoft.DataFactory/datafactories/pipelines" ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "linkedServiceCommon": {
+      "type": "object",
+      "required": [
+        "apiVersion",
+        "name",
+        "properties"
+      ],
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2015-10-01"
+          ]
+        },
+        "name": {
+          "description": "Data factory linkedService name.",
+          "type": "string",
+          "maxLength": 260,
+          "pattern": "^[A-Za-z0-9_][^<>*#.%&:\\\\+?/]*$"
+        },
+        "properties": {
+          "description": "Data factory linked service properties.",
+          "$ref": "#/definitions/linkedServicePropertiesTypes"
+        }
+      }
+    },
+    "linkedServiceChild": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/linkedServiceCommon"
+        },
+        {
+          "required": [ "type" ],
+          "properties": {
+            "type": {
+              "enum": [ "linkedservices" ]
+            }
+          }
+        }
+      ]
+    },
+    "datasetCommon": {
+      "type": "object",
+      "required": [
+        "apiVersion",
+        "name",
+        "properties"
+      ],
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2015-10-01"
+          ]
+        },
+        "name": {
+          "description": "Name of the dataset.",
+          "type": "string",
+          "maxLength": 260,
+          "pattern": "^[A-Za-z0-9_][^<>*#.%&:\\\\+?/]*$"
+        },
+        "properties": {
+          "description": "Dataset properties.",
+          "$ref": "#/definitions/datasetPropertiesTypes"
+        }
+      }
+    },
+    "datasetChild": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/datasetCommon"
+        },
+        {
+          "required": [ "type" ],
+          "properties": {
+            "type": {
+              "enum": [ "datasets" ]
+            }
+          }
+        }
+      ]
+    },
+    "pipelineCommon": {
+      "type": "object",
+      "required": [
+        "apiVersion",
+        "name",
+        "properties"
+      ],
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2015-10-01"
+          ]
+        },
+        "name": {
+          "description": "Name of the pipeline.",
+          "type": "string",
+          "maxLength": 260,
+          "pattern": "^[A-Za-z0-9_][^<>*#.%&:\\\\+?/]*$"
+        },
+        "properties": {
+          "description": "Pipeline properties.",
+          "$ref": "#/definitions/pipelineProperties"
+        }
+      }
+    },
+    "pipelineChild": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/pipelineCommon"
+        },
+        {
+          "required": [ "type" ],
+          "properties": {
+            "type": {
+              "enum": [ "pipelines" ]
+            }
+          }
+        }
+      ]
+    },
+    "linkedServiceProperties": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.LinkedServiceProperties",
+      "description": "Data factory linkedService properties.",
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "Data factory linked service description.",
+          "type": "string"
+        },
+        "hubName": {
+          "description": "The name of the Hub that this linked service belongs to.",
+          "type": "string"
+        }
+      }
+    },
+    "azureSqlDatabaseLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureSqlDatabaseLinkedService",
+      "description": "Windows Azure SQL database.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureSqlDatabase"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "connectionString"
+          ],
+          "properties": {
+            "connectionString": {
+              "description": "The connection string.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "azureSqlDataWarehouseLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureSqlDataWarehouseLinkedService",
+      "description": "Azure SQL data warehouse linked service.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureSqlDW"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "connectionString"
+          ],
+          "properties": {
+            "connectionString": {
+              "description": "The connection string.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "linkedServicePropertiesTypes": {
+      "type": "object",
+      "required": [
+        "type",
+        "typeProperties"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/linkedServiceProperties"
+        },
+        {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/azureSqlDatabaseLinkedService"
+            },
+            {
+              "$ref": "#/definitions/azureSqlDataWarehouseLinkedService"
+            },
+            {
+              "$ref": "#/definitions/azureStorageLinkedService"
+            },
+            {
+              "$ref": "#/definitions/azureStorageSasLinkedService"
+            },
+            {
+              "$ref": "#/definitions/azureBatchLinkedService"
+            },
+            {
+              "$ref": "#/definitions/documentDbLinkedService"
+            },
+            {
+              "$ref": "#/definitions/hdInsightLinkedService"
+            },
+            {
+              "$ref": "#/definitions/onPremisesFileServerLinkedService"
+            },
+            {
+              "$ref": "#/definitions/onPremisesSqlServerLinkedService"
+            },
+            {
+              "$ref": "#/definitions/onPremisesOracleLinkedService"
+            },
+            {
+              "$ref": "#/definitions/onPremisesMySqlLinkedService"
+            },
+            {
+              "$ref": "#/definitions/onPremisesPostgreSqlLinkedService"
+            },
+            {
+              "$ref": "#/definitions/onPremisesSybaseLinkedService"
+            },
+            {
+              "$ref": "#/definitions/onPremisesTeradataLinkedService"
+            },
+            {
+              "$ref": "#/definitions/onPremisesDb2LinkedService"
+            },
+            {
+              "$ref": "#/definitions/azureMLLinkedService"
+            },
+            {
+              "$ref": "#/definitions/hdInsightOnDemandLinkedService"
+            },
+            {
+              "$ref": "#/definitions/azureDataLakeStoreLinkedService"
+            },
+            {
+              "$ref": "#/definitions/azureDataLakeAnalyticsLinkedService"
+            },
+            {
+              "$ref": "#/definitions/onPremisesOdbcLinkedService"
+            },
+            {
+              "$ref": "#/definitions/hdfsLinkedService"
+            },
+            {
+              "$ref": "#/definitions/oDataLinkedService"
+            },
+            {
+              "$ref": "#/definitions/webLinkedService"
+            },
+            {
+              "$ref": "#/definitions/onPremisesCassandraLinkedService"
+            },
+            {
+              "$ref": "#/definitions/customDataSourceLinkedService"
+            },
+            {
+              "$ref": "#/definitions/salesforceLinkedService"
+            }
+          ]
+        }
+      ]
+    },
+    "azureStorageLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureStorageLinkedService",
+      "description": "The storage account linked service.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureStorage"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "connectionString"
+          ],
+          "properties": {
+            "connectionString": {
+              "description": "The connection string.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "azureStorageSasLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureStorageSasLinkedService",
+      "description": "Azure Storage SAS URI linked service. This linked service type can be used to provide restricted access to an Azure Storage resource using SAS URI.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureStorageSas"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "sasUri"
+          ],
+          "properties": {
+            "sasUri": {
+              "description": "SAS URI of the Azure Storage resource.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "azureBatchLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureBatchLinkedService",
+      "description": "Azure Batch linked service.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureBatch"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "accountName",
+            "accessKey",
+            "batchUri",
+            "poolName",
+            "linkedServiceName"
+          ],
+          "properties": {
+            "accountName": {
+              "description": "The Azure Batch account name.",
+              "type": "string"
+            },
+            "accessKey": {
+              "description": "The Azure Batch account access key.",
+              "type": "string"
+            },
+            "batchUri": {
+              "description": "The Azure Batch Uri.",
+              "type": "string"
+            },
+            "poolName": {
+              "description": "The Azure Batch pool name.",
+              "type": "string"
+            },
+            "linkedServiceName": {
+              "description": "The azure storage linked service name.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "documentDbLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.DocumentDbLinkedService",
+      "description": "Windows Azure Document Database.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "DocumentDb"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "connectionString"
+          ],
+          "properties": {
+            "connectionString": {
+              "description": "The connection string.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "hDInsightSchemaGenerationProperties": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.HDInsightSchemaGenerationProperties",
+      "description": "Schema generation options for activities that execute against HDInsight clusters.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of schema",
+          "type": "string"
+        },
+        "inputPartition": {
+          "description": "Input partition option.",
+          "type": "string"
+        },
+        "alterSchema": {
+          "description": "Flag to indicate if alter schema should be performed.",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "hdInsightLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.HDInsightLinkedService",
+      "description": "The properties for the HDInsight linked service.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "HDInsight"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "clusterUri",
+            "userName",
+            "password"
+          ],
+          "properties": {
+            "clusterUri": {
+              "description": "HDInsight cluster URI.",
+              "type": "string"
+            },
+            "userName": {
+              "description": "HDInsight cluster user name.",
+              "type": "string"
+            },
+            "password": {
+              "description": "HDInsight cluster password.",
+              "type": "string"
+            },
+            "linkedServiceName": {
+              "description": "Storage service name.",
+              "type": "string"
+            },
+            "hcatalogLinkedServiceName": {
+              "description": "The name of Azure SQL linked service that point to the HCatalog database.",
+              "type": "string"
+            },
+            "schemaGeneration": {
+              "description": "Define what options to use for generating/altering table for an input and output tables for an HDInsight activity.",
+              "$ref": "#/definitions/hDInsightSchemaGenerationProperties"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "onPremisesFileServerLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.OnPremisesFileServerLinkedService",
+      "description": "An on-premises file system linked service.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "OnPremisesFileServer"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "host",
+            "gatewayName"
+          ],
+          "properties": {
+            "host": {
+              "description": "Host name of the server.",
+              "type": "string"
+            },
+            "gatewayName": {
+              "description": "The on-premises gateway name.",
+              "type": "string"
+            },
+            "userId": {
+              "description": "UserID to logon the server.",
+              "type": "string"
+            },
+            "password": {
+              "description": "Password to logon the server.",
+              "type": "string"
+            },
+            "encryptedCredential": {
+              "description": "Encrypted credential which contains host, userId and password.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "onPremisesSqlServerLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.OnPremisesSqlServerLinkedService",
+      "description": "An on-premises SQL server database.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "OnPremisesSqlServer"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "connectionString",
+            "gatewayName"
+          ],
+          "properties": {
+            "connectionString": {
+              "description": "The connection string.",
+              "type": "string"
+            },
+            "gatewayName": {
+              "description": "The on-premises gateway name.",
+              "type": "string"
+            },
+            "userName": {
+              "description": "The on-premises Windows authentication user name.",
+              "type": "string"
+            },
+            "password": {
+              "description": "The on-premises Windows authentication password.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "onPremisesOracleLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.OnPremisesOracleLinkedService",
+      "description": "An on-premises Oracle database.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "OnPremisesOracle"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "connectionString",
+            "gatewayName"
+          ],
+          "properties": {
+            "connectionString": {
+              "description": "The connection string.",
+              "type": "string"
+            },
+            "gatewayName": {
+              "description": "The on-premises HDIS gateway name.",
+              "type": "string"
+            },
+            "userName": {
+              "description": "The on-premises Windows authentication user name.",
+              "type": "string"
+            },
+            "password": {
+              "description": "The on-premises Windows authentication password.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "customDataSourceLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.CustomDataSourceLinkedService",
+      "description": "Custom linked service.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "CustomDataSource"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object"
+        }
+      }
+    },
+    "azureMLLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureMLLinkedService",
+      "description": "Azure ML Web Service linked service.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureML"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "mlEndpoint",
+            "apiKey"
+          ],
+          "properties": {
+            "mlEndpoint": {
+              "description": "The Batch Execution REST URL for an Azure ML Web Service endpoint.",
+              "type": "string"
+            },
+            "apiKey": {
+              "description": "The API key for accessing the Azure ML model endpoint.",
+              "type": "string"
+            },
+            "updateResourceEndpoint": {
+              "description": "The Update Resource REST URL for an Azure ML Web Service endpoint.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "onPremisesPostgreSqlLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.OnPremisesPostgreSqlLinkedService",
+      "description": "Linked service for PostgreSql data source.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "OnPremisesPostgreSql"
+          ]
+        },
+        "typeProperties": {
+          "required": [
+            "server",
+            "database",
+            "authenticationType",
+            "gatewayName"
+          ],
+          "properties": {
+            "server": {
+              "description": "Server name for connection.",
+              "type": "string"
+            },
+            "database": {
+              "description": "Database name for connection.",
+              "type": "string"
+            },
+            "schema": {
+              "description": "Schema name for connection.",
+              "type": "string"
+            },
+            "authenticationType": {
+              "description": "AuthenticationType to be used for connection.",
+              "type": "string"
+            },
+            "username": {
+              "description": "Username for authentication.",
+              "type": "string"
+            },
+            "password": {
+              "description": "Password for authentication.",
+              "type": "string"
+            },
+            "gatewayName": {
+              "description": "The on-premises gateway name.",
+              "type": "string"
+            },
+            "encryptedCredential": {
+              "description": "The encryptedCredential for authentication.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "onPremisesMySqlLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.OnPremisesMySqlLinkedService",
+      "description": "Linked service for MySQL data source.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "OnPremisesMySql"
+          ]
+        },
+        "typeProperties": {
+          "required": [
+            "server",
+            "database",
+            "authenticationType",
+            "gatewayName"
+          ],
+          "properties": {
+            "server": {
+              "description": "Server name for connection.",
+              "type": "string"
+            },
+            "database": {
+              "description": "Database name for connection.",
+              "type": "string"
+            },
+            "schema": {
+              "description": "Schema name for connection.",
+              "type": "string"
+            },
+            "authenticationType": {
+              "description": "AuthenticationType to be used for connection.",
+              "type": "string"
+            },
+            "username": {
+              "description": "Username for authentication.",
+              "type": "string"
+            },
+            "password": {
+              "description": "Password for authentication.",
+              "type": "string"
+            },
+            "gatewayName": {
+              "description": "The on-premises gateway name.",
+              "type": "string"
+            },
+            "encryptedCredential": {
+              "description": "The encryptedCredential for authentication.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "onPremisesTeradataLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.OnPremisesTeradataLinkedService",
+      "description": "Linked service for Teradata data source.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "OnPremisesTeradata"
+          ]
+        },
+        "typeProperties": {
+          "required": [
+            "server",
+            "authenticationType",
+            "gatewayName"
+          ],
+          "properties": {
+            "server": {
+              "description": "Server name for connection.",
+              "type": "string"
+            },
+            "authenticationType": {
+              "description": "AuthenticationType to be used for connection.",
+              "type": "string"
+            },
+            "username": {
+              "description": "Username for authentication.",
+              "type": "string"
+            },
+            "password": {
+              "description": "Password for authentication.",
+              "type": "string"
+            },
+            "gatewayName": {
+              "description": "The on-premises gateway name.",
+              "type": "string"
+            },
+            "encryptedCredential": {
+              "description": "The encryptedCredential for authentication.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "onPremisesDb2LinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.OnPremisesDb2LinkedService",
+      "description": "Linked service for DB2 data source.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "OnPremisesDb2"
+          ]
+        },
+        "typeProperties": {
+          "required": [
+            "server",
+            "database",
+            "authenticationType",
+            "gatewayName"
+          ],
+          "properties": {
+            "server": {
+              "description": "Server name for connection.",
+              "type": "string"
+            },
+            "database": {
+              "description": "Database name for connection.",
+              "type": "string"
+            },
+            "schema": {
+              "description": "Schema name for connection.",
+              "type": "string"
+            },
+            "authenticationType": {
+              "description": "AuthenticationType to be used for connection.",
+              "type": "string"
+            },
+            "username": {
+              "description": "Username for authentication.",
+              "type": "string"
+            },
+            "password": {
+              "description": "Password for authentication.",
+              "type": "string"
+            },
+            "gatewayName": {
+              "description": "The on-premises gateway name.",
+              "type": "string"
+            },
+            "encryptedCredential": {
+              "description": "The encryptedCredential for authentication.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "onPremisesSybaseLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.OnPremisesSybaseLinkedService",
+      "description": "Linked service for Sybase data source.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "OnPremisesSybase"
+          ]
+        },
+        "typeProperties": {
+          "required": [
+            "server",
+            "database",
+            "authenticationType",
+            "gatewayName"
+          ],
+          "properties": {
+            "server": {
+              "description": "Server name for connection.",
+              "type": "string"
+            },
+            "database": {
+              "description": "Database name for connection.",
+              "type": "string"
+            },
+            "schema": {
+              "description": "Schema name for connection.",
+              "type": "string"
+            },
+            "authenticationType": {
+              "description": "AuthenticationType to be used for connection.",
+              "type": "string"
+            },
+            "username": {
+              "description": "Username for authentication.",
+              "type": "string"
+            },
+            "password": {
+              "description": "Password for authentication.",
+              "type": "string"
+            },
+            "gatewayName": {
+              "description": "The on-premises gateway name.",
+              "type": "string"
+            },
+            "encryptedCredential": {
+              "description": "The encryptedCredential for authentication.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "hdInsightOnDemandLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.HDInsightOnDemandLinkedService",
+      "description": "The properties for the HDInsight linked service.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "HDInsightOnDemand"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "clusterSize",
+            "timeToLive",
+            "linkedServiceName"
+          ],
+          "properties": {
+            "version": {
+              "description": "HDInsight version.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "clusterType": {
+              "description": "Gets or sets the flavor for the HDInsight cluster.",
+              "type": "string"
+            },
+            "clusterSize": {
+              "description": "HDInsight cluster size.",
+              "type": "integer"
+            },
+            "timeToLive": {
+              "description": "Time to live.",
+              "type": "string",
+              "pattern": "((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))"
+            },
+            "linkedServiceName": {
+              "description": "Storage service name.",
+              "type": "string"
+            },
+            "hiveCustomLibrariesContainer": {
+              "description": "The name of the blob container that contains custom jar files for HIVE consumption.",
+              "type": "string"
+            },
+            "coreConfiguration": {
+              "description": "Allows user to override default values for core configuration.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "hBaseConfiguration": {
+              "description": "Allows user to override default values for HBase configuration.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "hdfsConfiguration": {
+              "description": "Allows user to override default values for Hdfs configuration.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "hiveConfiguration": {
+              "description": "Allows user to override default values for HIVE configuration.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "mapReduceConfiguration": {
+              "description": "Allows user to override default values for mapreduce configuration.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "oozieConfiguration": {
+              "description": "Allows user to override default values for oozie configuration.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "stormConfiguration": {
+              "description": "Allows user to override default values for Storm configuration.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "sparkConfiguration": {
+              "description": "The Spark service configuration of this HDInsight cluster.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "yarnConfiguration": {
+              "description": "Allows user to override default values for YARN configuration.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "additionalLinkedServiceNames": {
+              "description": "Specify additional Azure storage accounts that need to be accessible from the cluster.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "hcatalogLinkedServiceName": {
+              "description": "The name of Azure SQL linked service that point to the HCatalog database.",
+              "type": "string"
+            },
+            "schemaGeneration": {
+              "description": "Define what options to use for generating/altering table for an input and output tables for an HDInsight activity.",
+              "$ref": "#/definitions/hDInsightSchemaGenerationProperties"
+            },
+            "dataNodeSize": {
+              "description": "Gets or sets the size of the Data Node.",
+              "type": "string"
+            },
+            "headNodeSize": {
+              "description": "Gets or sets the size of the Head Node.",
+              "type": "string"
+            },
+            "zookeeperNodeSize": {
+              "description": "Gets or sets the size of the Zookeeper Node.",
+              "type": "string"
+            },
+            "osType": {
+              "description": "Gets or sets the type of operating system installed on cluster nodes.",
+              "type": "string"
+            },
+            "sshPassword": {
+              "description": "Gets or sets SSH password.",
+              "type": "string"
+            },
+            "sshPublicKey": {
+              "description": "Gets or sets the public key to be used for SSH.",
+              "type": "string"
+            },
+            "sshUserName": {
+              "description": "Gets or sets SSH user name.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "onPremisesCassandraLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.OnPremisesCassandraLinkedService",
+      "description": "An on-premises Cassandra database.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "OnPremisesCassandra"
+          ]
+        },
+        "typeProperties": {
+          "required": [
+            "host",
+            "authenticationType",
+            "gatewayName"
+          ],
+          "properties": {
+            "host": {
+              "description": "One or more IP addresses or host names of the Cassandra server. Specify a comma-separated list of IP addresses and/or host names if attempting to connect to multiple servers. Each server is a replica.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The TCP port number that the Cassandra server uses to listen for client connections. The default value is 9042.",
+              "type": "integer",
+              "minimum": 0
+            },
+            "authenticationType": {
+              "description": "The authentication type to be used to connect to the Cassandra database. Must be Basic or Anonymous.",
+              "type": "string"
+            },
+            "username": {
+              "description": "User name for Basic authentication.",
+              "type": "string"
+            },
+            "password": {
+              "description": "Password for Basic authentication.",
+              "type": "string"
+            },
+            "gatewayName": {
+              "description": "The on-premises gateway name.",
+              "type": "string"
+            },
+            "encryptedCredential": {
+              "description": "The encrypted credential for Basic authentication.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "azureDataLakeStoreLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureDataLakeStoreLinkedService",
+      "description": "Azure Data Lake Store linked service.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureDataLakeStore"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "authorization",
+            "sessionId",
+            "dataLakeStoreUri"
+          ],
+          "properties": {
+            "authorization": {
+              "description": "OAuth authorization that may be used by ADF to access resources on your behalf. Each authorization is unique and may only be used once.",
+              "type": "string"
+            },
+            "sessionId": {
+              "description": "OAuth session ID from the oauth authorization session. Each session id is unique and may only be used once.",
+              "type": "string"
+            },
+            "dataLakeStoreUri": {
+              "description": "Data Lake Store service URI.",
+              "type": "string"
+            },
+            "accountName": {
+              "description": "Data Lake Store account name.",
+              "type": "string"
+            },
+            "subscriptionId": {
+              "description": "Data Lake Store account subscription ID (if different from Data Factory account).",
+              "type": "string"
+            },
+            "resourceGroupName": {
+              "description": "Data Lake Store account resource group name (if different from Data Factory account).",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "azureDataLakeAnalyticsLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureDataLakeAnalyticsLinkedService",
+      "description": "Azure Data Lake Analytics linked service.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureDataLakeAnalytics"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "authorization",
+            "sessionId",
+            "accountName"
+          ],
+          "properties": {
+            "authorization": {
+              "description": "OAuth authorization that may be used by ADF to access resources on your behalf. Each authorization is unique and may only be used once.",
+              "type": "string"
+            },
+            "sessionId": {
+              "description": "OAuth session ID from the oauth authorization session. Each session id is unique and may only be used once.",
+              "type": "string"
+            },
+            "dataLakeAnalyticsUri": {
+              "description": "Data Lake Analytics service URI.",
+              "type": "string"
+            },
+            "accountName": {
+              "description": "Data Lake Analytics account name.",
+              "type": "string"
+            },
+            "subscriptionId": {
+              "description": "Data Lake Analytics account subscription ID (if different from Data Factory account).",
+              "type": "string"
+            },
+            "resourceGroupName": {
+              "description": "Data Lake Analytics account resource group name (if different from Data Factory account).",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "webLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.WebLinkedService",
+      "description": "Web linked service.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Web"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "url",
+            "authenticationType"
+          ],
+          "properties": {
+            "url": {
+              "description": "The URL of the web service endpoint, e.g. http://www.microsoft.com.",
+              "type": "string"
+            },
+            "authenticationType": {
+              "description": "Type of authentication used to connect to the web table source. Possible values are: Anonymous and Basic.",
+              "type": "string",
+              "enum": [
+                "Basic",
+                "Anonymous"
+              ]
+            },
+            "username": {
+              "description": "User name for Basic authentication.",
+              "type": "string"
+            },
+            "password": {
+              "description": "Password for Basic authentication.",
+              "type": "string"
+            },
+            "apiKey": {
+              "description": "Deprecated. WebApi-based authentication is no longer supported.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "hdfsLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.HdfsLinkedService",
+      "description": "Hadoop Distributed File System (HDFS) linked service.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Hdfs"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "url",
+            "authenticationType",
+            "gatewayName"
+          ],
+          "properties": {
+            "url": {
+              "description": "The URL of the HDFS service endpoint, e.g. http://myhostname:50070/webhdfs/v1.",
+              "type": "string"
+            },
+            "authenticationType": {
+              "description": "Type of authentication used to connect to the HDFS. Possible values are: Anonymous, and Windows.",
+              "type": "string"
+            },
+            "gatewayName": {
+              "description": "The on-premises gateway name.",
+              "type": "string"
+            },
+            "encryptedCredential": {
+              "description": "The encrypted credential for Windows authentication.",
+              "type": "string"
+            },
+            "userName": {
+              "description": "User name for Windows authentication.",
+              "type": "string"
+            },
+            "password": {
+              "description": "Password for Windows authentication.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "onPremisesOdbcLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.OnPremisesOdbcLinkedService",
+      "description": "On-premises Open Database Connectivity (ODBC) linked service.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "OnPremisesOdbc"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "connectionString",
+            "authenticationType",
+            "gatewayName"
+          ],
+          "properties": {
+            "authenticationType": {
+              "description": "Type of authentication used to connect to the ODBC data store. Possible values are: Anonymous and Basic.",
+              "type": "string"
+            },
+            "gatewayName": {
+              "description": "The on-premises gateway name.",
+              "type": "string"
+            },
+            "connectionString": {
+              "description": "The non-access credential portion of the connection string as well as an optional encrypted credential.",
+              "type": "string"
+            },
+            "credential": {
+              "description": "The access credential portion of the connection string specified in driver-specific property-value format.",
+              "type": "string"
+            },
+            "userName": {
+              "description": "User name for Basic authentication.",
+              "type": "string"
+            },
+            "password": {
+              "description": "Password for Basic authentication.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "oDataLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.ODataLinkedService",
+      "description": "Open Data Protocol (OData) linked service.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "OData"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "url",
+            "authenticationType"
+          ],
+          "properties": {
+            "url": {
+              "description": "The URL of the OData service endpoint.",
+              "type": "string"
+            },
+            "authenticationType": {
+              "description": "Type of authentication used to connect to the OData service.",
+              "$ref": "#/definitions/oDataAuthenticationType"
+            },
+            "username": {
+              "description": "User name of the OData service.",
+              "type": "string"
+            },
+            "password": {
+              "description": "Password of the OData service.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "oDataAuthenticationType": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.ODataAuthenticationType",
+      "description": "Available authentication types for ODataLinkedService.",
+      "type": "string",
+      "enum": [
+        "Basic",
+        "Anonymous"
+      ]
+    },
+    "salesforceLinkedService": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.SalesforceLinkedService",
+      "description": "Linked Service for Salesforce connector.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Salesforce"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this linked service type.",
+          "type": "object",
+          "required": [
+            "username",
+            "password",
+            "securityToken"
+          ],
+          "properties": {
+            "username": {
+              "description": "The username for Basic authentication of the Salesforce source.",
+              "type": "string"
+            },
+            "password": {
+              "description": "The password for Basic authentication of the Salesforce source.",
+              "type": "string"
+            },
+            "securityToken": {
+              "description": "The security token is required to access Salesforce.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "dataElement": {
+      "title": "Microsoft.Azure.Management.DataFactories.Common.Models.DataElement",
+      "description": "Data element defines the semantics of each column of a dataset.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the data element.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Description of the data element.",
+          "type": "string"
+        },
+        "culture": {
+          "description": "Culture of the data element.",
+          "type": "string"
+        },
+        "format": {
+          "description": "Format of the data element.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of the data element.",
+          "type": "string",
+          "enum": [
+            "String",
+            "Int16",
+            "Int32",
+            "Int64",
+            "Single",
+            "Double",
+            "Decimal",
+            "Guid",
+            "Boolean",
+            "Enum",
+            "Datetime",
+            "DateTimeOffset",
+            "Timespan",
+            "Byte[]"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "partitionValue": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.PartitionValue",
+      "description": "The value of a partition.",
+      "type": "object",
+      "properties": { }
+    },
+    "dateTimePartitionValue": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.DateTimePartitionValue",
+      "description": "The date/time value of a partition.",
+      "type": "object",
+      "properties": {
+        "date": {
+          "description": "Name of variable containing date.",
+          "type": "string"
+        },
+        "format": {
+          "description": "Format string for the Date value.",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "DateTime"
+          ]
+        }
+      }
+    },
+    "partitionValueTypes": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/partitionValue"
+        },
+        {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dateTimePartitionValue"
+            }
+          ]
+        }
+      ]
+    },
+    "partition": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.Partition",
+      "description": "The partition definition.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the partition.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Value of the partition.",
+          "$ref": "#/definitions/partitionValueTypes"
+        }
+      },
+      "additionalProperties": false
+    },
+    "storageFormat": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.StorageFormat",
+      "description": "The format definition of a storage.",
+      "type": "object",
+      "properties": {
+        "serializer": {
+          "description": "Serializer.",
+          "type": "string"
+        },
+        "deserializer": {
+          "description": "Deserializer.",
+          "type": "string"
+        }
+      }
+    },
+    "textFormat": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.TextFormat",
+      "description": "Text format.",
+      "type": "object",
+      "properties": {
+        "columnDelimiter": {
+          "description": "The column delimiter.",
+          "type": "string"
+        },
+        "rowDelimiter": {
+          "description": "The row delimiter.",
+          "type": "string"
+        },
+        "escapeChar": {
+          "description": "The escape character.",
+          "type": "string"
+        },
+        "quoteChar": {
+          "description": "The quote character.",
+          "type": "string"
+        },
+        "nullValue": {
+          "description": "The null value string.",
+          "type": "string"
+        },
+        "encodingName": {
+          "description": "The code page name of the preferred encoding. If miss, the default value is “utf-8”, unless BOM denotes another Unicode encoding. Refer to the “Name” column of the table in the following link to set supported values: https://msdn.microsoft.com/library/system.text.encoding.aspx.",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "TextFormat"
+          ]
+        }
+      }
+    },
+    "storageFormatTypes": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/storageFormat"
+        },
+        {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/textFormat"
+            },
+            {
+              "$ref": "#/definitions/avroFormat"
+            },
+            {
+              "$ref": "#/definitions/jsonFormat"
+            },
+            {
+              "$ref": "#/definitions/orcFormat"
+            }
+          ]
+        }
+      ]
+    },
+    "jsonFormat": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.JsonFormat",
+      "description": "The data stored in JSON format.",
+      "type": "object",
+      "properties": {
+        "filePattern": {
+          "description": "File pattern of JSON. To be more specific, the way of separating a collection of JSON objects. The default value is 'setOfObjects'. It is case-sensitive.",
+          "$ref": "#/definitions/jsonFormatFilePattern"
+        },
+        "nestingSeparator": {
+          "description": "The character used to separate nesting levels. Default value is '.' (dot).",
+          "type": "string"
+        },
+        "encodingName": {
+          "description": "The code page name of the preferred encoding. If not provided, the default value is 'utf-8', unless the byte order mark (BOM) denotes another Unicode encoding. The full list of supported values can be found in the 'Name' column of the table of encodings in the following reference: https://msdn.microsoft.com/library/system.text.encoding.aspx#Anchor_5.",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "JsonFormat"
+          ]
+        }
+      }
+    },
+    "jsonFormatFilePattern": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.JsonFormatFilePattern",
+      "description": "JSON format file pattern. A property of JsonFormat",
+      "type": "string",
+      "enum": [
+        "setOfObjects",
+        "arrayOfObjects"
+      ]
+    },
+    "avroFormat": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AvroFormat",
+      "description": "Avro format.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AvroFormat"
+          ]
+        }
+      }
+    },
+    "orcFormat": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.OrcFormat",
+      "description": "Optimized row columnar (ORC) format.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "OrcFormat"
+          ]
+        }
+      }
+    },
+    "compressionTypes": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/compression"
+        },
+        {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/bzip2Compression"
+            },
+            {
+              "$ref": "#/definitions/deflateCompression"
+            },
+            {
+              "$ref": "#/definitions/gzipCompression"
+            }
+          ]
+        }
+      ]
+    },
+    "compression": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.Compression",
+      "description": "The compression method used on a dataset.",
+      "type": "object"
+    },
+    "bzip2Compression": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.BZip2Compression",
+      "description": "The BZip2 compression method used on a dataset.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "BZip2"
+          ]
+        }
+      }
+    },
+    "deflateCompression": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.DeflateCompression",
+      "description": "The Deflate compression method used on a dataset.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Deflate"
+          ]
+        },
+        "level": {
+          "description": "The Deflate compression method used on a dataset.",
+          "$ref": "#/definitions/compressionLevel"
+        }
+      }
+    },
+    "gzipCompression": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.GZipCompression",
+      "description": "The GZip compression method used on a dataset.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "GZip"
+          ]
+        },
+        "level": {
+          "description": "The GZip compression method used on a dataset.",
+          "$ref": "#/definitions/compressionLevel"
+        }
+      }
+    },
+    "compressionLevel": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.CompressionLevel",
+      "description": "All available compression levels.",
+      "type": "string",
+      "enum": [
+        "Optimal",
+        "Fastest"
+      ]
+    },
+    "azureBlobDataset": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureBlobLocation",
+      "description": "The Azure blob storage.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureBlob"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this dataset type.",
+          "type": "object",
+          "properties": {
+            "folderPath": {
+              "description": "The path of the Azure blob storage.",
+              "type": "string"
+            },
+            "tableRootLocation": {
+              "description": "The root of blob path.",
+              "type": "string"
+            },
+            "fileName": {
+              "description": "The name of the Azure blob.",
+              "type": "string"
+            },
+            "partitionedBy": {
+              "description": "The partitions to be used by the path.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/partition"
+              }
+            },
+            "format": {
+              "description": "The format of the Azure blob storage.",
+              "$ref": "#/definitions/storageFormatTypes"
+            },
+            "compression": {
+              "description": "The data compression method used for the blob storage.",
+              "$ref": "#/definitions/compressionTypes"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "azureTableDataset": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureTableDataset",
+      "description": "The Azure dataset storage.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureTable"
+          ]
+        },
+        "typeProperties": {
+          "required": [
+            "tableName"
+          ],
+          "description": "Properties specific to this dataset type.",
+          "type": "object",
+          "properties": {
+            "tableName": {
+              "description": "The table name of the Azure table storage.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "azureSqlTableDataset": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureSqlTableDataset",
+      "description": "The Azure SQL Server database.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureSqlTable"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this dataset type.",
+          "type": "object",
+          "required": [
+            "tableName"
+          ],
+          "properties": {
+            "tableName": {
+              "description": "The table name of the Azure SQL database.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "azureSqlDataWarehouseTableDataset": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureSqlDataWarehouseTableDataset",
+      "description": "The Azure SQL data warehouse dataset.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureSqlDWTable"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this dataset type.",
+          "type": "object",
+          "required": [
+            "tableName"
+          ],
+          "properties": {
+            "tableName": {
+              "description": "The table name of the Azure SQL data warehouse dataset.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "documentDbCollectionDataset": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.DocumentDbCollectionDataset",
+      "description": "Document Database Collection location.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "DocumentDbCollection"
+          ]
+        },
+        "typeProperties": {
+          "properties": {
+            "collectionName": {
+              "description": "Document Database collection name.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "azureDataLakeStoreDataset": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureDataLakeStoreDataset",
+      "description": "Azure Data Lake Store dataset.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureDataLakeStore"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this data set type.",
+          "type": "object",
+          "required": [
+            "folderPath"
+          ],
+          "properties": {
+            "folderPath": {
+              "description": "Path to the folder in the Azure Data Lake Store.",
+              "type": "string"
+            },
+            "fileName": {
+              "description": "The name of the file in the Azure Data Lake Store.",
+              "type": "string"
+            },
+            "format": {
+              "description": "The format of the Data Lake Store.",
+              "$ref": "#/definitions/storageFormatTypes"
+            },
+            "compression": {
+              "description": "The data compression method used for the item(s) in the Azure Data Lake Store.",
+              "$ref": "#/definitions/compressionTypes"
+            },
+            "partitionedBy": {
+              "description": "Specify a dynamic path and filename for time series data.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/partition"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "sqlServerTableDataset": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.SqlServerTableDataset",
+      "description": "The on-premises SQL Server database.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "SqlServerTable"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this dataset type.",
+          "type": "object",
+          "required": [
+            "tableName"
+          ],
+          "properties": {
+            "tableName": {
+              "description": "The table name of the on-premises SQL database.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "fileShareDataset": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.FileShareDataset",
+      "description": "An on-premises file system.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "FileShare"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this dataset type.",
+          "type": "object",
+          "properties": {
+            "folderPath": {
+              "description": "The name of the file folder.",
+              "type": "string"
+            },
+            "fileName": {
+              "description": "The name of the file.",
+              "type": "string"
+            },
+            "partitionedBy": {
+              "description": "The partitions to be used by the path.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/partition"
+              }
+            },
+            "format": {
+              "description": "The format of the file.",
+              "$ref": "#/definitions/storageFormatTypes"
+            },
+            "fileFilter": {
+              "description": "Files sets filter by wildcard.",
+              "type": "string"
+            },
+            "compression": {
+              "description": "The data compression method used on files.",
+              "$ref": "#/definitions/compressionTypes"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "relationalTableDataset": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.RelationalTableDataset",
+      "description": "Relational Table location.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "RelationalTable"
+          ]
+        },
+        "typeProperties": {
+          "properties": {
+            "tableName": {
+              "description": "The table name.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "onPremisesCassandraTableDataset": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.OnPremisesCassandraTableDataset",
+      "description": "A table in a Cassandra database.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "CassandraTable"
+          ]
+        },
+        "typeProperties": {
+          "properties": {
+            "tableName": {
+              "description": "The table name of the Cassandra database.",
+              "type": "string"
+            },
+            "keyspace": {
+              "description": "The keyspace of the Cassandra database.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "oracleTableDataset": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.OracleTableDataset",
+      "description": "The on-premises Oracle database.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "OracleTable"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this dataset type.",
+          "type": "object",
+          "required": [
+            "tableName"
+          ],
+          "properties": {
+            "tableName": {
+              "description": "The table name of the on-premises Oracle database.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "customDataset": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.CustomDataset",
+      "description": "Custom location.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "CustomDataset"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this dataset type.",
+          "type": "object"
+        }
+      }
+    },
+    "oDataResourceDataset": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.ODataResourceDataset",
+      "description": "Open Data Protocol (OData) Resource Dataset.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "ODataResource"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this dataset type.",
+          "type": "object",
+          "properties": {
+            "path": {
+              "description": "OData resource path.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "webTableDataset": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.WebTableDataset",
+      "description": "HTML table in a web page.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "WebTable"
+          ]
+        },
+        "typeProperties": {
+          "description": "Properties specific to this dataset type.",
+          "type": "object",
+          "required": [
+            "index"
+          ],
+          "properties": {
+            "index": {
+              "description": "The zero-based index of the table in web page.",
+              "type": "integer",
+              "minimum": 0
+            },
+            "path": {
+              "description": "The relative URL to the web page from the linked service URL.",
+              "type": "string"
+            },
+            "partitionedBy": {
+              "description": "The partitions to be used by the path.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/partition"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "availability": {
+      "title": "Microsoft.Azure.Management.DataFactories.Common.Models.Availability",
+      "description": "The scheduler definition.",
+      "type": "object",
+      "required": [
+        "frequency",
+        "interval"
+      ],
+      "properties": {
+        "frequency": {
+          "description": "Frequency in terms of minute, hour, day, etc.",
+          "type": "string",
+          "enum": [
+            "Minute",
+            "Hour",
+            "Day",
+            "Week",
+            "Month"
+          ]
+        },
+        "interval": {
+          "description": "The interval of running the scheduler.",
+          "type": "integer"
+        },
+        "anchorDateTime": {
+          "description": "The date used as a reference point for calculating slice start and end dates.",
+          "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/UTC"
+        },
+        "offset": {
+          "description": "The offset relative to the anchor time.",
+          "type": "string",
+          "pattern": "((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))"
+        },
+        "style": {
+          "description": "The scheduler style.",
+          "type": "string",
+          "enum": [
+            "NotSpecified",
+            "StartOfInterval",
+            "EndOfInterval"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "validationPolicy": {
+      "title": "Microsoft.Azure.Management.DataFactories.Common.Models.ValidationPolicy",
+      "description": "Validation policy.",
+      "type": "object",
+      "properties": {
+        "minimumRows": {
+          "description": "Minimum rows.",
+          "type": "integer"
+        },
+        "minimumSizeMB": {
+          "description": "Minimum size in MB.",
+          "type": "number"
+        },
+        "validationPriorityOrder": {
+          "description": "Validation priority order.  Choose from OldestFirst or NewestFirst.",
+          "type": "string",
+          "enum": [
+            "OldestFirst",
+            "NewestFirst"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "latencyPolicy": {
+      "title": "Microsoft.Azure.Management.DataFactories.Common.Models.LatencyPolicy",
+      "description": "Latency policy.",
+      "type": "object",
+      "properties": {
+        "latencyLength": {
+          "description": "Latency length.",
+          "type": "string",
+          "pattern": "((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))"
+        }
+      },
+      "additionalProperties": false
+    },
+    "externalDataPolicy": {
+      "title": "Microsoft.Azure.Management.DataFactories.Common.Models.ExternalDataPolicy",
+      "description": "External data policy.",
+      "type": "object",
+      "properties": {
+        "dataDelay": {
+          "description": "Data delay.",
+          "type": "string",
+          "pattern": "((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))"
+        },
+        "retryInterval": {
+          "description": "Retry interval.",
+          "type": "string",
+          "pattern": "((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))"
+        },
+        "retryTimeout": {
+          "description": "Specifies the timeout for the activity to run. If there is value specified, it takes the value of TimeSpan.FromMilliseconds(-1) which means indefinite timeout.",
+          "type": "string",
+          "pattern": "((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))"
+        },
+        "maximumRetry": {
+          "description": "Maximum retry.",
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false
+    },
+    "policy": {
+      "title": "Microsoft.Azure.Management.DataFactories.Common.Models.Policy",
+      "description": "Policy of a dataset.",
+      "type": "object",
+      "properties": {
+        "validation": {
+          "description": "Validation policy.",
+          "$ref": "#/definitions/validationPolicy"
+        },
+        "latency": {
+          "description": "Latency policy.",
+          "$ref": "#/definitions/latencyPolicy"
+        },
+        "externalData": {
+          "description": "External data policy.",
+          "$ref": "#/definitions/externalDataPolicy"
+        }
+      },
+      "additionalProperties": false
+    },
+    "datasetProperties": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.DatasetProperties",
+      "description": "Dataset properties.",
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "Dataset description.",
+          "type": "string"
+        },
+        "structure": {
+          "description": "Columns that define the structure of the dataset.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/dataElement"
+          }
+        },
+        "availability": {
+          "description": "Scheduler of the dataset.",
+          "$ref": "#/definitions/availability"
+        },
+        "policy": {
+          "description": "Policy applied to the dataset.",
+          "$ref": "#/definitions/policy"
+        },
+        "external": {
+          "description": "If set to true, the dataset is an external data set.",
+          "type": "boolean"
+        },
+        "linkedServiceName": {
+          "description": "The referenced data linkedService name.",
+          "type": "string"
+        }
+      }
+    },
+    "datasetPropertiesTypes": {
+      "type": "object",
+      "required": [
+        "availability",
+        "linkedServiceName",
+        "type",
+        "typeProperties"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/datasetProperties"
+        },
+        {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/azureBlobDataset"
+            },
+            {
+              "$ref": "#/definitions/azureTableDataset"
+            },
+            {
+              "$ref": "#/definitions/azureSqlTableDataset"
+            },
+            {
+              "$ref": "#/definitions/azureSqlDataWarehouseTableDataset"
+            },
+            {
+              "$ref": "#/definitions/documentDbCollectionDataset"
+            },
+            {
+              "$ref": "#/definitions/sqlServerTableDataset"
+            },
+            {
+              "$ref": "#/definitions/fileShareDataset"
+            },
+            {
+              "$ref": "#/definitions/oracleTableDataset"
+            },
+            {
+              "$ref": "#/definitions/relationalTableDataset"
+            },
+            {
+              "$ref": "#/definitions/azureDataLakeStoreDataset"
+            },
+            {
+              "$ref": "#/definitions/oDataResourceDataset"
+            },
+            {
+              "$ref": "#/definitions/webTableDataset"
+            },
+            {
+              "$ref": "#/definitions/onPremisesCassandraTableDataset"
+            },
+            {
+              "$ref": "#/definitions/customDataset"
+            }
+          ]
+        }
+      ]
+    },
+    "activityPolicy": {
+      "title": "Microsoft.Azure.Management.DataFactories.Common.Models.ActivityPolicy",
+      "description": "Activity policy.",
+      "type": "object",
+      "properties": {
+        "timeout": {
+          "description": "Specifies the timeout for the activity to run. If there is value specified, it takes the value of TimeSpan.FromMilliseconds(-1) which means indefinite timeout.",
+          "type": "string",
+          "pattern": "((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))"
+        },
+        "delay": {
+          "description": "Delay activity execution so that upstream activities can have extra time to finish.",
+          "type": "string",
+          "pattern": "((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))"
+        },
+        "concurrency": {
+          "description": "The maximum number of concurrent activity executions.",
+          "type": "integer"
+        },
+        "executionPriorityOrder": {
+          "description": "Execution priority order.  Choose from OldestFirst or NewestFirst.",
+          "type": "string",
+          "enum": [
+            "OldestFirst",
+            "NewestFirst"
+          ]
+        },
+        "retry": {
+          "description": "Total number of short retries for a failed activity.",
+          "type": "integer"
+        },
+        "longRetry": {
+          "description": "Total number of long retries after failed short retries.",
+          "type": "integer"
+        },
+        "longRetryInterval": {
+          "description": "Interval between two long retries.",
+          "type": "string",
+          "pattern": "((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))"
+        }
+      },
+      "additionalProperties": false
+    },
+    "activityInput": {
+      "title": "Microsoft.Azure.Management.DataFactories.Common.Models.ActivityInput",
+      "description": "An activity input.",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "startTime": {
+          "description": "Start time.",
+          "type": "string"
+        },
+        "endTime": {
+          "description": "EndTime.",
+          "type": "string"
+        },
+        "length": {
+          "description": "Length.",
+          "type": "string",
+          "pattern": "((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))"
+        },
+        "name": {
+          "description": "Referenced table name.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "activityOutput": {
+      "title": "Microsoft.Azure.Management.DataFactories.Common.Models.ActivityOutput",
+      "description": "An activity output.",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "description": "Referenced table name.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "activity": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.Activity",
+      "description": "A pipeline activity.",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "description": "Activity name.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Activity description.",
+          "type": "string"
+        },
+        "linkedServiceName": {
+          "description": "LinkedService name where the Activity Runs.",
+          "type": "string"
+        },
+        "policy": {
+          "description": "Policy.",
+          "$ref": "#/definitions/activityPolicy"
+        },
+        "inputs": {
+          "description": "Inputs.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/activityInput"
+          }
+        },
+        "outputs": {
+          "description": "Outputs.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/activityOutput"
+          }
+        },
+        "scheduler": {
+          "description": "Scheduler of the activity",
+          "$ref": "#/definitions/scheduler"
+        }
+      }
+    },
+    "scheduler": {
+      "title": "Microsoft.Azure.Management.DataFactories.Common.Models.Scheduler",
+      "description": "The scheduler definition.",
+      "type": "object",
+      "required": [
+        "frequency",
+        "interval"
+      ],
+      "properties": {
+        "frequency": {
+          "description": "Frequency in terms of minute, hour, day, etc.",
+          "type": "string",
+          "enum": [
+            "Minute",
+            "Hour",
+            "Day",
+            "Week",
+            "Month"
+          ]
+        },
+        "interval": {
+          "description": "The interval of running the scheduler.",
+          "type": "integer"
+        },
+        "anchorDateTime": {
+          "description": "The date used as a reference point for calculating slice start and end dates.",
+          "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/UTC"
+        },
+        "offset": {
+          "description": "The offset relative to the anchor time.",
+          "type": "string",
+          "pattern": "((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))"
+        },
+        "style": {
+          "description": "The scheduler style.",
+          "type": "string",
+          "enum": [
+            "NotSpecified",
+            "StartOfInterval",
+            "EndOfInterval"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "copySource": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.CopySource",
+      "description": "A copy activity source.",
+      "type": "object",
+      "properties": {
+        "sourceRetryCount": {
+          "description": "Source retry count.",
+          "type": "integer"
+        },
+        "sourceRetryWait": {
+          "description": "Source retry wait.",
+          "type": "string",
+          "pattern": "((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))"
+        }
+      }
+    },
+    "azureTableSource": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureTableSource",
+      "description": "A copy activity Azure table source.",
+      "type": "object",
+      "properties": {
+        "azureTableSourceQuery": {
+          "description": "Azure table source query.",
+          "type": "string"
+        },
+        "azureTableSourceIgnoreTableNotFound": {
+          "description": "Azure table source ignore table not found.",
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureTableSource"
+          ]
+        }
+      }
+    },
+    "copySourceTypes": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/copySource"
+        },
+        {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/azureTableSource"
+            },
+            {
+              "$ref": "#/definitions/blobSource"
+            },
+            {
+              "$ref": "#/definitions/documentDbCollectionSource"
+            },
+            {
+              "$ref": "#/definitions/relationalSource"
+            },
+            {
+              "$ref": "#/definitions/sqlSource"
+            },
+            {
+              "$ref": "#/definitions/sqlDWSource"
+            },
+            {
+              "$ref": "#/definitions/fileSystemSource"
+            },
+            {
+              "$ref": "#/definitions/oracleSource"
+            },
+            {
+              "$ref": "#/definitions/azureDataLakeStoreSource"
+            },
+            {
+              "$ref": "#/definitions/cassandraSource"
+            },
+            {
+              "$ref": "#/definitions/webSource"
+            }
+          ]
+        }
+      ]
+    },
+    "blobSource": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.BlobSource",
+      "description": "A copy activity blob source.",
+      "type": "object",
+      "properties": {
+        "treatEmptyAsNull": {
+          "description": "Treat empty as null.",
+          "type": "boolean"
+        },
+        "skipHeaderLineCount": {
+          "description": "Number of header lines to skip from each blob",
+          "type": "integer"
+        },
+        "recursive": {
+          "description": "If true, files under the folder path will be read recursively.",
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "BlobSource"
+          ]
+        }
+      }
+    },
+    "documentDbCollectionSource": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.DocumentDbCollectionSource",
+      "description": "A copy activity Document Database Collection source.",
+      "type": "object",
+      "properties": {
+        "query": {
+          "description": "Documents query.",
+          "type": "string"
+        },
+        "nestingSeparator": {
+          "description": "Nested properties separator.",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "DocumentDbCollectionSource"
+          ]
+        }
+      }
+    },
+    "relationalSource": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.RelationalSource",
+      "description": "A copy activity source for various relational databases.",
+      "type": "object",
+      "properties": {
+        "query": {
+          "description": "Database query.",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "RelationalSource"
+          ]
+        }
+      }
+    },
+    "sqlSource": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.SqlSource",
+      "description": "A copy activity SQL source.",
+      "type": "object",
+      "properties": {
+        "sqlReaderQuery": {
+          "description": "SQL reader query.",
+          "type": "string"
+        },
+        "sqlReaderStoredProcedureName": {
+          "description": "Name of the stored procedure for a SQL Database source. This cannot be used at the same time as SqlReaderQuery.",
+          "type": "string"
+        },
+        "storedProcedureParameters": {
+          "description": "Value and type setting for stored procedure parameters. Example: \"{Parameter1: {value: \"1\", type: \"int\"}}\".",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "SqlSource"
+          ]
+        }
+      }
+    },
+    "sqlDWSource": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.SqlDWSource",
+      "description": "A copy activity SQL Data Warehouse source.",
+      "type": "object",
+      "properties": {
+        "sqlReaderQuery": {
+          "description": "SQL Data Warehouse reader query.",
+          "type": "string"
+        },
+        "sqlReaderStoredProcedureName": {
+          "description": "Name of the stored procedure for a SQL Data Warehouse source. This cannot be used at the same time as SqlReaderQuery.",
+          "type": "string"
+        },
+        "storedProcedureParameters": {
+          "description": "Value and type setting for stored procedure parameters. Example: \"{Parameter1: {value: \"1\", type: \"int\"}}\".",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "SqlDWSource"
+          ]
+        }
+      }
+    },
+    "fileSystemSource": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.FileSystemSource",
+      "description": "A copy activity file system source.",
+      "type": "object",
+      "properties": {
+        "recursive": {
+          "description": "If true, files under the folder path will be read recursively.",
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "FileSystemSource"
+          ]
+        }
+      }
+    },
+    "oracleSource": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.OracleSource",
+      "description": "A copy activity Oracle source.",
+      "type": "object",
+      "properties": {
+        "oracleReaderQuery": {
+          "description": "Oracle reader query.",
+          "type": "string"
+        },
+        "queryTimeout": {
+          "description": "Query timeout",
+          "type": "string",
+          "pattern": "((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "OracleSource"
+          ]
+        }
+      }
+    },
+    "webSource": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.WebSource",
+      "description": "A copy activity source for web page table.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "WebSource"
+          ]
+        }
+      }
+    },
+    "azureDataLakeStoreSource": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureDataLakeStoreSource",
+      "description": "A copy activity Azure Data Lake source.",
+      "type": "object",
+      "properties": {
+        "recursive": {
+          "description": "If true, files under the folder path will be read recursively.",
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureDataLakeStoreSource"
+          ]
+        }
+      }
+    },
+    "cassandraSource": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.CassandraSource",
+      "description": "A copy activity source for a Cassandra database.",
+      "type": "object",
+      "properties": {
+        "query": {
+          "description": "Database query. Should be a SQL-92 query expression or Cassandra Query Language (CQL) command.",
+          "type": "string"
+        },
+        "consistencyLevel": {
+          "description": "The consistency level specifies how many Cassandra servers must respond to a read request before returning data to the client application. Cassandra checks the specified number of Cassandra servers for data to satisfy the read request. Must be one of cassandraSourceReadConsistencyLevels. The default value is 'ONE'. It is case-insensitive.",
+          "$ref": "#/definitions/cassandraSourceReadConsistencyLevels"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "CassandraSource"
+          ]
+        }
+      }
+    },
+    "cassandraSourceReadConsistencyLevels": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.CassandraSourceReadConsistencyLevels",
+      "description": "Consistency level when connecting to the Cassandra database. A property of CassandraSource.",
+      "type": "string",
+      "enum": [
+        "ALL",
+        "EACH_QUORUM",
+        "QUORUM",
+        "LOCAL_QUORUM",
+        "ONE",
+        "TWO",
+        "THREE",
+        "LOCAL_ONE",
+        "SERIAL",
+        "LOCAL_SERIAL"
+      ]
+    },
+    "azureDataLakeStoreSink": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureDataLakeStoreSink",
+      "description": "A copy activity Azure Data Lake Store sink.",
+      "type": "object",
+      "properties": {
+        "copyBehavior": {
+          "description": "The type of copy behavior for copy sink.",
+          "$ref": "#/definitions/copyBehaviorType"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureDataLakeStoreSink"
+          ]
+        }
+      }
+    },
+    "copySink": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.CopySink",
+      "description": "A copy activity sink.",
+      "type": "object",
+      "properties": {
+        "writeBatchSize": {
+          "description": "Write batch size.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "writeBatchTimeout": {
+          "description": "Write batch timeout.",
+          "type": "string",
+          "pattern": "((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))"
+        },
+        "sinkRetryCount": {
+          "description": "Sink retry count.",
+          "type": "integer"
+        },
+        "sinkRetryWait": {
+          "description": "Sink retry wait.",
+          "type": "string",
+          "pattern": "((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))"
+        }
+      }
+    },
+    "azureQueueSink": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureQueueSink",
+      "description": "A copy activity Azure queue sink.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureQueueSink"
+          ]
+        }
+      }
+    },
+    "copySinkTypes": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/copySink"
+        },
+        {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/azureQueueSink"
+            },
+            {
+              "$ref": "#/definitions/azureTableSink"
+            },
+            {
+              "$ref": "#/definitions/blobSink"
+            },
+            {
+              "$ref": "#/definitions/documentDbCollectionSink"
+            },
+            {
+              "$ref": "#/definitions/sqlSink"
+            },
+            {
+              "$ref": "#/definitions/sqlDWSink"
+            },
+            {
+              "$ref": "#/definitions/fileSystemSink"
+            },
+            {
+              "$ref": "#/definitions/oracleSink"
+            },
+            {
+              "$ref": "#/definitions/azureDataLakeStoreSink"
+            }
+          ]
+        }
+      ]
+    },
+    "copyBehaviorType": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.CopyBehaviorType",
+      "description": "All available types of copy behavior.",
+      "type": "string",
+      "enum": [
+        "PreserveHierarchy",
+        "FlattenHierarchy",
+        "MergeFiles"
+      ]
+    },
+    "azureTableSink": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureTableSink",
+      "description": "A copy activity Azure table sink.",
+      "type": "object",
+      "properties": {
+        "azureTableDefaultPartitionKeyValue": {
+          "description": "Azure table default partition key value.",
+          "type": "string"
+        },
+        "azureTablePartitionKeyName": {
+          "description": "Azure table partition key name.",
+          "type": "string"
+        },
+        "azureTableRowKeyName": {
+          "description": "Azure table row key name.",
+          "type": "string"
+        },
+        "azureTableInsertType": {
+          "description": "azure table insert type.",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureTableSink"
+          ]
+        }
+      }
+    },
+    "blobSink": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.BlobSink",
+      "description": "A copy activity blob sink.",
+      "type": "object",
+      "properties": {
+        "blobWriterOverwriteFiles": {
+          "description": "Blob writer overwrite files.",
+          "type": "boolean"
+        },
+        "blobWriterDateTimeFormat": {
+          "description": "Blob writer date time format.",
+          "type": "string"
+        },
+        "blobWriterAddHeader": {
+          "description": "Blob writer add header.",
+          "type": "boolean"
+        },
+        "copyBehavior": {
+          "description": "The type of copy behavior for copy sink.",
+          "$ref": "#/definitions/copyBehaviorType"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "BlobSink"
+          ]
+        }
+      }
+    },
+    "fileSystemSink": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.FileSystemSink",
+      "description": "A copy activity file system sink.",
+      "type": "object",
+      "properties": {
+        "copyBehavior": {
+          "description": "The type of copy behavior for file system sink.",
+          "$ref": "#/definitions/copyBehaviorType"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "FileSystemSink"
+          ]
+        }
+      }
+    },
+    "documentDbCollectionSink": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.DocumentDbCollectionSink",
+      "description": "A copy activity Document Database Collection sink.",
+      "type": "object",
+      "properties": {
+        "nestingSeparator": {
+          "description": "Nested properties separator.",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "DocumentDbCollectionSink"
+          ]
+        }
+      }
+    },
+    "sqlSink": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.SqlSink",
+      "description": "A copy activity SQL sink.",
+      "type": "object",
+      "properties": {
+        "sqlWriterStoredProcedureName": {
+          "description": "Sql writer stored procedure name.",
+          "type": "string"
+        },
+        "sqlWriterTableType": {
+          "description": "Sql writer table type.",
+          "type": "string"
+        },
+        "sliceIdentifierColumnName": {
+          "description": "Name of the SQL column which is used to save slice identifier information, to support idempotent copy.",
+          "type": "string"
+        },
+        "sqlWriterCleanupScript": {
+          "description": "SQL writer cleanup script.",
+          "type": "string"
+        },
+        "storedProcedureParameters": {
+          "description": "Sql stored procedure parameters.",
+          "type": "object",
+          "additionalProperties": {
+            "allOf": [
+              {
+                "$ref": "#/definitions/storedProcedureParameter"
+              }
+            ]
+          }
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "SqlSink"
+          ]
+        }
+      }
+    },
+    "sqlDWSink": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.SqlDWSink",
+      "description": "A copy activity SQL data warehouse sink.",
+      "type": "object",
+      "properties": {
+        "sliceIdentifierColumnName": {
+          "description": "Name of the SQL column which is used to save slice identifier information, to support idempotent copy.",
+          "type": "string"
+        },
+        "sqlWriterCleanupScript": {
+          "description": "SQL writer cleanup script.",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "SqlDWSink"
+          ]
+        },
+        "allowPolyBase": {
+          "description": "Indicates to use PolyBase to copy data into SQL Data Warehouse when applicable.",
+          "type": "boolean"
+        },
+        "polyBaseSettings": {
+          "description": "Specifies PolyBase-related settings when AllowPolyBase is true.",
+          "$ref": "#/definitions/polyBaseSettings"
+        }
+      }
+    },
+    "polyBaseSettings": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.PolyBaseSettings",
+      "description": "PolyBase settings.",
+      "type": "object",
+      "properties": {
+        "rejectType": {
+          "description": "Indicates whether the RejectValue property is specified as a literal value or a percentage.",
+          "type": "string",
+          "enum": [
+            "value",
+            "percentage"
+          ]
+        },
+        "rejectValue": {
+          "description": "Specifies the value or the percentage of rows that can be rejected before the query fails.",
+          "type": "number",
+          "minimum": 0
+        },
+        "rejectSampleValue": {
+          "description": "Determines the number of rows to attempt to retrieve before the PolyBase recalculates the percentage of rejected rows.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "useTypeDefault": {
+          "description": "Specifies how to handle missing values in delimited text files when PolyBase retrieves data from the text file.",
+          "type": "boolean"
+        }
+      }
+    },
+    "storedProcedureParameter": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.StoredProcedureParameter",
+      "description": "SQL stored procedure parameter.",
+      "type": "object",
+      "required": [ "value" ],
+      "properties": {
+        "value": {
+          "description": "Stored procedure parameter type.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Stored procedure parameter type.",
+          "$ref": "#/definitions/storedProcedureParameterType"
+        }
+      }
+    },
+    "storedProcedureParameterType": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.StoredProcedureParameterType",
+      "description": "Stored procedure parameter type.",
+      "type": "string",
+      "enum": [
+        "String",
+        "Int",
+        "Decimal",
+        "Guid",
+        "Boolean",
+        "Date"
+      ]
+    },
+    "oracleSink": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.OracleSink",
+      "description": "A copy activity Oracle sink.",
+      "type": "object",
+      "properties": {
+        "sliceIdentifierColumnName": {
+          "description": "Name of the SQL column which is used to save slice identifier information, to support idempotent copy.",
+          "type": "string"
+        },
+        "sqlWriterCleanupScript": {
+          "description": "SQL writer cleanup script.",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "OracleSink"
+          ]
+        }
+      }
+    },
+    "copyTranslator": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.CopyTranslator",
+      "description": "A copy activity translator.",
+      "type": "object",
+      "properties": { }
+    },
+    "tabularTranslator": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.TabularTranslator",
+      "description": "A copy activity tabular translator.",
+      "type": "object",
+      "properties": {
+        "columnMappings": {
+          "description": "Column mappings.",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "TabularTranslator"
+          ]
+        }
+      }
+    },
+    "copyTranslatorTypes": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/copyTranslator"
+        },
+        {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/tabularTranslator"
+            }
+          ]
+        }
+      ]
+    },
+    "copyActivity": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.CopyActivity",
+      "description": "Copy activity.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Copy"
+          ]
+        },
+        "typeProperties": {
+          "description": "Copy activity properties.",
+          "type": "object",
+          "required": [
+            "source",
+            "sink"
+          ],
+          "properties": {
+            "source": {
+              "description": "Copy activity source.",
+              "$ref": "#/definitions/copySourceTypes"
+            },
+            "sink": {
+              "description": "Copy activity sink.",
+              "$ref": "#/definitions/copySinkTypes"
+            },
+            "translator": {
+              "description": "Copy activity translator. If not specificed, tabular translator is used.",
+              "$ref": "#/definitions/copyTranslatorTypes"
+            },
+            "enableStaging": {
+              "description": "Specifies whether to copy data via an interim staging. Default value is false.",
+              "type": "boolean"
+            },
+            "stagingSettings": {
+              "description": "Specifies interim staging settings when EnableStaging is true.",
+              "$ref": "#/definitions/stagingSettings"
+            },
+            "parallelCopies": {
+              "description": "Maximum number of concurrent sessions opened on the source or sink to avoid overloading the data store.",
+              "type": "integer",
+              "minimum": 0
+            },
+            "cloudDataMovementUnits": {
+              "description": "Maximum number of cloud data movement units that can be used to perform this data movement.",
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "stagingSettings": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.StagingSettings",
+      "description": "Interim staging settings",
+      "type": "object",
+      "required": [ "linkedServiceName" ],
+      "properties": {
+        "linkedServiceName": {
+          "description": "Name of the Azure Storage or Storage SAS linked service used for interim staging. Must be specified if copy via staging is enbled.",
+          "type": "string"
+        },
+        "path": {
+          "description": "The path to storage for storing the interim data",
+          "type": "string"
+        },
+        "enableCompression": {
+          "description": "Specifies whether to use compression when copying data via an interim staging. Default value is false.",
+          "type": "boolean"
+        }
+      }
+    },
+    "activityTypes": {
+      "type": "object",
+      "required": [
+        "type",
+        "typeProperties"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/activity"
+        },
+        {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/copyActivity"
+            },
+            {
+              "$ref": "#/definitions/sqlServerStoredProcedureActivity"
+            },
+            {
+              "$ref": "#/definitions/azureMLBatchScoringActivity"
+            },
+            {
+              "$ref": "#/definitions/azureMLBatchExecutionActivity"
+            },
+            {
+              "$ref": "#/definitions/azureMLUpdateResourceActivity"
+            },
+            {
+              "$ref": "#/definitions/hdInsightHiveActivity"
+            },
+            {
+              "$ref": "#/definitions/hdInsightPigActivity"
+            },
+            {
+              "$ref": "#/definitions/hdInsightMapReduceActivity"
+            },
+            {
+              "$ref": "#/definitions/hdInsightStreamingActivity"
+            },
+            {
+              "$ref": "#/definitions/dataLakeAnalyticsUSQLActivity"
+            },
+            {
+              "$ref": "#/definitions/dotNetActivity"
+            }
+          ]
+        }
+      ]
+    },
+    "hdInsightHiveActivity": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.HDInsightHiveActivity",
+      "description": "HDInsight activity.",
+      "type": "object",
+      "properties": {
+        "typeProperties": {
+          "description": "HDInsight activity properties.",
+          "type": "object",
+          "properties": {
+            "storageLinkedServices": {
+              "description": "Storage linked services.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "arguments": {
+              "description": "User specified arguments to HDInsightActivity.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "getDebugInfo": {
+              "description": "The HDInsightActivityDebugInfoOption settings to use.",
+              "$ref": "#/definitions/hdInsightActivityDebugInfoOption"
+            },
+            "script": {
+              "description": "script.",
+              "type": "string"
+            },
+            "scriptPath": {
+              "description": "Script path.",
+              "type": "string"
+            },
+            "scriptLinkedService": {
+              "description": "Script linked service.",
+              "type": "string"
+            },
+            "defines": {
+              "description": "Allows user to specify defines for Hive job request.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "HDInsightHive"
+          ]
+        }
+      }
+    },
+    "hdInsightPigActivity": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.HDInsightPigActivity",
+      "description": "HDInsight activity.",
+      "type": "object",
+      "properties": {
+        "typeProperties": {
+          "description": "HDInsight activity properties.",
+          "type": "object",
+          "properties": {
+            "storageLinkedServices": {
+              "description": "Storage linked services.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "arguments": {
+              "description": "User specified arguments to HDInsightActivity.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "getDebugInfo": {
+              "description": "The HDInsightActivityDebugInfoOption settings to use.",
+              "$ref": "#/definitions/hdInsightActivityDebugInfoOption"
+            },
+            "script": {
+              "description": "script.",
+              "type": "string"
+            },
+            "scriptPath": {
+              "description": "Script path.",
+              "type": "string"
+            },
+            "scriptLinkedService": {
+              "description": "Script linked service.",
+              "type": "string"
+            },
+            "defines": {
+              "description": "Allows user to specify defines for the Pig job request.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "HDInsightPig"
+          ]
+        }
+      }
+    },
+    "hdInsightMapReduceActivity": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.HDInsightMapReduceActivity",
+      "description": "HDInsight activity.",
+      "type": "object",
+      "properties": {
+        "typeProperties": {
+          "description": "HDInsight activity properties.",
+          "type": "object",
+          "required": [
+            "className",
+            "jarFilePath"
+          ],
+          "properties": {
+            "storageLinkedServices": {
+              "description": "Storage linked services.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "arguments": {
+              "description": "User specified arguments to HDInsightActivity.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "getDebugInfo": {
+              "description": "The HDInsightActivityDebugInfoOption settings to use.",
+              "$ref": "#/definitions/hdInsightActivityDebugInfoOption"
+            },
+            "className": {
+              "description": "Class Name.",
+              "type": "string"
+            },
+            "jarFilePath": {
+              "description": "Jar path.",
+              "type": "string"
+            },
+            "jarLinkedService": {
+              "description": "Jar linked service.",
+              "type": "string"
+            },
+            "jarLibs": {
+              "description": "Jar libs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "defines": {
+              "description": "Allows user to specify defines for mapreduce job request.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "HDInsightMapReduce"
+          ]
+        }
+      }
+    },
+    "hdInsightStreamingActivity": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.HDInsightStreamingActivity",
+      "description": "HDInsight activity.",
+      "type": "object",
+      "properties": {
+        "typeProperties": {
+          "description": "HDInsight streaming activity properties.",
+          "type": "object",
+          "required": [
+            "mapper",
+            "reducer",
+            "input",
+            "output",
+            "filePaths"
+          ],
+          "properties": {
+            "storageLinkedServices": {
+              "description": "Storage linked services.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "arguments": {
+              "description": "User specified arguments to HDInsightActivity.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "getDebugInfo": {
+              "description": "The HDInsightActivityDebugInfoOption settings to use.",
+              "$ref": "#/definitions/hdInsightActivityDebugInfoOption"
+            },
+            "mapper": {
+              "description": "Mapper executable name.",
+              "type": "string"
+            },
+            "reducer": {
+              "description": "Reducer executable name.",
+              "type": "string"
+            },
+            "input": {
+              "description": "Input blob path.",
+              "type": "string"
+            },
+            "output": {
+              "description": "Output blob path.",
+              "type": "string"
+            },
+            "filePaths": {
+              "description": "Paths to streaming job files. Can be directories.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "fileLinkedService": {
+              "description": "Linked service where the files are located",
+              "type": "string"
+            },
+            "combiner": {
+              "description": "Combiner executable name.",
+              "type": "string"
+            },
+            "commandEnvironment": {
+              "description": "Commandline environment values",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "defines": {
+              "description": "Allows user to specify defines for streaming job request.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "HDInsightStreaming"
+          ]
+        }
+      }
+    },
+    "hdInsightActivityDebugInfoOption": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.HDInsightActivityDebugInfoOption",
+      "description": "All available options on how to get the YARN logs for HDInsight activities.",
+      "type": "string",
+      "enum": [
+        "None",
+        "Always",
+        "Failure"
+      ]
+    },
+    "dotNetActivity": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.DotNetActivity",
+      "description": ".NET activity.",
+      "type": "object",
+      "properties": {
+        "typeProperties": {
+          "description": ".NET activity properties.",
+          "type": "object",
+          "required": [
+            "assemblyName",
+            "entryPoint",
+            "packageFile"
+          ],
+          "properties": {
+            "assemblyName": {
+              "description": "Assembly name.",
+              "type": "string"
+            },
+            "entryPoint": {
+              "description": "Entry point.",
+              "type": "string"
+            },
+            "packageLinkedService": {
+              "description": "Package linkedService.",
+              "type": "string"
+            },
+            "packageFile": {
+              "description": "PackageFile.",
+              "type": "string"
+            },
+            "extendedProperties": {
+              "description": "User defined property bag. There is no restriction on the keys or values that can be used. The user specified .NET activity has the full responsibility to consume and interpret the content defined.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "DotNetActivity"
+          ]
+        }
+      }
+    },
+    "sqlServerStoredProcedureActivity": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.SqlServerStoredProcedureActivity",
+      "description": "SQL Stored Procedure activity.",
+      "type": "object",
+      "properties": {
+        "typeProperties": {
+          "description": "SQL Stored Procedure activity properties.",
+          "type": "object",
+          "required": [
+            "storedProcedureName"
+          ],
+          "properties": {
+            "storedProcedureName": {
+              "description": "Stored Procedure Name.",
+              "type": "string"
+            },
+            "storedProcedureParameters": {
+              "description": "User specified property bag used in Stored Procedure. There is no restriction on the keys or values that can be used. User needs to consume and interpret the content accordingly in their customized Stored Procedure.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "SqlServerStoredProcedure"
+          ]
+        }
+      }
+    },
+    "azureMLBatchScoringActivity": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureMLBatchScoringActivity",
+      "description": "Azure ML Web Service batch scoring activity.",
+      "type": "object",
+      "properties": {
+        "typeProperties": {
+          "description": "Azure ML activity properties.",
+          "type": "object",
+          "properties": {
+            "webServiceParameters": {
+              "description": "Key,Value pairs to be passed to the Azure ML Batch Execution Service Endpoint (these are also referred to as GlobalParameters). Keys must match the names of web service parameters defined in published the Azure ML web service. Values may include ADF macros to be resolved at each slice execution time.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureMLBatchScoring"
+          ]
+        }
+      }
+    },
+    "azureMLBatchExecutionActivity": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureMLBatchExecutionActivity",
+      "description": "Azure ML Batch Execution Service activity.",
+      "type": "object",
+      "properties": {
+        "typeProperties": {
+          "properties": {
+            "globalParameters": {
+              "type": "object",
+              "description": "Key,Value pairs to be passed to the Azure ML Batch Execution Service Endpoint Keys must match the names of web service parameters defined in the published Azure ML web service. Values may include ADF functions to be resolved at each slice execution time (See https://msdn.microsoft.com/en-us/library/azure/dn835056.aspx). Values will be passed in the GlobalParameters property of the Azure ML batch execution request.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "webServiceOutputs": {
+              "type": "object",
+              "description": "Key,Value pairs mapping the Azure ML endpoint's Web Service Output names to names of ADF Blob Tables where the batch execution output should be written. This information will be passed in the WebServiceOutputs property of the Azure ML batch execution request. Mapped Tables must be included in the Activity's Outputs.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "webServiceInput": {
+              "description": "Name of ADF Blob Table giving the input to the batch execution. This information will be passed in the WebServiceInput property of the Azure ML batch execution request.",
+              "type": "string"
+            }
+          }
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureMLBatchExecution"
+          ]
+        }
+      }
+    },
+    "azureMLUpdateResourceActivity": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.AzureMLUpdateResourceActivity",
+      "description": "Azure ML Update Resource management activity.",
+      "type": "object",
+      "properties": {
+        "typeProperties": {
+          "required": [
+            "trainedModelDatasetName",
+            "trainedModelName"
+          ],
+          "properties": {
+            "trainedModelDatasetName": {
+              "type": "string",
+              "description": "Name of ADF Blob Dataset representing the .ilearner file that will be uploaded by the update operation. The Dataset must be included in this Activity's pipeline Inputs."
+            },
+            "trainedModelName": {
+              "type": "string",
+              "description": "Name of the Trained Model module in the Web Service experiment to be updated."
+            }
+          }
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "AzureMLUpdateResource"
+          ]
+        }
+      }
+    },
+    "dataLakeAnalyticsUSQLActivity": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.DataLakeAnalyticsUSQLActivity",
+      "description": "Azure Data Lake Analytics U-SQL activity.",
+      "type": "object",
+      "properties": {
+        "typeProperties": {
+          "description": "Data Lake Analytics U-SQL activity properties.",
+          "type": "object",
+          "properties": {
+            "script": {
+              "description": "The U-SQL script. This cannot be used at the same time as ScriptPath and ScriptLinkedService.",
+              "type": "string"
+            },
+            "scriptPath": {
+              "description": "The path to the U-SQL script in the ScriptLinkedService. This needs to be used at the same time as ScriptLinkedService.",
+              "type": "string"
+            },
+            "scriptLinkedService": {
+              "description": "The linked service hosting the U-SQL script. This needs to be used at the same time as ScriptPath.",
+              "type": "string"
+            },
+            "runtimeVersion": {
+              "description": "Runtime version of U-SQL engine to use.",
+              "type": "string"
+            },
+            "compilationMode": {
+              "description": "Compilation mode of U-SQL. Must be one of the USqlCompilationMode",
+              "$ref": "#/definitions/uSqlCompilationMode"
+            },
+            "degreeOfParallelism": {
+              "description": "The maximum number of nodes that will be used simultaneously to run the job.",
+              "type": "integer"
+            },
+            "priority": {
+              "description": "Determines which jobs out of all that are queued should be selected to run first. The lower the number, the higher the priority (minimum is 0).",
+              "type": "integer"
+            },
+            "parameters": {
+              "description": "Allows user to specify parameters for the U-SQL activity.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "DataLakeAnalyticsU-SQL"
+          ]
+        }
+      }
+    },
+    "uSqlCompilationMode": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.USqlCompilationMode",
+      "description": "Compilation mode for a U-SQL activity.",
+      "type": "string",
+      "enum": [
+        "Semantic",
+        "Full",
+        "SingleBox"
+      ]
+    },
+    "pipelineProperties": {
+      "title": "Microsoft.Azure.Management.DataFactories.Models.PipelineProperties",
+      "description": "Pipeline properties.",
+      "type": "object",
+      "required": [
+        "activities"
+      ],
+      "properties": {
+        "description": {
+          "description": "Item description.",
+          "type": "string"
+        },
+        "activities": {
+          "description": "Activities that belong to the pipeline.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/activityTypes"
+          }
+        },
+        "start": {
+          "description": "The start time of the pipeline.",
+          "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/UTC"
+        },
+        "end": {
+          "description": "The end time of the pipeline.",
+          "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/UTC"
+        },
+        "isPaused": {
+          "description": "The status of the pipline. Pipeline is paused when boolean is set to true.",
+          "type": "boolean"
+        },
+        "hubName": {
+          "description": "The name of the Hub that this pipeline belongs to.",
+          "type": "string"
+        },
+        "pipelineMode": {
+          "description": "The method of scheduling runs for the pipeline. 'Scheduled' indicates that the pipeline will run at a specified time interval according to its active period (start and end time). 'OneTime' indicates that the pipeline will run only once.",
+          "type": "string",
+          "enum": [
+            "Scheduled",
+            "OneTime"
+          ]
+        },
+        "expirationTime": {
+          "description": "Duration of time after creation for which the pipeline is valid and should remain provisioned. The pipeline will be deleted automatically once it reaches the expiration time if it does not have any active or pending runs.",
+          "type": "string",
+          "pattern": "((\\d+)\\.)?(\\d\\d):(60|([0-5][0-9])):(60|([0-5][0-9]))"
+        },
+        "datasets": {
+          "description": "List of datasets to be used by activities defined in the pipeline. This can be used to define datasets that are specific to this pipeline and not defined within the data factory. Datasets defined within this pipeline can only be used by this pipeline and cannot be shared.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/datasetCommon"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/tests/2015-10-01/Microsoft.DataFactory.tests.json
+++ b/tests/2015-10-01/Microsoft.DataFactory.tests.json
@@ -1,0 +1,134 @@
+{
+  "tests": [
+    {
+      "name": "Data Factory: top-level resource only",
+      "definition": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/dataFactories",
+      "json": {
+        "type": "Microsoft.DataFactory/datafactories",
+        "apiVersion": "2015-10-01",
+        "name": "dataFactoryName",
+        "location": "WestUS"
+      }
+    },
+    {
+      "name": "Data Factory: top-level and child resources",
+      "definition": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/dataFactories",
+      "json": {
+        "name": "connectedCarDataFactory",
+        "apiVersion": "2015-10-01",
+        "type": "Microsoft.DataFactory/datafactories",
+        "location": "NorthEurope",
+        "resources": [
+          {
+            "type": "linkedservices",
+            "name": "azureSqlLinkedServiceName",
+            "apiVersion": "2015-10-01",
+            "properties": {
+              "type": "AzureSqlDatabase",
+              "typeProperties": {
+                "connectionString": "[concat('Server=tcp:',parameters('sqlServerName'),'.database.windows.net,1433;Database=connectedcar;User ID=',parameters('sqlServerUserName'),';Password=',parameters('sqlServerPassword'),';Trusted_Connection=False;Encrypt=True;Connection Timeout=30')]"
+              }
+            }
+          },
+          {
+            "type": "datasets",
+            "name": "AggresiveDrivingModelReportName",
+            "apiVersion": "2015-10-01",
+            "properties": {
+              "structure": [
+                {
+                  "name": "vin",
+                  "type": "String"
+                },
+                {
+                  "name": "model",
+                  "type": "String"
+                },
+                {
+                  "name": "timestamp",
+                  "type": "String"
+                },
+                {
+                  "name": "city",
+                  "type": "String"
+                },
+                {
+                  "name": "speed",
+                  "type": "String"
+                },
+                {
+                  "name": "transmission_gear_position",
+                  "type": "String"
+                },
+                {
+                  "name": "brake_pedal_status",
+                  "type": "String"
+                },
+                {
+                  "name": "Year",
+                  "type": "String"
+                },
+                {
+                  "name": "Month",
+                  "type": "String"
+                }
+              ],
+              "type": "AzureSqlTable",
+              "linkedServiceName": "AzureSqlLinkedService",
+              "typeProperties": {
+                "tableName": "AggresiveDrivingModelReport"
+              },
+              "availability": {
+                "frequency": "Month",
+                "interval": 1,
+                "style": "StartOfInterval"
+              }
+            }
+          },
+          {
+            "type":  "pipelines",
+            "name": "PartitionCarEventsPipelineName",
+            "apiVersion": "2015-10-01",
+            "properties": {
+              "description": "This is a sample pipeline to prepare the car events data for further processing",
+              "activities": [
+                {
+                  "name": "BlobPartitionHiveActivity",
+                  "inputs": [
+                    {
+                      "name": "RawCarEventsTable"
+                    }
+                  ],
+                  "outputs": [
+                    {
+                      "name": "PartitionedCarEventsTable"
+                    }
+                  ],
+                  "linkedServiceName": "hdInsightLinkedServiceName",
+                  "type": "HDInsightHive",
+                  "typeProperties": {
+                    "scriptPath": "connectedcar\\scripts\\partitioncarevents.hql",
+                    "scriptLinkedService": "StorageLinkedService",
+                    "defines": {
+                      "RAWINPUT": "[concat('wasb://connectedcar@',parameters('storageAccountName'),'.blob.core.windows.net/rawcarevents/')]",
+                      "PARTITIONEDOUTPUT": "[concat('wasb://connectedcar@',parameters('storageAccountName'),'.blob.core.windows.net/partitionedcarevents/')]",
+                      "Year": "$$Text.Format('{0:yyyy}',SliceStart)",
+                      "Month": "$$Text.Format('{0:%M}',SliceStart)",
+                      "Day": "$$Text.Format('{0:%d}',SliceStart)"
+                    }
+                  },
+                  "policy": {
+                    "concurrency": 1,
+                    "executionPriorityOrder": "NewestFirst",
+                    "retry": 2,
+                    "timeout": "01:00:00"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
  * Adds schemas for data factories (the top-level resource in the
    Microsoft.DataFactory namespace) and its child resources (linked
    services, datasets and pipelines).
  * We are not supporting template expressions at this time.
    This commit is aimed at supporting the "export resource" feature.