### PR TITLE
Add option to run tests in one folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@ Welcome to contribute to template deployment schemas, please send pull request t
   1. [tools\validateJSON.js](https://github.com/Azure/azure-resource-manager-schemas/blob/master/tools/validateJSON.js) and [ResourceMetaSchema.json](https://github.com/Azure/azure-resource-manager-schemas/blob/master/tools/ResourceMetaSchema.json):  
 The script uses the ResourceMetaSchema.json to do some basic checks against the new/updated schema file.  
 **Usage:**   
-Node validateJSON.js \<schema file path\> ResourceMetaSchema.json \<schema folder path\>
+Node validateJSON.js \<schema file path\> ResourceMetaSchema.json \<schema folder path\>  
 **Sample:**  
 Node validateJSON.js ..\schemas\2015-08-01\Microsoft.Compute.json ResourceMetaSchema.json ..\schemas\
   2. [tools\runSchemaTests.js](https://github.com/Azure/azure-resource-manager-schemas/blob/master/tools/runSchemaTests.js)  
 The script uses all test JSON files under [tests](https://github.com/Azure/azure-resource-manager-schemas/tree/master/tests) folder to test against the schema files.  
 **Usage:**   
-Node runSchemaTests.js
+Node runSchemaTests.js  
+&nbsp;&nbsp;&nbsp;&nbsp;***To run tests in single folder:***  
+&nbsp;&nbsp;&nbsp;&nbsp;Node runSchemaTests.js ..\tests\2018-08-01  
+&nbsp;&nbsp;&nbsp;&nbsp;***To run tests in single folder and assert subErrors:***  
+&nbsp;&nbsp;&nbsp;&nbsp;Node runSchemaTests.js ..\tests\2018-08-01 -AssertSubErrors  
 
 ---
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Node validateJSON.js ..\schemas\2015-08-01\Microsoft.Compute.json ResourceMetaSc
   2. [tools\runSchemaTests.js](https://github.com/Azure/azure-resource-manager-schemas/blob/master/tools/runSchemaTests.js)  
 The script uses all test JSON files under [tests](https://github.com/Azure/azure-resource-manager-schemas/tree/master/tests) folder to test against the schema files.  
 **Usage:**   
-Node runSchemaTests.js  
+Node runSchemaTests.js [--dir _folder_] [--AssertSubErrors]  
 &nbsp;&nbsp;&nbsp;&nbsp;***To run tests in single folder:***  
-&nbsp;&nbsp;&nbsp;&nbsp;Node runSchemaTests.js ..\tests\2018-08-01  
+&nbsp;&nbsp;&nbsp;&nbsp;Node runSchemaTests.js --dir ..\tests\2018-08-01  
 &nbsp;&nbsp;&nbsp;&nbsp;***To run tests in single folder and assert subErrors:***  
-&nbsp;&nbsp;&nbsp;&nbsp;Node runSchemaTests.js ..\tests\2018-08-01 -AssertSubErrors  
+&nbsp;&nbsp;&nbsp;&nbsp;Node runSchemaTests.js --dir ..\tests\2018-08-01 --AssertSubErrors  
 
 ---
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/tools/runSchemaTests.js
+++ b/tools/runSchemaTests.js
@@ -37,10 +37,15 @@ module.exports.getTestFiles = getTestFiles;
  */
 function getTestFiles() {
     /** @type {String[]} */
-    let customTestFolder = process.argv[2];
+    let customTestFolder = null;
+    for (let i = 1; i < process.argv.length - 1; i++){
+        if (process.argv[i] === "--dir") {
+            customTestFolder = process.argv[i + 1];
+        }
+    }
 
     let testsFolderPath = utilities.findFileOrFolder("tests")
-    if (customTestFolder && customTestFolder !== "-AssertSubErrors") {
+    if (customTestFolder) {
         if (customTestFolder.startsWith("../") || customTestFolder.startsWith("..\\")) {
             customTestFolder = customTestFolder.substring(3);
         }
@@ -191,8 +196,10 @@ function runSchemaTests() {
     };
 
     let assertSubErrors = false;
-    if ((process.argv[2] && process.argv[2] === "-AssertSubErrors") || (process.argv[3] && process.argv[3] === "-AssertSubErrors")) {
-        assertSubErrors = true;
+    for (let i = 1; i < process.argv.length; i++){
+        if (process.argv[i] === "--AssertSubErrors") {
+            assertSubErrors = true;
+        }
     }
 
     const schemasFolderPath = utilities.getSchemasFolderPath();

--- a/tools/runSchemaValidation.js
+++ b/tools/runSchemaValidation.js
@@ -105,14 +105,14 @@ describe('run schema tests - ', () => {
         if (testResult.testsFailed > 0) {
 			let message = `there are failing schema test cases: `;
 
-			for (const testcase of testResult.testcases) {
-				if (!testcase.valid) {
-					message += "\n";
-					message += `\n     Test file: ${testcase.testFile}`;
-					message += `\n     Test name: ${testcase.testName}`;
-					message += `\n     ${testcase.message}`;
-				}
-			}
+			// for (const testcase of testResult.testcases) {
+			// 	if (!testcase.valid) {
+			// 		message += `\n`;
+			// 		message += `\n     Test file: ${testcase.testFile}`;
+			// 		message += `\n     Test name: ${testcase.testName}`;
+			// 		message += `\n     ${testcase.message}`;
+			// 	}
+			// }
 
 			assert.fail(message);
 		}

--- a/tools/runSchemaValidation.js
+++ b/tools/runSchemaValidation.js
@@ -107,7 +107,7 @@ describe('run schema tests - ', () => {
 
 			for (const testcase of testResult.testcases) {
 				if (!testcase.valid) {
-					message += `\n`;
+					message += "\n";
 					message += `\n     Test file: ${testcase.testFile}`;
 					message += `\n     Test name: ${testcase.testName}`;
 					message += `\n     ${testcase.message}`;

--- a/tools/runSchemaValidation.js
+++ b/tools/runSchemaValidation.js
@@ -105,14 +105,14 @@ describe('run schema tests - ', () => {
         if (testResult.testsFailed > 0) {
 			let message = `there are failing schema test cases: `;
 
-			// for (const testcase of testResult.testcases) {
-			// 	if (!testcase.valid) {
-			// 		message += `\n`;
-			// 		message += `\n     Test file: ${testcase.testFile}`;
-			// 		message += `\n     Test name: ${testcase.testName}`;
-			// 		message += `\n     ${testcase.message}`;
-			// 	}
-			// }
+			for (const testcase of testResult.testcases) {
+				if (!testcase.valid) {
+					message += `\n`;
+					message += `\n     Test file: ${testcase.testFile}`;
+					message += `\n     Test name: ${testcase.testName}`;
+					message += `\n     ${testcase.message}`;
+				}
+			}
 
 			assert.fail(message);
 		}


### PR DESCRIPTION
Added option to run tests in one schema folder.
Added option to assert subErrors (recursive). Not enabled by default because 70 tests fail when asserting subErrors but at least one can check their tests before submitting.
Added usage of the new options to the readme.md