### PR TITLE
properties is not a required field for Microsoft.Storage/storageAccounts

### DIFF
--- a/schemas/2016-01-01/Microsoft.Storage.json
+++ b/schemas/2016-01-01/Microsoft.Storage.json
@@ -79,8 +79,7 @@
         "apiVersion",
         "sku",
         "kind",
-        "location",
-        "properties"
+        "location"
       ],
       "description": "Microsoft.Storage/storageAccounts"
     }


### PR DESCRIPTION
Starting in 2016-01-01, properties is used to specify some more advanced use cases.
The common scenario is to deploy with no properties field at all.

If the user doesn't want to see schema problems, he needs to insert an empty properties field
( "properties": { } ) in his resource declaration.
This PR will improve the experience.