### PR TITLE
add required location parameter in VM extensions

### DIFF
--- a/schemas/2015-08-01/Microsoft.Compute.json
+++ b/schemas/2015-08-01/Microsoft.Compute.json
@@ -229,7 +229,8 @@
       "required": [
         "type",
         "properties",
-        "apiVersion"
+        "apiVersion",
+        "location"
       ],
       "description": "Microsoft.Compute/virtualMachines/extensions"
     },
@@ -296,7 +297,8 @@
       "required": [
         "type",
         "apiVersion",
-        "properties"
+        "properties",
+        "location"
       ],
       "description": "Microsoft.Compute/extensionsChild"
     }

--- a/tests/2015-08-01/Microsoft.Compute.tests.json
+++ b/tests/2015-08-01/Microsoft.Compute.tests.json
@@ -188,6 +188,7 @@
       "json": {
         "type": "extensions",
         "apiVersion": "2015-06-15",
+        "location": "West Us",
         "properties": {
           "publisher": "Test Publisher",
           "type": "Test Type",
@@ -203,6 +204,7 @@
       "json": {
         "type": "extensions",
         "apiVersion": "2015-06-15",
+        "location": "West Us",
         "properties": {
           "publisher": "Microsoft.Compute",
           "type": "CustomScriptExtension",


### PR DESCRIPTION
(1) Added required location parameter to Extensions & ExtensionsChild resources in 2015-08-01/Microsoft.Compute.json.

(2) Updated tests "extensionsChild - Minimal" & "extensionsChild - CustomScriptExtension" with location parameter so that they now pass.

If needed, please reference: https://docs.microsoft.com/en-us/rest/api/compute/virtualmachineextensions to confirm location is required. Please note that attempting to deploy extension without location results in this error: "error:   The location property is required for this definition."

Thank you,
Edward Milkey