### PR TITLE
Add policy assignment resource type to deployment template schemas

### DIFF
--- a/schemas/2014-04-01-preview/deploymentTemplate.json
+++ b/schemas/2014-04-01-preview/deploymentTemplate.json
@@ -1273,6 +1273,8 @@
                   { "$ref": "https://schema.management.azure.com/schemas/2018-09-01-preview/Microsoft.BareMetal.json#/resourceDefinitions/crayServers" },
                   { "$ref": "https://schema.management.azure.com/schemas/2019-06-01/Microsoft.ContainerService.json#/resourceDefinitions/managedClusters" },
                   { "$ref": "https://schema.management.azure.com/schemas/2019-06-01/Microsoft.ContainerService.json#/resourceDefinitions/managedClusters_agentPools" },
+                  { "$ref": "https://schema.management.azure.com/schemas/2018-03-01/Microsoft.Authorization.json#/resourceDefinitions/policyAssignments" },
+                  { "$ref": "https://schema.management.azure.com/schemas/2018-05-01/Microsoft.Authorization.json#/resourceDefinitions/policyAssignments" },
                   { "$ref": "#/definitions/resourceGeneric" }
                 ]
               }

--- a/schemas/2015-01-01/deploymentTemplate.json
+++ b/schemas/2015-01-01/deploymentTemplate.json
@@ -1284,7 +1284,9 @@
                   { "$ref": "https://schema.management.azure.com/schemas/2019-06-01/Microsoft.ManagedServices.json#/resourceDefinitions/registrationDefinitions" },
                   { "$ref": "https://schema.management.azure.com/schemas/2018-09-01-preview/Microsoft.BareMetal.json#/resourceDefinitions/crayServers" },
                   { "$ref": "https://schema.management.azure.com/schemas/2019-06-01/Microsoft.ContainerService.json#/resourceDefinitions/managedClusters" },
-                  { "$ref": "https://schema.management.azure.com/schemas/2019-06-01/Microsoft.ContainerService.json#/resourceDefinitions/managedClusters_agentPools" }
+                  { "$ref": "https://schema.management.azure.com/schemas/2019-06-01/Microsoft.ContainerService.json#/resourceDefinitions/managedClusters_agentPools" },
+                  { "$ref": "https://schema.management.azure.com/schemas/2018-03-01/Microsoft.Authorization.json#/resourceDefinitions/policyAssignments" },
+                  { "$ref": "https://schema.management.azure.com/schemas/2018-05-01/Microsoft.Authorization.json#/resourceDefinitions/policyAssignments" }
                 ]
               }
             ]

--- a/schemas/2019-04-01/deploymentTemplate.json
+++ b/schemas/2019-04-01/deploymentTemplate.json
@@ -1270,7 +1270,9 @@
                   { "$ref": "https://schema.management.azure.com/schemas/2019-03-01/Microsoft.Compute.Galleries.json#/resourceDefinitions/galleries_images" },
                   { "$ref": "https://schema.management.azure.com/schemas/2019-03-01/Microsoft.Compute.Galleries.json#/resourceDefinitions/galleries_images_versions" },
                   { "$ref": "https://schema.management.azure.com/schemas/2018-02-16-preview/Microsoft.WindowsIoT.json#/resourceDefinitions/deviceServices" },
-                  { "$ref": "https://schema.management.azure.com/schemas/2018-09-01-preview/Microsoft.BareMetal.json#/resourceDefinitions/crayServers" }
+                  { "$ref": "https://schema.management.azure.com/schemas/2018-09-01-preview/Microsoft.BareMetal.json#/resourceDefinitions/crayServers" },
+                  { "$ref": "https://schema.management.azure.com/schemas/2018-03-01/Microsoft.Authorization.json#/resourceDefinitions/policyAssignments" },
+                  { "$ref": "https://schema.management.azure.com/schemas/2018-05-01/Microsoft.Authorization.json#/resourceDefinitions/policyAssignments" }
                 ]
               }
             ]


### PR DESCRIPTION
Fixing [this](https://github.com/Azure/azure-resource-manager-schemas/issues/445#issuecomment-503322715
) issue for policy assignments. Policy definitions can only be created at the subscription or MG level. The schema for subscription deployment is already up to date.
