### PR TITLE
add diagnosticsProfile to Compute/VirtualMachines

### DIFF
--- a/schemas/2015-08-01/Microsoft.Compute.json
+++ b/schemas/2015-08-01/Microsoft.Compute.json
@@ -90,6 +90,13 @@
                 { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
               ],
               "description": "Microsoft.Compute/virtualMachines - Network profile"
+            },
+            "diagnosticsProfile": {
+              "oneOf": [
+                { "$ref": "#/definitions/diagnosticsProfile" },
+                { "$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression" }
+              ],
+              "description": "Microsoft.Compute/virtualMachines - Diagnostics profile"
             }
           },
           "type": "object",
@@ -368,6 +375,21 @@
         "offer",
         "sku",
         "version"
+      ]
+    },
+    "bootDiagnostics": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "storageUri": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "enabled",
+        "storageUri"
       ]
     },
     "vhd": {
@@ -691,6 +713,20 @@
       "type": "object",
       "required": [
         "networkInterfaces"
+      ]
+    },
+    "diagnosticsProfile": {
+      "properties": {
+        "bootDiagnostics": {
+          "oneOf": [
+            {"$ref": "#/definitions/bootDiagnostics"},
+            {"$ref": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"}
+          ]
+        }
+      },
+      "type": "object",
+      "required": [
+        "bootDiagnostics"
       ]
     },
     "sku": {

--- a/tests/2015-08-01/Microsoft.Compute.tests.json
+++ b/tests/2015-08-01/Microsoft.Compute.tests.json
@@ -88,6 +88,45 @@
         }
       }
     },
+    {
+      "name": "virtualMachines - Extra",
+      "definition": "http://schema.management.azure.com/schemas/2015-08-01/Microsoft.Compute.json#/resourceDefinitions/virtualMachines",
+      "json": {
+        "apiVersion": "2015-06-15",
+        "type": "Microsoft.Compute/virtualMachines",
+        "name": "[variables('vmName')]",
+        "location": "[variables('location')]",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "[variables('vmSize')]"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "[variables('imagePublisher')]",
+              "offer": "[variables('imageOffer')]",
+              "sku": "[parameters('windowsOSVersion')]",
+              "version": "latest"
+            },
+            "osDisk": {
+              "name": "osdisk",
+              "vhd": {
+                "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+              },
+              "createOption": "FromImage"
+            }
+          },
+          "networkProfile": {
+            "networkInterfaces": [ ]
+          },
+          "diagnosticsProfile": {
+            "bootDiagnostics": {
+              "enabled": true,
+              "storageUri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+            }
+          }
+        }
+      }
+    },
  
     {
       "name": "extensions - Minimal",


### PR DESCRIPTION
Added diagnosticsProfile [1,2] to virtualMachines resource, and updated tests.

Thanks,
Edward Milkey

[1] https://docs.microsoft.com/en-us/rest/api/compute/virtualmachines
[2] https://github.com/Azure/azure-quickstart-templates/blob/master/101-vm-simple-linux/azuredeploy.json