### PR TITLE
policyDefinition rule schema (2018-05-01)

### DIFF
--- a/schemas/2018-05-01/policyDefinition.json
+++ b/schemas/2018-05-01/policyDefinition.json
@@ -1,0 +1,269 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Policy Definition",
+  "description": "This schema defines Azure resource policy definition, please see https://azure.microsoft.com/en-us/documentation/articles/resource-manager-policy/ for more details.",
+  "type": "object",
+  "properties": {
+    "if": {
+      "oneOf": [
+        { "$ref": "#/definitions/condition" },
+        { "$ref": "#/definitions/operatorNot" },
+        { "$ref": "#/definitions/operatorAnyOf" },
+        { "$ref": "#/definitions/operatorAllOf" }
+      ]
+    },
+    "then": {
+      "type": "object",
+      "properties": {
+        "effect": {
+          "type": "string",
+          "enum": [ "append", "audit", "auditIfNotExists", "deny" ]
+        },
+        "details": {
+          "oneOf": [
+            { "$ref": "#/definitions/ifNotExistsDetails" },
+            { "$ref": "#/definitions/appendDetails" }
+          ]
+        }
+      },
+      "required": [ "effect" ],
+      "additionalProperties": false
+    }
+  },
+  "required": [ "if", "then" ],
+  "additionalProperties": false,
+  "definitions": {
+    "appendDetails": {
+      "type": "array",
+      "items": {
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {
+          }
+        },
+        "required": [ "field", "value" ],
+        "additionalProperties": false
+      },
+      "minItems": 1,
+      "additionalItems": false
+    },
+    "ifNotExistsDetails": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "resourceGroupName": {
+          "type": "string"
+        },
+        "existenceCondition": {
+          "oneOf": [
+            { "$ref": "#/definitions/condition" },
+            { "$ref": "#/definitions/operatorNot" },
+            { "$ref": "#/definitions/operatorAnyOf" },
+            { "$ref": "#/definitions/operatorAllOf" }
+          ]
+        },
+        "deployment": {
+          "type": "object"
+        }
+      },
+      "required": [ "type" ],
+      "additionalProperties": false
+    },
+    "condition": {
+      "allOf": [
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "source": {
+                  "type": "string"
+                }
+              },
+              "required": [ "source" ]
+            },
+            {
+              "properties": {
+                "field": {
+                  "type": "string"
+                }
+              },
+              "required": [ "field" ]
+            }
+          ]
+        },
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "equals": {
+                  "type": "string"
+                }
+              },
+              "required": [ "equals" ]
+            },
+            {
+              "properties": {
+                "notEquals": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notEquals" ]
+            },
+            {
+              "properties": {
+                "like": {
+                  "type": "string"
+                }
+              },
+              "required": [ "like" ]
+            },
+            {
+              "properties": {
+                "notLike": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notLike" ]
+            },
+            {
+              "properties": {
+                "contains": {
+                  "type": "string"
+                }
+              },
+              "required": [ "contains" ]
+            },
+            {
+              "properties": {
+                "notContains": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notContains" ]
+            },
+            {
+              "properties": {
+                "in": {
+                  "oneOf": [
+                    { "type": "array" },
+                    { "type": "string" }
+                  ]
+                }
+              },
+              "required": [ "in" ]
+            },
+            {
+              "properties": {
+                "notIn": {
+                  "oneOf": [
+                    { "type": "array" },
+                    { "type": "string" }
+                  ]
+                }
+              },
+              "required": [ "notIn" ]
+            },
+            {
+              "properties": {
+                "containsKey": {
+                  "type": "string"
+                }
+              },
+              "required": [ "containsKey" ]
+            },
+            {
+              "properties": {
+                "notContainsKey": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notContainsKey" ]
+            },
+            {
+              "properties": {
+                "match": {
+                  "type": "string"
+                }
+              },
+              "required": [ "match" ]
+            },
+            {
+              "properties": {
+                "notMatch": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notMatch" ]
+            },
+            {
+              "properties": {
+                "exists": {
+                  "type": "string"
+                }
+              },
+              "required": [ "exists" ]
+            }
+          ]
+        }
+      ]
+    },
+    "operatorNot": {
+      "properties": {
+        "not": {
+          "oneOf": [
+            { "$ref": "#/definitions/condition" },
+            { "$ref": "#/definitions/operatorNot" },
+            { "$ref": "#/definitions/operatorAnyOf" },
+            { "$ref": "#/definitions/operatorAllOf" }
+          ]
+        }
+      },
+      "required": [ "not" ],
+      "additionalProperties": false
+    },
+    "operatorAnyOf": {
+      "properties": {
+        "anyOf": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              { "$ref": "#/definitions/condition" },
+              { "$ref": "#/definitions/operatorNot" },
+              { "$ref": "#/definitions/operatorAnyOf" },
+              { "$ref": "#/definitions/operatorAllOf" }
+            ]
+          }
+        }
+      },
+      "required": [ "anyOf" ],
+      "additionalProperties": false
+    },
+    "operatorAllOf": {
+      "properties": {
+        "allOf": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              { "$ref": "#/definitions/condition" },
+              { "$ref": "#/definitions/operatorNot" },
+              { "$ref": "#/definitions/operatorAnyOf" },
+              { "$ref": "#/definitions/operatorAllOf" }
+            ]
+          }
+        }
+      },
+      "required": [ "allOf" ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/2018-05-01/policyDefinition.json
+++ b/schemas/2018-05-01/policyDefinition.json
@@ -81,7 +81,12 @@
           ]
         },
         "deployment": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "properties": {
+              "$ref": "https://schema.management.azure.com/schemas/2018-05-01/Microsoft.Resources.json#/definitions/DeploymentProperties"
+            }
+          }
         }
       },
       "required": [ "type" ],

--- a/schemas/2018-05-01/policyDefinition.json
+++ b/schemas/2018-05-01/policyDefinition.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+  "id": "https://schema.management.azure.com/schemas/2018-05-01/policyDefinition.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Policy Definition",
   "description": "This schema defines Azure resource policy definition, please see https://azure.microsoft.com/en-us/documentation/articles/resource-manager-policy/ for more details.",
@@ -18,7 +18,7 @@
       "properties": {
         "effect": {
           "type": "string",
-          "enum": [ "append", "audit", "auditIfNotExists", "deny" ]
+          "enum": [ "append", "audit", "auditIfNotExists", "deny", "deployIfNotExists" ]
         },
         "details": {
           "oneOf": [
@@ -61,6 +61,16 @@
         },
         "resourceGroupName": {
           "type": "string"
+        },
+        "existenceScope": {
+          "type": "string",
+          "enum": [ "resourceGroup", "subscription" ]
+        },
+        "roleDefinitionIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "existenceCondition": {
           "oneOf": [

--- a/tests/2018-05-01/policyDefinition.tests.json
+++ b/tests/2018-05-01/policyDefinition.tests.json
@@ -1,0 +1,257 @@
+{
+  "tests": [
+    {
+      "name": "PolicyDefinition tests - valid minimal rule",
+      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "location",
+          "equals": "westus"
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - valid complex rule",
+      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "not": {
+            "anyOf": [
+              {
+                "field": "type",
+                "equals": "Microsoft.SQL/servers"
+              },
+              {
+                "source": "action",
+                "equals": "asdkfjkladsf"
+              },
+              {
+                "not": {
+                  "allOf": [
+                    {
+                      "field": "foo",
+                      "notIn": [ "foo12", "asdf", "asdf" ]
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "then": {
+          "effect": "audit"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - valid append details",
+      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "append",
+          "details": [
+            {
+              "field": "tags.location",
+              "value": "westus"
+            },
+            {
+              "field": "tags.foo",
+              "value": "bar"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - minmal ifNotExists details",
+      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "auditIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions"
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - complex ifNotExists details",
+      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "auditIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "resourceGroupName": "myRG",
+            "name": "myResource",
+            "existenceCondition": {
+              "not": {
+                "field": "location",
+                "in": [ "eastus", "westeurope" ]
+              }
+            },
+            "deployment": {
+              "name": "myDeployment",
+              "template": {
+                "resources": [
+                  {
+                    "type": "Microsoft.Compute/virtualMachines",
+                    "name": "MyVirtualMachine"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid ifNotExists existenceCondition",
+      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "auditIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "existenceCondition": {
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - missing append details",
+      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "append",
+          "details": []
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid effect",
+      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "No enum match for: \"foo\"",
+          "dataPath": "/then/effect"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "location",
+          "equals": "westus"
+        },
+        "then": {
+          "effect": "foo"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid field property",
+      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/if"
+        }
+      ],
+      "json": {
+        "if": {
+          "field2": "location",
+          "equals": "westus"
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid operator",
+      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/if"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "location",
+          "notEqualTo": "westus"
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - array for non-array operator",
+      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/if"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "location",
+          "equals": [ "foo" ]
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - string for array operator",
+      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "location",
+          "notIn": "[parameters('foo')]"
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    }
+  ]
+}

--- a/tests/2018-05-01/policyDefinition.tests.json
+++ b/tests/2018-05-01/policyDefinition.tests.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "name": "PolicyDefinition tests - valid minimal rule",
-      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2018-05-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "location",
@@ -15,7 +15,7 @@
     },
     {
       "name": "PolicyDefinition tests - valid complex rule",
-      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2018-05-01/policyDefinition.json#",
       "json": {
         "if": {
           "not": {
@@ -48,7 +48,7 @@
     },
     {
       "name": "PolicyDefinition tests - valid append details",
-      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2018-05-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "tags",
@@ -71,7 +71,7 @@
     },
     {
       "name": "PolicyDefinition tests - minmal ifNotExists details",
-      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2018-05-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "tags",
@@ -87,7 +87,7 @@
     },
     {
       "name": "PolicyDefinition tests - complex ifNotExists details",
-      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2018-05-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "tags",
@@ -105,6 +105,8 @@
                 "in": [ "eastus", "westeurope" ]
               }
             },
+            "existenceScope": "subscription",
+            "roleDefinitionIds": [ "/providers/microsoft.authorization/roleDefinitions/d0610b27-9663-4c05-89f8-5b4be01e86a5" ],
             "deployment": {
               "name": "myDeployment",
               "template": {
@@ -122,7 +124,7 @@
     },
     {
       "name": "PolicyDefinition tests - invalid ifNotExists existenceCondition",
-      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2018-05-01/policyDefinition.json#",
       "expectedErrors": [
         {
           "message": "Data does not match any schemas from \"oneOf\"",
@@ -145,8 +147,31 @@
       }
     },
     {
+      "name": "PolicyDefinition tests - invalid ifNotExists existenceScope",
+      "definition": "https://schema.management.azure.com/schemas/2018-05-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "auditIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "existenceScope": "foo"
+          }
+        }
+      }
+    },
+    {
       "name": "PolicyDefinition tests - missing append details",
-      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2018-05-01/policyDefinition.json#",
       "expectedErrors": [
         {
           "message": "Data does not match any schemas from \"oneOf\"",
@@ -166,7 +191,7 @@
     },
     {
       "name": "PolicyDefinition tests - invalid effect",
-      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2018-05-01/policyDefinition.json#",
       "expectedErrors": [
         {
           "message": "No enum match for: \"foo\"",
@@ -185,7 +210,7 @@
     },
     {
       "name": "PolicyDefinition tests - invalid field property",
-      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2018-05-01/policyDefinition.json#",
       "expectedErrors": [
         {
           "message": "Data does not match any schemas from \"oneOf\"",
@@ -204,7 +229,7 @@
     },
     {
       "name": "PolicyDefinition tests - invalid operator",
-      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2018-05-01/policyDefinition.json#",
       "expectedErrors": [
         {
           "message": "Data does not match any schemas from \"oneOf\"",
@@ -223,7 +248,7 @@
     },
     {
       "name": "PolicyDefinition tests - array for non-array operator",
-      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2018-05-01/policyDefinition.json#",
       "expectedErrors": [
         {
           "message": "Data does not match any schemas from \"oneOf\"",
@@ -242,7 +267,7 @@
     },
     {
       "name": "PolicyDefinition tests - string for array operator",
-      "definition": "https://schema.management.azure.com/schemas/2016-12-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2018-05-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "location",

--- a/tests/2018-05-01/policyDefinition.tests.json
+++ b/tests/2018-05-01/policyDefinition.tests.json
@@ -108,14 +108,300 @@
             "existenceScope": "subscription",
             "roleDefinitionIds": [ "/providers/microsoft.authorization/roleDefinitions/d0610b27-9663-4c05-89f8-5b4be01e86a5" ],
             "deployment": {
-              "name": "myDeployment",
-              "template": {
-                "resources": [
-                  {
-                    "type": "Microsoft.Compute/virtualMachines",
-                    "name": "MyVirtualMachine"
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "resources": [
+                    {
+                      "type": "Microsoft.Compute/virtualMachines",
+                      "name": "MyVirtualMachine",
+                      "apiVersion": "2018-06-01"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid deployIfNotExists deployment template",
+      "definition": "https://schema.management.azure.com/schemas/2018-05-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "type",
+          "equals": "Microsoft.Compute/virtualMachines"
+        },
+        "then": {
+          "effect": "deployIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "existenceCondition": {
+              "field": "Microsoft.Compute/virtualMachines/extensions/type",
+              "equals": "OmsAgentForLinux"
+            },
+            "roleDefinitionIds": [
+              "/providers/microsoft.authorization/roleDefinitions/d0610b27-9663-4c05-89f8-5b4be01e86a5"
+            ],
+            "deployment": {
+              "properties": {
+                "template": {
+                  "resources": [
+                    {
+                      "type": "Microsoft.Compute/virtualMachines",
+                      "name": "MyVirtualMachine",
+                      "apiVersion": "2018-06-01"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - complex deployIfNotExists deployment",
+      "definition": "https://schema.management.azure.com/schemas/2018-05-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.Compute/virtualMachines"
+            },
+            {
+              "anyOf": [
+                {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "RedHat"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "in": [
+                        "RHEL",
+                        "RHEL-SAP-HANA"
+                      ]
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "6.*"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "7*"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "SUSE"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "in": [
+                        "SLES",
+                        "SLES-SAP",
+                        "SLES-SAP-BYOS",
+                        "SLES-Priority",
+                        "SLES-BYOS",
+                        "SLES-SAPCAL",
+                        "sles-byos"
+                      ]
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "12*"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "Canonical"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "equals": "UbuntuServer"
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "14.04*LTS"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "16.04*LTS"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "18.04*LTS"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "Oracle"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "equals": "Oracle-Linux"
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "6.*"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "7.*"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "OpenLogic"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "in": [
+                        "CentOS",
+                        "Centos-LVM"
+                      ]
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "6.*"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "7*"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "then": {
+          "effect": "deployIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "roleDefinitionIds": [
+              "/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293"
+            ],
+            "existenceCondition": {
+              "allOf": [
+                {
+                  "field": "Microsoft.Compute/virtualMachines/extensions/type",
+                  "equals": "OmsAgentForLinux"
+                },
+                {
+                  "field": "Microsoft.Compute/virtualMachines/extensions/publisher",
+                  "equals": "Microsoft.EnterpriseCloud.Monitoring"
+                },
+                {
+                  "field": "Microsoft.Compute/virtualMachines/extensions/provisioningState",
+                  "equals": "Succeeded"
+                }
+              ]
+            },
+            "deployment": {
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {
+                    "vmName": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "logAnalytics": {
+                      "type": "string"
+                    }
+                  },
+                  "variables": {
+                    "vmExtensionName": "MMAExtension",
+                    "vmExtensionPublisher": "Microsoft.EnterpriseCloud.Monitoring",
+                    "vmExtensionType": "OmsAgentForLinux",
+                    "vmExtensionTypeHandlerVersion": "1.7"
+                  },
+                  "resources": [
+                    {
+                      "name": "[concat(parameters('vmName'), '/', variables('vmExtensionName'))]",
+                      "type": "Microsoft.Compute/virtualMachines/extensions",
+                      "location": "[parameters('location')]",
+                      "apiVersion": "2018-06-01",
+                      "properties": {
+                        "publisher": "[variables('vmExtensionPublisher')]",
+                        "type": "[variables('vmExtensionType')]",
+                        "typeHandlerVersion": "[variables('vmExtensionTypeHandlerVersion')]",
+                        "autoUpgradeMinorVersion": true,
+                        "settings": {
+                          "workspaceId": "[reference(parameters('logAnalytics'), '2015-03-20').customerId]",
+                          "stopOnMultipleConnections": "true"
+                        },
+                        "protectedSettings": {
+                          "workspaceKey": "[listKeys(parameters('logAnalytics'), '2015-03-20').primarySharedKey]"
+                        }
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "policy": {
+                      "type": "string",
+                      "value": "[concat('Enabled extension for VM', ': ', parameters('vmName'))]"
+                    }
                   }
-                ]
+                },
+                "parameters": {
+                  "vmName": {
+                    "value": "[field('name')]"
+                  },
+                  "location": {
+                    "value": "[field('location')]"
+                  },
+                  "logAnalytics": {
+                    "value": "[parameters('logAnalytics')]"
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
Updating the policyDefinition rule schema to account for recent changes.  The latest api-version is 2018-05-01.  

This schema file is not a resource type in ARM.  It is purely the schema used for Azure Resource Policy rules and is consumed in the JSON editor in the Portal as well as by standalone tooling for policy authors.  

Compare  the second commit against the first to see the delta from the previous api-version (2016-12-01).