### PR TITLE
Combined recommendedSizes and regex fixes

### DIFF
--- a/schemas/0.0.1-preview/CreateUIDefinition.CommonControl.json
+++ b/schemas/0.0.1-preview/CreateUIDefinition.CommonControl.json
@@ -459,7 +459,13 @@
           "properties": {
             "required": {
               "type": [ "boolean", "string" ]
-            }
+            },
+            "regex": {
+              "type": "string"
+            },
+            "validationMessage": {
+              "type": "string"
+            }            
           },
           "additionalProperties": false
         },

--- a/schemas/0.0.1-preview/CreateUIDefinition.CommonControl.json
+++ b/schemas/0.0.1-preview/CreateUIDefinition.CommonControl.json
@@ -460,7 +460,7 @@
             "required": {
               "type": [ "boolean", "string" ]
             },
-            "regex": {
+            "regex": {
               "type": "string"
             },
             "validationMessage": {

--- a/schemas/0.0.1-preview/CreateUIDefinition.ProviderControl.json
+++ b/schemas/0.0.1-preview/CreateUIDefinition.ProviderControl.json
@@ -170,7 +170,7 @@
           "items": {
             "type": "string"
           },
-          "minItems": 3
+          "minItems": 1
         },
         "constraints": {
           "oneOf": [

--- a/schemas/0.1.0-preview/CreateUIDefinition.CommonControl.json
+++ b/schemas/0.1.0-preview/CreateUIDefinition.CommonControl.json
@@ -459,7 +459,13 @@
           "properties": {
             "required": {
               "type": [ "boolean", "string" ]
-            }
+            },
+            "regex": {
+              "type": "string"
+            },
+            "validationMessage": {
+              "type": "string"
+            } 
           },
           "additionalProperties": false
         },

--- a/schemas/0.1.0-preview/CreateUIDefinition.ProviderControl.json
+++ b/schemas/0.1.0-preview/CreateUIDefinition.ProviderControl.json
@@ -170,7 +170,7 @@
           "items": {
             "type": "string"
           },
-          "minItems": 3
+          "minItems": 1
         },
         "constraints": {
           "oneOf": [

--- a/schemas/0.1.1-preview/CreateUIDefinition.CommonControl.json
+++ b/schemas/0.1.1-preview/CreateUIDefinition.CommonControl.json
@@ -459,7 +459,13 @@
           "properties": {
             "required": {
               "type": [ "boolean", "string" ]
-            }
+            },
+            "regex": {
+              "type": "string"
+            },
+            "validationMessage": {
+              "type": "string"
+            }           
           },
           "additionalProperties": false
         },

--- a/schemas/0.1.1-preview/CreateUIDefinition.ProviderControl.json
+++ b/schemas/0.1.1-preview/CreateUIDefinition.ProviderControl.json
@@ -170,7 +170,7 @@
           "items": {
             "type": "string"
           },
-          "minItems": 3
+          "minItems": 1
         },
         "constraints": {
           "oneOf": [

--- a/schemas/0.1.1-preview/CreateUIDefinition.ProviderControl.json
+++ b/schemas/0.1.1-preview/CreateUIDefinition.ProviderControl.json
@@ -170,7 +170,7 @@
           "items": {
             "type": "string"
           },
-          "minItems": 1
+          "minItems": 1 
         },
         "constraints": {
           "oneOf": [

--- a/schemas/0.1.2-preview/CreateUIDefinition.CommonControl.json
+++ b/schemas/0.1.2-preview/CreateUIDefinition.CommonControl.json
@@ -465,7 +465,13 @@
           "properties": {
             "required": {
               "type": [ "boolean", "string" ]
-            }
+            },
+            "regex": {
+              "type": "string"
+            },
+            "validationMessage": {
+              "type": "string"
+            }             
           },
           "additionalProperties": false
         },

--- a/schemas/0.1.2-preview/CreateUIDefinition.ProviderControl.json
+++ b/schemas/0.1.2-preview/CreateUIDefinition.ProviderControl.json
@@ -93,7 +93,7 @@
         },
         "type": {
           "type": "string",
-          "enum" : [
+          "enum": [
             "Microsoft.Common.Selector"
           ]
         },
@@ -104,7 +104,7 @@
           "type": "object",
           "properties": {
             "prevalidation": {
-              "type" : "string"
+              "type": "string"
             },
             "postvalidation": {
               "type": "string"

--- a/schemas/0.1.2-preview/CreateUIDefinition.ProviderControl.json
+++ b/schemas/0.1.2-preview/CreateUIDefinition.ProviderControl.json
@@ -93,7 +93,7 @@
         },
         "type": {
           "type": "string",
-          "enum" 3 [
+          "enum" : [
             "Microsoft.Common.Selector"
           ]
         },
@@ -104,7 +104,7 @@
           "type": "object",
           "properties": {
             "prevalidation": {
-              "type" 3 "string"
+              "type" : "string"
             },
             "postvalidation": {
               "type": "string"

--- a/schemas/0.1.2-preview/CreateUIDefinition.ProviderControl.json
+++ b/schemas/0.1.2-preview/CreateUIDefinition.ProviderControl.json
@@ -93,7 +93,7 @@
         },
         "type": {
           "type": "string",
-          "enum": [
+          "enum" 3 [
             "Microsoft.Common.Selector"
           ]
         },
@@ -104,7 +104,7 @@
           "type": "object",
           "properties": {
             "prevalidation": {
-              "type": "string"
+              "type" 3 "string"
             },
             "postvalidation": {
               "type": "string"
@@ -170,7 +170,7 @@
           "items": {
             "type": "string"
           },
-          "minItems": 3
+          "minItems": 1
         },
         "constraints": {
           "oneOf": [


### PR DESCRIPTION
Combination pull request with both of:
1. Change for VM SizeSelector Control to reduce the minimum size of the recommendedSizes array from 3 to 1.
2. Expose the regex and validationMessage constraints on the UserNameTextBox control.