### PR TITLE
Add support for conditional output in deploymentTemplate

### DIFF
--- a/schemas/2015-01-01/deploymentTemplate.json
+++ b/schemas/2015-01-01/deploymentTemplate.json
@@ -1257,6 +1257,17 @@
     "output": {
       "type": "object",
       "properties": {
+        "condition": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/expression"
+            }
+          ],
+          "description": "Condition of the output"
+        },
         "type": {
           "$ref": "#/definitions/parameterTypes",
           "description": "Type of output value"


### PR DESCRIPTION
We will now support `condition` in `output`. It is not a required property and can be a `boolean` or a string expression that evaluates to a `boolean`.