### PR TITLE
Updated for TextBlock and InfoBox Controls

### DIFF
--- a/schemas/0.1.2-preview/CreateUIDefinition.CommonControl.json
+++ b/schemas/0.1.2-preview/CreateUIDefinition.CommonControl.json
@@ -1,7 +1,13 @@
-﻿{
+{
   "$schema": "http://json-schema.org/schema#",
   "id": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.CommonControl.json#",
   "oneOf": [
+    {
+      "$ref": "#/definitions/Microsoft.Common.TextBlock"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.Common.InfoBox"
+    },
     {
       "$ref": "#/definitions/Microsoft.Common.TextBox"
     },
@@ -275,6 +281,120 @@
         "constraints"
       ]
     },
+    "Microsoft.Common.TextBlock": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Common.TextBlock"
+          ]
+        },
+        "options": {
+          "type": "object",
+          "oneOf": [
+            {
+              "properties": {
+                "text": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "text"
+              ]
+            },
+            {
+              "properties": {
+                "text": {
+                  "type": "string"
+                },
+                "link": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "uri": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "label",
+                    "uri"
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "link"
+              ]
+            }
+          ]
+        },
+        "visible": {
+          "type": [ "boolean", "string" ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "options"
+      ]
+    },
+    "Microsoft.Common.InfoBox": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Common.InfoBox"
+          ]
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "icon": {
+              "type": "string",
+              "enum": [
+                "None",
+                "Info",
+                "Warning",
+                "Error"
+              ]
+            },
+            "text": {
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "icon",
+            "text"
+          ]
+        },
+        "visible": {
+          "type": [ "boolean", "string" ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "options"
+      ]
+    },
     "Microsoft.Common.FileUpload": {
       "type": "object",
       "properties": {
@@ -471,7 +591,7 @@
             },
             "validationMessage": {
               "type": "string"
-            }             
+            }
           },
           "additionalProperties": false
         },


### PR DESCRIPTION
Updated 0.1.2-preview schema to include both controls.  As per docs:
- [TextBlock ](https://docs.microsoft.com/en-us/azure/managed-applications/microsoft-common-textbox)enforces one of text, text + link or just link.  Link must include both label and uri.
- [InfoBox](https://docs.microsoft.com/en-us/azure/managed-applications/microsoft-common-infobox) enforces values for icon.  It requires both icon and text.  uri is optional.

**Note:** I've only updated this latest schema version -- this is an example of where we should say that new controls are only going in the newest schema version.  i.e. No need to retrofit this same set of changes backwards into the other 3 schema versions.