### PR TITLE
Fix type for pipeline resources for data factories

### DIFF
--- a/schemas/2014-04-01-preview/deploymentTemplate.json
+++ b/schemas/2014-04-01-preview/deploymentTemplate.json
@@ -155,7 +155,7 @@
                   { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/dataFactories" },
                   { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/linkedServices" },
                   { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/datasets" },
-                  { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/pipelines" },
+                  { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/dataPipelines" },
                   { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/Sendgrid.Email.json#/resourceDefinitions/accounts" },
                   { "$ref": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.ServiceBus.json#/resourceDefinitions/namespaces" },
                   { "$ref": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.ServiceBus.json#/resourceDefinitions/namespaces_AuthorizationRules" },

--- a/schemas/2015-01-01/deploymentTemplate.json
+++ b/schemas/2015-01-01/deploymentTemplate.json
@@ -153,7 +153,7 @@
                   { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/dataFactories" },
                   { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/linkedServices" },
                   { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/datasets" },
-                  { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/pipelines" },
+                  { "$ref": "http://schema.management.azure.com/schemas/2015-10-01/Microsoft.DataFactory.json#/resourceDefinitions/dataPipelines" },
                   { "$ref": "http://schema.management.azure.com/schemas/2016-02-03/Microsoft.Devices.json#/resourceDefinitions/IotHubs" },
                   { "$ref": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.ServiceBus.json#/resourceDefinitions/namespaces" },
                   { "$ref": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.ServiceBus.json#/resourceDefinitions/namespaces_AuthorizationRules" },

--- a/schemas/2015-10-01/Microsoft.DataFactory.json
+++ b/schemas/2015-10-01/Microsoft.DataFactory.json
@@ -125,7 +125,7 @@
         }
       }
     },
-    "pipelines": {
+    "dataPipelines": {
       "description": "A logical grouping of Activities. that operate as a unit that together perform a task.",
       "type": "object",
       "required": [
@@ -141,7 +141,7 @@
           ]
         },
         "type": {
-          "enum": [ "Microsoft.DataFactory/datafactories/pipelines" ]
+          "enum": [ "Microsoft.DataFactory/datafactories/dataPipelines" ]
         },
         "name": {
           "description": "Name of the pipeline.",
@@ -240,7 +240,7 @@
           ]
         },
         "type": {
-          "enum": [ "pipelines" ]
+          "enum": [ "dataPipelines" ]
         },
         "name": {
           "description": "Name of the pipeline.",

--- a/tests/2015-10-01/Microsoft.DataFactory.tests.json
+++ b/tests/2015-10-01/Microsoft.DataFactory.tests.json
@@ -86,7 +86,7 @@
             }
           },
           {
-            "type":  "pipelines",
+            "type":  "dataPipelines",
             "name": "PartitionCarEventsPipelineName",
             "apiVersion": "2015-10-01",
             "properties": {


### PR DESCRIPTION
  * Although the child resources are known publicly as "pipelines", the
    type name in the API route is "datapipelines".
  * This will fix resource creation and export via deployment template
    schemas.