### PR TITLE
Hot fix for NIC schemas

### DIFF
--- a/schemas/2017-06-01/Microsoft.Network.json
+++ b/schemas/2017-06-01/Microsoft.Network.json
@@ -4572,17 +4572,6 @@
     "NetworkInterfacePropertiesFormat": {
       "type": "object",
       "properties": {
-        "virtualMachine": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/SubResource"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-            }
-          ],
-          "description": "The reference of a virtual machine."
-        },
         "networkSecurityGroup": {
           "oneOf": [
             {

--- a/schemas/2017-08-01/Microsoft.Network.json
+++ b/schemas/2017-08-01/Microsoft.Network.json
@@ -4772,17 +4772,6 @@
     "NetworkInterfacePropertiesFormat": {
       "type": "object",
       "properties": {
-        "virtualMachine": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/SubResource"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-            }
-          ],
-          "description": "The reference of a virtual machine."
-        },
         "networkSecurityGroup": {
           "oneOf": [
             {

--- a/schemas/2017-09-01/Microsoft.Network.json
+++ b/schemas/2017-09-01/Microsoft.Network.json
@@ -5402,17 +5402,6 @@
     "NetworkInterfacePropertiesFormat": {
       "type": "object",
       "properties": {
-        "virtualMachine": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/SubResource"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-            }
-          ],
-          "description": "The reference of a virtual machine."
-        },
         "networkSecurityGroup": {
           "oneOf": [
             {

--- a/schemas/2017-10-01/Microsoft.Network.json
+++ b/schemas/2017-10-01/Microsoft.Network.json
@@ -5362,17 +5362,6 @@
     "NetworkInterfacePropertiesFormat": {
       "type": "object",
       "properties": {
-        "virtualMachine": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/SubResource"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-            }
-          ],
-          "description": "The reference of a virtual machine."
-        },
         "networkSecurityGroup": {
           "oneOf": [
             {

--- a/schemas/2017-11-01/Microsoft.Network.json
+++ b/schemas/2017-11-01/Microsoft.Network.json
@@ -5080,17 +5080,6 @@
     "NetworkInterfacePropertiesFormat": {
       "type": "object",
       "properties": {
-        "virtualMachine": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/SubResource"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-            }
-          ],
-          "description": "The reference of a virtual machine."
-        },
         "networkSecurityGroup": {
           "oneOf": [
             {

--- a/schemas/2018-01-01/Microsoft.Network.json
+++ b/schemas/2018-01-01/Microsoft.Network.json
@@ -5104,17 +5104,6 @@
     "NetworkInterfacePropertiesFormat": {
       "type": "object",
       "properties": {
-        "virtualMachine": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/SubResource"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-            }
-          ],
-          "description": "The reference of a virtual machine."
-        },
         "networkSecurityGroup": {
           "oneOf": [
             {

--- a/schemas/2018-02-01/Microsoft.Network.json
+++ b/schemas/2018-02-01/Microsoft.Network.json
@@ -5632,17 +5632,6 @@
     "NetworkInterfacePropertiesFormat": {
       "type": "object",
       "properties": {
-        "virtualMachine": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/SubResource"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-            }
-          ],
-          "description": "The reference of a virtual machine."
-        },
         "networkSecurityGroup": {
           "oneOf": [
             {


### PR DESCRIPTION
VM reference on the nic is not marked as readonly this is causing the vm reference on the nic to be present when we generate the schema.
Currently we fix this manually for the older versions. [Fix for the newer versions](https://github.com/Azure/azure-rest-api-specs/pull/3118) was sent.

Please contact @DeepakRajendranMsft in case more details required.