### PR TITLE
Remove minlength requirement for phpVersion

### DIFF
--- a/schemas/2015-08-01/Microsoft.Web.json
+++ b/schemas/2015-08-01/Microsoft.Web.json
@@ -379,7 +379,6 @@
           "properties": {
             "phpVersion": {
               "type": "string",
-              "minLength": 1,
               "description": "Microsoft.Web/sites/config: PHP version (an empty string disables PHP)."
             },
             "netFrameworkVersion": {


### PR DESCRIPTION
An empty string is valid for phpVersion (it's also states so in the description), yet it had a minlength requirement.