### PR TITLE
Move CommonControls to help Intellisense

### DIFF
--- a/schemas/0.0.1-preview/CreateUIDefinition.ProviderControl.json
+++ b/schemas/0.0.1-preview/CreateUIDefinition.ProviderControl.json
@@ -3,23 +3,6 @@
   "id": "https://schema.management.azure.com/schemas/0.0.1-preview/CreateUIDefinition.ProviderControl.json#",
   "oneOf": [
     {
-      "allOf": [
-        {
-          "$ref": "CreateUIDefinition.CommonControl.json#"
-        },
-        {
-          "not": {
-            "$ref": "CreateUIDefinition.CommonControl.json#/definitions/Microsoft.Common.Section-common"
-          }
-        },
-        {
-          "not": {
-            "$ref": "CreateUIDefinition.CommonControl.json#/definitions/Microsoft.Common.Selector-common"
-          }
-        }
-      ]
-    },
-    {
       "$ref": "#/definitions/Microsoft.Common.Selector-provider"
     },
     {
@@ -39,7 +22,24 @@
     },
     {
       "$ref": "#/definitions/Microsoft.Common.Section-provider"
-    }
+    },
+    {
+      "allOf": [
+        {
+          "$ref": "CreateUIDefinition.CommonControl.json#"
+        },
+        {
+          "not": {
+            "$ref": "CreateUIDefinition.CommonControl.json#/definitions/Microsoft.Common.Section-common"
+          }
+        },
+        {
+          "not": {
+            "$ref": "CreateUIDefinition.CommonControl.json#/definitions/Microsoft.Common.Selector-common"
+          }
+        }
+      ]
+    },
   ],
   "definitions": {
     "Microsoft.Common.Section-provider": {

--- a/schemas/0.0.1-preview/CreateUIDefinition.ProviderControl.json
+++ b/schemas/0.0.1-preview/CreateUIDefinition.ProviderControl.json
@@ -39,7 +39,7 @@
           }
         }
       ]
-    },
+    }
   ],
   "definitions": {
     "Microsoft.Common.Section-provider": {

--- a/schemas/0.1.0-preview/CreateUIDefinition.ProviderControl.json
+++ b/schemas/0.1.0-preview/CreateUIDefinition.ProviderControl.json
@@ -2,24 +2,7 @@
   "$schema": "http://json-schema.org/schema#",
   "id": "https://schema.management.azure.com/schemas/0.1.0-preview/CreateUIDefinition.ProviderControl.json#",
   "oneOf": [
-    {
-      "allOf": [
-        {
-          "$ref": "CreateUIDefinition.CommonControl.json#"
-        },
-        {
-          "not": {
-            "$ref": "CreateUIDefinition.CommonControl.json#/definitions/Microsoft.Common.Section-common"
-          }
-        },
-        {
-          "not": {
-            "$ref": "CreateUIDefinition.CommonControl.json#/definitions/Microsoft.Common.Selector-common"
-          }
-        }
-      ]
-    },
-    {
+     {
       "$ref": "#/definitions/Microsoft.Common.Selector-provider"
     },
     {
@@ -39,6 +22,23 @@
     },
     {
       "$ref": "#/definitions/Microsoft.Common.Section-provider"
+    },
+    {
+      "allOf": [
+        {
+          "$ref": "CreateUIDefinition.CommonControl.json#"
+        },
+        {
+          "not": {
+            "$ref": "CreateUIDefinition.CommonControl.json#/definitions/Microsoft.Common.Section-common"
+          }
+        },
+        {
+          "not": {
+            "$ref": "CreateUIDefinition.CommonControl.json#/definitions/Microsoft.Common.Selector-common"
+          }
+        }
+      ]
     }
   ],
   "definitions": {

--- a/schemas/0.1.1-preview/CreateUIDefinition.ProviderControl.json
+++ b/schemas/0.1.1-preview/CreateUIDefinition.ProviderControl.json
@@ -3,23 +3,6 @@
   "id": "https://schema.management.azure.com/schemas/0.1.1-preview/CreateUIDefinition.ProviderControl.json#",
   "oneOf": [
     {
-      "allOf": [
-        {
-          "$ref": "CreateUIDefinition.CommonControl.json#"
-        },
-        {
-          "not": {
-            "$ref": "CreateUIDefinition.CommonControl.json#/definitions/Microsoft.Common.Section-common"
-          }
-        },
-        {
-          "not": {
-            "$ref": "CreateUIDefinition.CommonControl.json#/definitions/Microsoft.Common.Selector-common"
-          }
-        }
-      ]
-    },
-    {
       "$ref": "#/definitions/Microsoft.Common.Selector-provider"
     },
     {
@@ -39,6 +22,23 @@
     },
     {
       "$ref": "#/definitions/Microsoft.Common.Section-provider"
+    },
+    {
+      "allOf": [
+        {
+          "$ref": "CreateUIDefinition.CommonControl.json#"
+        },
+        {
+          "not": {
+            "$ref": "CreateUIDefinition.CommonControl.json#/definitions/Microsoft.Common.Section-common"
+          }
+        },
+        {
+          "not": {
+            "$ref": "CreateUIDefinition.CommonControl.json#/definitions/Microsoft.Common.Selector-common"
+          }
+        }
+      ]
     }
   ],
   "definitions": {

--- a/schemas/0.1.2-preview/CreateUIDefinition.ProviderControl.json
+++ b/schemas/0.1.2-preview/CreateUIDefinition.ProviderControl.json
@@ -3,23 +3,6 @@
   "id": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.ProviderControl.json#",
   "oneOf": [
     {
-      "allOf": [
-        {
-          "$ref": "CreateUIDefinition.CommonControl.json#"
-        },
-        {
-          "not": {
-            "$ref": "CreateUIDefinition.CommonControl.json#/definitions/Microsoft.Common.Section-common"
-          }
-        },
-        {
-          "not": {
-            "$ref": "CreateUIDefinition.CommonControl.json#/definitions/Microsoft.Common.Selector-common"
-          }
-        }
-      ]
-    },
-    {
       "$ref": "#/definitions/Microsoft.Common.Selector-provider"
     },
     {
@@ -39,6 +22,23 @@
     },
     {
       "$ref": "#/definitions/Microsoft.Common.Section-provider"
+    },
+    {
+      "allOf": [
+        {
+          "$ref": "CreateUIDefinition.CommonControl.json#"
+        },
+        {
+          "not": {
+            "$ref": "CreateUIDefinition.CommonControl.json#/definitions/Microsoft.Common.Section-common"
+          }
+        },
+        {
+          "not": {
+            "$ref": "CreateUIDefinition.CommonControl.json#/definitions/Microsoft.Common.Selector-common"
+          }
+        }
+      ]
     }
   ],
   "definitions": {


### PR DESCRIPTION
Move common controls to come after Provider controls in the list of permitted control types.  This results in better Intellisense suggestions for Steps controls that are malformed by having extra properties, etc.