### PR TITLE
include more properties in SignalR Resource

### DIFF
--- a/schemas/2018-10-01/Microsoft.SignalRService.json
+++ b/schemas/2018-10-01/Microsoft.SignalRService.json
@@ -130,9 +130,46 @@
         "hostNamePrefix": {
           "type": "string",
           "description": "Prefix for the hostName of the SignalR service. Retained for future use.\r\nThe hostname will be of format: &lt;hostNamePrefix&gt;.service.signalr.net."
+        },
+        "features": {
+          "type": "array",
+          "description": "List of SignalR featureFlags. e.g. ServiceMode.\r\n\r\nFeatureFlags that are not included in the parameters for the update operation will not be modified.\r\nAnd the response will only include featureFlags that are explicitly set. \r\nWhen a featureFlag is not explicitly set, SignalR service will use its globally default value. \r\nBut keep in mind, the default value doesn't mean \"false\". It varies in terms of different FeatureFlags.",
+          "items": {
+            "$ref": "#/definitions/SignalRFeature"
+          }         
         }
       },
       "description": "Settings used to provision or configure the resource."
+    },
+    "SignalRFeature": {
+      "description": "Feature of a SignalR resource, which controls the SignalR runtime behavior.",
+      "required": [
+        "flag",
+        "value"
+      ],
+      "type": "object",
+      "properties": {
+        "flag": {
+          "description": "Kind of feature. Required.",
+          "enum": [
+            "ServiceMode"
+          ],
+          "type": "string"
+        },
+        "value": {
+          "description": "Value of the feature flag. See Azure SignalR service document https://docs.microsoft.com/en-us/azure/azure-signalr/ for allowed values.",
+          "maxLength": 128,
+          "minLength": 1,
+          "type": "string"
+        },
+        "properties": {
+          "description": "Optional properties related to this feature.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
     }
   }
 }

--- a/tests/2018-10-01/Microsoft.SignalRService.tests.json
+++ b/tests/2018-10-01/Microsoft.SignalRService.tests.json
@@ -15,7 +15,13 @@
           "from": "test"
         },
         "properties": {
-          "hostNamePrefix": "signalr-free-westus"
+          "hostNamePrefix": "signalr-free-westus",
+          "features": [
+            {
+              "flag": "ServiceMode",
+              "value": "Default"
+            }
+          ]
         }
       }
     },
@@ -35,6 +41,12 @@
           "region": "EastUS"
         },
         "properties": {
+          "features": [
+            {
+              "flag": "ServiceMode",
+              "value": "Serverless"
+            }
+          ]
         }
       }
     }


### PR DESCRIPTION
Include more properties in SignalR Resource which is already merged into Azure Rest API specifications.

Both schema validation(via `tools\validateJSON.js`) and tests(via `tools\runSchemaTests.js`) passed.