### PR TITLE
Update Microsoft.Compute.json

### DIFF
--- a/schemas/2015-08-01/Microsoft.Compute.json
+++ b/schemas/2015-08-01/Microsoft.Compute.json
@@ -1024,13 +1024,13 @@
             "xmlCfg": {
               "type": "string"
             },
-            "StorageAccount": {
+            "storageAccount": {
               "type": "string"
             }
           },
           "required": [
             "xmlCfg",
-            "StorageAccount"
+            "storageAccount"
           ]
         },
         "protectedSettings": {


### PR DESCRIPTION
The VM Extension settings key "storageAccount" was misspelled as "StorageAccount", which shows up as intellisense errors.  Corrected.