### PR TITLE
Added $schema Property to all versions of CreateUIDefinition schema

### DIFF
--- a/schemas/0.0.1-preview/CreateUIDefinition.MultiVm.json
+++ b/schemas/0.0.1-preview/CreateUIDefinition.MultiVm.json
@@ -2,7 +2,13 @@
   "$schema": "http://json-schema.org/schema#",
   "id": "https://schema.management.azure.com/schemas/0.0.1-preview/CreateUIDefinition.MultiVm.json#",
   "type": "object",
-  "properties": {
+  "properties": {    
+    "$schema": {
+      "type": "string",
+      "enum": [
+        "https://schema.management.azure.com/schemas/0.0.1-preview/CreateUIDefinition.MultiVm.json#"
+      ]
+    },
     "handler": {
       "type": "string",
       "enum": [

--- a/schemas/0.1.0-preview/CreateUIDefinition.MultiVm.json
+++ b/schemas/0.1.0-preview/CreateUIDefinition.MultiVm.json
@@ -2,7 +2,13 @@
   "$schema": "http://json-schema.org/schema#",
   "id": "https://schema.management.azure.com/schemas/0.1.0-preview/CreateUIDefinition.MultiVm.json#",
   "type": "object",
-  "properties": {
+  "properties": { 
+    "$schema": {
+      "type": "string",
+      "enum": [
+        "https://schema.management.azure.com/schemas/0.1.0-preview/CreateUIDefinition.MultiVm.json#"
+      ]
+    },
     "handler": {
       "type": "string",
       "enum": [

--- a/schemas/0.1.1-preview/CreateUIDefinition.MultiVm.json
+++ b/schemas/0.1.1-preview/CreateUIDefinition.MultiVm.json
@@ -2,7 +2,13 @@
   "$schema": "http://json-schema.org/schema#",
   "id": "https://schema.management.azure.com/schemas/0.1.1-preview/CreateUIDefinition.MultiVm.json#",
   "type": "object",
-  "properties": {
+  "properties": {    
+    "$schema": {
+      "type": "string",
+      "enum": [
+        "https://schema.management.azure.com/schemas/0.1.1-preview/CreateUIDefinition.MultiVm.json#"
+      ]
+    },
     "handler": {
       "type": "string",
       "enum": [

--- a/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json
+++ b/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json
@@ -3,12 +3,12 @@
   "id": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
   "type": "object",
   "properties": {
-    "$schema": {
-      "type": "string",
-      "enum": [
-        "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#"
-      ]
-    },   
+    "$schema": {
+      "type": "string",
+      "enum": [
+        "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#"
+      ]
+    },   
     "handler": {
       "type": "string",
       "enum": [

--- a/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json
+++ b/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json
@@ -3,6 +3,12 @@
   "id": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string",
+      "enum": [
+        "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#"
+      ]
+    },   
     "handler": {
       "type": "string",
       "enum": [

--- a/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json
+++ b/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json
@@ -2,13 +2,13 @@
   "$schema": "http://json-schema.org/schema#",
   "id": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
   "type": "object",
-  "properties": {
-    "$schema": {
-      "type": "string",
-      "enum": [
+  "properties": {    
+    "$schema": {
+      "type": "string",
+      "enum": [
         "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#"
       ]
-    },   
+    },
     "handler": {
       "type": "string",
       "enum": [


### PR DESCRIPTION
Necessary to include "$schema" in a JSON UI source file to have VS Code and other static validators associate the correct schema.   Left $schema as an optional property so as not to break existing UI definitions.