### PR TITLE
Update Azure FHIR Apis Kind to include R4

### DIFF
--- a/schemas/2018-08-20-preview/Microsoft.HealthcareApis.json
+++ b/schemas/2018-08-20-preview/Microsoft.HealthcareApis.json
@@ -30,7 +30,9 @@
             {
               "type": "string",
               "enum": [
-                "fhir"
+                "fhir",
+                "fhir-Stu3",
+                "fhir-R4"
               ]
             },
             {


### PR DESCRIPTION
Azure FHIR Apis is adding an option to create either Stu3 or R4 version of the FHIR service.  This is reflected in the Kind value.  Updating the enum to allow for the new values.