### PR TITLE
onboarding schemas for SignalR service 2018-10-01

### DIFF
--- a/schemas/2014-04-01-preview/deploymentTemplate.json
+++ b/schemas/2014-04-01-preview/deploymentTemplate.json
@@ -789,6 +789,7 @@
                   { "$ref": "https://schema.management.azure.com/schemas/2016-10-01/Microsoft.StorSimple.json#/resourceDefinitions/managers_storageDomains" },
                   { "$ref": "https://schema.management.azure.com/schemas/2017-01-01/Microsoft.AAD.json#/resourceDefinitions/domainServices" },
                   { "$ref": "https://schema.management.azure.com/schemas/2017-06-01/Microsoft.AAD.json#/resourceDefinitions/domainServices" },
+                  { "$ref": "https://schema.management.azure.com/schemas/2018-10-01/Microsoft.SignalRService.json#/resourceDefinitions/SignalR" },
                   { "$ref": "#/definitions/resourceGeneric" }
                 ]
               }

--- a/schemas/2015-01-01/deploymentTemplate.json
+++ b/schemas/2015-01-01/deploymentTemplate.json
@@ -798,7 +798,8 @@
                   { "$ref": "https://schema.management.azure.com/schemas/2016-10-01/Microsoft.StorSimple.json#/resourceDefinitions/managers_storageAccountCredentials" },
                   { "$ref": "https://schema.management.azure.com/schemas/2016-10-01/Microsoft.StorSimple.json#/resourceDefinitions/managers_storageDomains" },
                   { "$ref": "https://schema.management.azure.com/schemas/2017-01-01/Microsoft.AAD.json#/resourceDefinitions/domainServices" },
-                  { "$ref": "https://schema.management.azure.com/schemas/2017-06-01/Microsoft.AAD.json#/resourceDefinitions/domainServices" }
+                  { "$ref": "https://schema.management.azure.com/schemas/2017-06-01/Microsoft.AAD.json#/resourceDefinitions/domainServices" },
+                  { "$ref": "https://schema.management.azure.com/schemas/2018-10-01/Microsoft.SignalRService.json#/resourceDefinitions/SignalR" }
                 ]
               }
             ]

--- a/schemas/2018-10-01/Microsoft.SignalRService.json
+++ b/schemas/2018-10-01/Microsoft.SignalRService.json
@@ -1,0 +1,138 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2018-10-01/Microsoft.SignalRService.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.SignalRService",
+  "description": "Microsoft SignalRService Resource Types",
+  "resourceDefinitions": {
+    "SignalR": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the SignalR resource."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.SignalRService/SignalR"
+          ]
+        },
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-10-01"
+          ]
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+            }
+          ],
+          "description": "A list of key value pairs that describe the resource."
+        },
+        "sku": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ResourceSku"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+            }
+          ],
+          "description": "The billing information of the resource.(e.g. basic vs. standard)"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SignalRCreateOrUpdateProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+            }
+          ],
+          "description": "Settings used to provision or configure the resource"
+        },
+        "location": {
+          "type": "string",
+          "description": "Azure GEO region: e.g. West US | East US | North Central US | South Central US | West Europe | North Europe | East Asia | Southeast Asia | etc. \r\nThe geo region of a resource never changes after it is created."
+        }
+      },
+      "required": [
+        "name",
+        "type",
+        "apiVersion",
+        "properties",
+        "location"
+      ],
+      "description": "Microsoft.SignalRService/SignalR"
+    }
+  },
+  "definitions": {
+    "ResourceSku": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the SKU. This is typically a letter + number code, such as A0 or P3.  Required (if sku is specified)"
+        },
+        "tier": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Free",
+                "Basic",
+                "Standard",
+                "Premium"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+            }
+          ],
+          "description": "Optional tier of this particular SKU. `Basic` is deprecated, use `Standard` instead for Basic tier."
+        },
+        "size": {
+          "type": "string",
+          "description": "Optional, string. When the name field is the combination of tier and some other value, this would be the standalone code."
+        },
+        "family": {
+          "type": "string",
+          "description": "Optional, string. If the service has different generations of hardware, for the same SKU, then that can be captured here."
+        },
+        "capacity": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+            }
+          ],
+          "description": "Optional, integer. If the SKU supports scale out/in then the capacity integer should be included. If scale out/in is not \r\npossible for the resource this may be omitted."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "description": "The billing information of the resource.(e.g. basic vs. standard)"
+    },
+    "SignalRCreateOrUpdateProperties": {
+      "type": "object",
+      "properties": {
+        "hostNamePrefix": {
+          "type": "string",
+          "description": "Prefix for the hostName of the SignalR service. Retained for future use.\r\nThe hostname will be of format: &lt;hostNamePrefix&gt;.service.signalr.net."
+        }
+      },
+      "description": "Settings used to provision or configure the resource."
+    }
+  }
+}

--- a/tests/2018-10-01/Microsoft.SignalRService.tests.json
+++ b/tests/2018-10-01/Microsoft.SignalRService.tests.json
@@ -1,0 +1,42 @@
+{
+  "tests": [
+    {
+      "name": "SignalR-Free-WestUS",
+      "definition": "https://schema.management.azure.com/schemas/2018-10-01/Microsoft.SignalRService.json#resourceDefinitions/SignalR",
+      "json": {
+        "type": "Microsoft.SignalRService/SignalR",
+        "name": "signalr-free-westus",
+        "sku": {
+          "name": "Free_F1"
+        },
+        "location": "West US",
+        "apiVersion": "2018-10-01",
+        "tags": {
+          "from": "test"
+        },
+        "properties": {
+          "hostNamePrefix": "signalr-free-westus"
+        }
+      }
+    },
+    {
+      "name": "SignalR-Standard-EastUS",
+      "definition": "https://schema.management.azure.com/schemas/2018-10-01/Microsoft.SignalRService.json#resourceDefinitions/SignalR",
+      "json": {
+        "type": "Microsoft.SignalRService/SignalR",
+        "name": "signalr-standard-eastus",
+        "sku": {
+          "name": "Standard_S1"
+        },
+        "location": "East US",
+        "apiVersion": "2018-10-01",
+        "tags": {
+          "from": "test",
+          "region": "EastUS"
+        },
+        "properties": {
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Onboarding schemas for SignalR service 2018-10-01. The schema file is created via AutoRest.  

Tests
- validationJson passed
- two more cases of SignalR service added and all tests in the repo passed