### PR TITLE
Update policyDefinition rule schema

### DIFF
--- a/schemas/2016-12-01/policyDefinition.json
+++ b/schemas/2016-12-01/policyDefinition.json
@@ -1,0 +1,269 @@
+{
+  "id": "http://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Policy Definition",
+  "description": "This schema defines Azure resource policy definition, please see https://azure.microsoft.com/en-us/documentation/articles/resource-manager-policy/ for more details.",
+  "type": "object",
+  "properties": {
+    "if": {
+      "oneOf": [
+        { "$ref": "#/definitions/condition" },
+        { "$ref": "#/definitions/operatorNot" },
+        { "$ref": "#/definitions/operatorAnyOf" },
+        { "$ref": "#/definitions/operatorAllOf" }
+      ]
+    },
+    "then": {
+      "type": "object",
+      "properties": {
+        "effect": {
+          "type": "string",
+          "enum": [ "append", "audit", "auditIfNotExists", "deny" ]
+        },
+        "details": {
+          "oneOf": [
+            { "$ref": "#/definitions/ifNotExistsDetails" },
+            { "$ref": "#/definitions/appendDetails" }
+          ]
+        }
+      },
+      "required": [ "effect" ],
+      "additionalProperties": false
+    }
+  },
+  "required": [ "if", "then" ],
+  "additionalProperties": false,
+  "definitions": {
+    "appendDetails": {
+      "type": "array",
+      "items": {
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {
+          }
+        },
+        "required": [ "field", "value" ],
+        "additionalProperties": false
+      },
+      "minItems": 1,
+      "additionalItems": false
+    },
+    "ifNotExistsDetails": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "resourceGroupName": {
+          "type": "string"
+        },
+        "existenceCondition": {
+          "oneOf": [
+            { "$ref": "#/definitions/condition" },
+            { "$ref": "#/definitions/operatorNot" },
+            { "$ref": "#/definitions/operatorAnyOf" },
+            { "$ref": "#/definitions/operatorAllOf" }
+          ]
+        },
+        "deployment": {
+          "type": "object"
+        }
+      },
+      "required": [ "type" ],
+      "additionalProperties": false
+    },
+    "condition": {
+      "allOf": [
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "source": {
+                  "type": "string"
+                }
+              },
+              "required": [ "source" ]
+            },
+            {
+              "properties": {
+                "field": {
+                  "type": "string"
+                }
+              },
+              "required": [ "field" ]
+            }
+          ]
+        },
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "equals": {
+                  "type": "string"
+                }
+              },
+              "required": [ "equals" ]
+            },
+            {
+              "properties": {
+                "notEquals": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notEquals" ]
+            },
+            {
+              "properties": {
+                "like": {
+                  "type": "string"
+                }
+              },
+              "required": [ "like" ]
+            },
+            {
+              "properties": {
+                "notLike": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notLike" ]
+            },
+            {
+              "properties": {
+                "contains": {
+                  "type": "string"
+                }
+              },
+              "required": [ "contains" ]
+            },
+            {
+              "properties": {
+                "notContains": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notContains" ]
+            },
+            {
+              "properties": {
+                "in": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [ "in" ]
+            },
+            {
+              "properties": {
+                "notIn": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [ "notIn" ]
+            },
+            {
+              "properties": {
+                "containsKey": {
+                  "type": "string"
+                }
+              },
+              "required": [ "containsKey" ]
+            },
+            {
+              "properties": {
+                "notContainsKey": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notContainsKey" ]
+            },
+            {
+              "properties": {
+                "match": {
+                  "type": "string"
+                }
+              },
+              "required": [ "match" ]
+            },
+            {
+              "properties": {
+                "notMatch": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notMatch" ]
+            },
+            {
+              "properties": {
+                "exists": {
+                  "type": "string"
+                }
+              },
+              "required": [ "exists" ]
+            }
+          ]
+        }
+      ]
+    },
+    "operatorNot": {
+      "properties": {
+        "not": {
+          "oneOf": [
+            { "$ref": "#/definitions/condition" },
+            { "$ref": "#/definitions/operatorNot" },
+            { "$ref": "#/definitions/operatorAnyOf" },
+            { "$ref": "#/definitions/operatorAllOf" }
+          ]
+        }
+      },
+      "required": [ "not" ],
+      "additionalProperties": false
+    },
+    "operatorAnyOf": {
+      "properties": {
+        "anyOf": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              { "$ref": "#/definitions/condition" },
+              { "$ref": "#/definitions/operatorNot" },
+              { "$ref": "#/definitions/operatorAnyOf" },
+              { "$ref": "#/definitions/operatorAllOf" }
+            ]
+          }
+        }
+      },
+      "required": [ "anyOf" ],
+      "additionalProperties": false
+    },
+    "operatorAllOf": {
+      "properties": {
+        "allOf": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              { "$ref": "#/definitions/condition" },
+              { "$ref": "#/definitions/operatorNot" },
+              { "$ref": "#/definitions/operatorAnyOf" },
+              { "$ref": "#/definitions/operatorAllOf" }
+            ]
+          }
+        }
+      },
+      "required": [ "allOf" ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/2016-12-01/policyDefinition.json
+++ b/schemas/2016-12-01/policyDefinition.json
@@ -152,10 +152,10 @@
             {
               "properties": {
                 "in": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "oneOf": [
+                    { "type": "array" },
+                    { "type": "string" }
+                  ]
                 }
               },
               "required": [ "in" ]
@@ -163,10 +163,10 @@
             {
               "properties": {
                 "notIn": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "oneOf": [
+                    { "type": "array" },
+                    { "type": "string" }
+                  ]
                 }
               },
               "required": [ "notIn" ]

--- a/tests/2016-12-01/policyDefinition.tests.json
+++ b/tests/2016-12-01/policyDefinition.tests.json
@@ -243,16 +243,10 @@
     {
       "name": "PolicyDefinition tests - string for array operator",
       "definition": "http://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
-      "expectedErrors": [
-        {
-          "message": "Data does not match any schemas from \"oneOf\"",
-          "dataPath": "/if"
-        }
-      ],
       "json": {
         "if": {
           "field": "location",
-          "notIn": "foo"
+          "notIn": "[parameters('foo')]"
         },
         "then": {
           "effect": "deny"

--- a/tests/2016-12-01/policyDefinition.tests.json
+++ b/tests/2016-12-01/policyDefinition.tests.json
@@ -1,0 +1,263 @@
+{
+  "tests": [
+    {
+      "name": "PolicyDefinition tests - valid minimal rule",
+      "definition": "http://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "location",
+          "equals": "westus"
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - valid complex rule",
+      "definition": "http://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "not": {
+            "anyOf": [
+              {
+                "field": "type",
+                "equals": "Microsoft.SQL/servers"
+              },
+              {
+                "source": "action",
+                "equals": "asdkfjkladsf"
+              },
+              {
+                "not": {
+                  "allOf": [
+                    {
+                      "field": "foo",
+                      "notIn": [ "foo12", "asdf", "asdf" ]
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "then": {
+          "effect": "audit"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - valid append details",
+      "definition": "http://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "append",
+          "details": [
+            {
+              "field": "tags.location",
+              "value": "westus"
+            },
+            {
+              "field": "tags.foo",
+              "value": "bar"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - minmal ifNotExists details",
+      "definition": "http://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "auditIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions"
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - complex ifNotExists details",
+      "definition": "http://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "auditIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "resourceGroupName": "myRG",
+            "name": "myResource",
+            "existenceCondition": {
+              "not": {
+                "field": "location",
+                "in": [ "eastus", "westeurope" ]
+              }
+            },
+            "deployment": {
+              "name": "myDeployment",
+              "template": {
+                "resources": [
+                  {
+                    "type": "Microsoft.Compute/virtualMachines",
+                    "name": "MyVirtualMachine"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid ifNotExists existenceCondition",
+      "definition": "http://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "auditIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "existenceCondition": {
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - missing append details",
+      "definition": "http://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "append",
+          "details": []
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid effect",
+      "definition": "http://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "No enum match for: \"foo\"",
+          "dataPath": "/then/effect"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "location",
+          "equals": "westus"
+        },
+        "then": {
+          "effect": "foo"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid field property",
+      "definition": "http://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/if"
+        }
+      ],
+      "json": {
+        "if": {
+          "field2": "location",
+          "equals": "westus"
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid operator",
+      "definition": "http://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/if"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "location",
+          "notEqualTo": "westus"
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - array for non-array operator",
+      "definition": "http://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/if"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "location",
+          "equals": [ "foo" ]
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - string for array operator",
+      "definition": "http://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/if"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "location",
+          "notIn": "foo"
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The original policyDefinition rule schema lives in schemas/2015-10-01-preview.  This update brings it in line with the currently available rule language and adds tests.

See https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-policy for details on Azure Resource Policy.