### PR TITLE
Use new multiapi format

### DIFF
--- a/generator/constants.ts
+++ b/generator/constants.ts
@@ -17,23 +17,40 @@ const generatedSchemasTemplatePath = path.join(__dirname, 'resources/autogenerat
 
 // Run "npm run list-basepaths" to discover all the valid readme files to add to this list
 const whitelist  = [
-  'sqlvirtualmachine/resource-manager',
-  'machinelearningcompute/resource-manager',
-  'iotspaces/resource-manager',
-  'botservice/resource-manager',
-  'databox/resource-manager',
-  'windowsiot/resource-manager',
-  'databricks/resource-manager',
-  'storagesync/resource-manager',
-  'devspaces/resource-manager',
-  'policyinsights/resource-manager',
-  'servicefabricmesh/resource-manager',
-  'labservices/resource-manager',
-  'EnterpriseKnowledgeGraph/resource-manager',
-  'edgegateway/resource-manager',
-  'portal/resource-manager',
-  'cosmos-db/resource-manager',
-  'servicefabric/resource-manager',
+    'sqlvirtualmachine/resource-manager',
+    'machinelearningcompute/resource-manager',
+    'iotspaces/resource-manager',
+    'botservice/resource-manager',
+    'databox/resource-manager',
+    'windowsiot/resource-manager',
+    'databricks/resource-manager',
+    'storagesync/resource-manager',
+    'devspaces/resource-manager',
+    'policyinsights/resource-manager',
+    'servicefabricmesh/resource-manager',
+    'labservices/resource-manager',
+    'EnterpriseKnowledgeGraph/resource-manager',
+    'edgegateway/resource-manager',
+    'portal/resource-manager',
+    'cosmos-db/resource-manager',
+    'servicefabric/resource-manager',
+];
+
+// paths in this list won't even appear in list-basepaths
+const blacklist = [
+    'azsadmin/resource-manager/azurebridge',
+    'azsadmin/resource-manager/backup',
+    'azsadmin/resource-manager/commerce',
+    'azsadmin/resource-manager/compute',
+    'azsadmin/resource-manager/fabric',
+    'azsadmin/resource-manager/gallery',
+    'azsadmin/resource-manager/infrastructureinsights',
+    'azsadmin/resource-manager/keyvault',
+    'azsadmin/resource-manager/network',
+    'azsadmin/resource-manager/storage',
+    'azsadmin/resource-manager/subscriptions',
+    'azsadmin/resource-manager/update',
+    'azsadmin/resource-manager/user-subscriptions',
 ];
 
 export {
@@ -50,4 +67,5 @@ export {
     generatedSchemasTemplatePath,
 
     whitelist,
+    blacklist,
 }

--- a/generator/generate.ts
+++ b/generator/generate.ts
@@ -5,7 +5,7 @@ import { promisify } from 'util';
 import { findRecursive, findDirRecursive, executeCmd, rmdirRecursive } from './utils';
 import * as constants from './constants';
 import chalk from 'chalk';
-import { isWhitelisted } from './specs';
+import { isWhitelisted, appendAutorestV3Config } from './specs';
 
 const autorestBinary = os.platform() === 'win32' ? 'autorest.cmd' : 'autorest';
 
@@ -51,6 +51,8 @@ async function execAutoRest(tmpFolder: string, params: string[]) {
 }
 
 async function generateSchema(readme: string, tmpFolder: string, apiVersion: string) {
+    await appendAutorestV3Config(readme);
+
     const autoRestParams = [
         '--azureresourceschema',
         `--output-folder=${tmpFolder}`,

--- a/generator/generate.ts
+++ b/generator/generate.ts
@@ -54,6 +54,7 @@ async function generateSchema(readme: string, tmpFolder: string, apiVersion: str
     const autoRestParams = [
         '--azureresourceschema',
         `--output-folder=${tmpFolder}`,
+        `--tag=all-api-versions`,
         `--api-version=${apiVersion}`,
         '--title=none',
         readme,
@@ -120,7 +121,7 @@ async function saveToSchemasDirectory(outputFile: string, schemaRefs: string[], 
 async function listReadmePaths(localPath: string, basePaths: string[]) {
     return basePaths
         .filter(p => isWhitelisted(p))
-        .map(p => path.join(localPath, 'specification', p, 'readme.enable-multi-api.md'))
+        .map(p => path.join(localPath, 'specification', p, 'readme.md'))
         .map(p => path.resolve(p));
 }
 

--- a/generator/git.ts
+++ b/generator/git.ts
@@ -7,9 +7,9 @@ const exists = promisify(fs.exists);
 
 async function resetGitDirectory(localPath: string) {
     if (await exists(localPath)) {
-        await executeCmd(localPath, 'git', ['reset', '.']);
-        await executeCmd(localPath, 'git', ['checkout', '--', '.']);
-        await executeCmd(localPath, 'git', ['clean', '-fd']);
+        await executeCmd(localPath, 'git', ['reset', '-q', '.']);
+        await executeCmd(localPath, 'git', ['checkout', '-q', '--', '.']);
+        await executeCmd(localPath, 'git', ['clean', '-q', '-fd']);
     }
 }
 

--- a/generator/package-lock.json
+++ b/generator/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@microsoft.azure/autorest-core": {
-      "version": "3.0.5526",
-      "resolved": "https://registry.npmjs.org/@microsoft.azure/autorest-core/-/autorest-core-3.0.5526.tgz",
-      "integrity": "sha512-vybUN9QqDkLkUWmFsy6vAEuDk7kz+5DIyDP2YrKADkqLsysbLQJ8rJ11vr6Xuhyd2uNA5crhetRhOCc5vjjjMg==",
+      "version": "3.0.5534",
+      "resolved": "https://registry.npmjs.org/@microsoft.azure/autorest-core/-/autorest-core-3.0.5534.tgz",
+      "integrity": "sha512-UGWdyhu/ivJvd7t+zreDhaZCEuK5aBcqIE5gyQYAVMI6Y/kUaA8UUbcJOrdlkJ2mqnvfQ+HBD57TP3cYCDaoxg==",
       "dev": true
     },
     "@microsoft.azure/autorest.azureresourceschema": {
@@ -26,9 +26,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
-      "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==",
+      "version": "12.7.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
+      "integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==",
       "dev": true
     },
     "ansi-styles": {
@@ -53,9 +53,9 @@
       "dev": true
     },
     "autorest": {
-      "version": "3.0.5226",
-      "resolved": "https://registry.npmjs.org/autorest/-/autorest-3.0.5226.tgz",
-      "integrity": "sha512-UetIr/i8OasiDELPaTJyOEmQOtr3DRsyYPp0TtgzcKrqC58R3U74QhJnNrWgAwIuC2PBjLUbtmvLdkoixssNfw==",
+      "version": "3.0.5230",
+      "resolved": "https://registry.npmjs.org/autorest/-/autorest-3.0.5230.tgz",
+      "integrity": "sha512-sfSkJfj+HEGrtDfdYKjcEpcAIzm35u7tHL4dmnB0a2e1MY53H7/gD6DmXQ3m9tZXIItQXBn0TehY2xbmC4Xfow==",
       "dev": true
     },
     "buffer-from": {

--- a/generator/package.json
+++ b/generator/package.json
@@ -10,12 +10,12 @@
     "start": "npm run clean && npm run generate-all"
   },
   "devDependencies": {
-    "@microsoft.azure/autorest-core": "^3.0.5526",
+    "@microsoft.azure/autorest-core": "^3.0.5534",
     "@microsoft.azure/autorest.azureresourceschema": "^3.0.37",
     "@types/async": "^3.0.1",
-    "@types/node": "^12.7.1",
+    "@types/node": "^12.7.2",
     "async": "^3.1.0",
-    "autorest": "^3.0.5226",
+    "autorest": "^3.0.5230",
     "chalk": "^2.4.2",
     "ts-node": "^8.3.0",
     "typescript": "^3.5.3"

--- a/generator/specs.ts
+++ b/generator/specs.ts
@@ -50,7 +50,8 @@ async function cloneAndGenerateBasePaths(localPath: string, remoteUri: string, c
 
     return filePaths
         .map(p => p.substring(0, p.lastIndexOf(path.sep)))
-        .map(getBasePathString.bind(null, localPath));
+        .map(getBasePathString.bind(null, localPath))
+        .filter(p => !isBlacklisted(p));
 }
 
 function getBasePathString(localPath: string, basePath: string) {
@@ -62,6 +63,10 @@ function getBasePathString(localPath: string, basePath: string) {
 
 function isWhitelisted(basePath: string) {
     return constants.whitelist.includes(basePath);
+}
+
+function isBlacklisted(basePath: string) {
+    return constants.blacklist.includes(basePath);
 }
 
 export {

--- a/generator/specs.ts
+++ b/generator/specs.ts
@@ -10,7 +10,7 @@ const exists = promisify(fs.exists);
 const npmBinary = os.platform() === 'win32' ? 'npm.cmd' : 'npm';
 
 async function validateUserProvidedBasePath(basePath: string) {
-    const readme = path.join(constants.specsRepoPath, 'specification', basePath, 'readme.enable-multi-api.md');
+    const readme = path.join(constants.specsRepoPath, 'specification', basePath, 'readme.md');
 
     if (!await exists(readme)) {
         throw new Error(`Unable to find readme '$readme' in specs repo`)
@@ -28,7 +28,7 @@ async function cloneAndGenerateBasePaths(localPath: string, remoteUri: string, c
     const specsPath = path.join(localPath, 'specification');
 
     const filePaths = await findRecursive(specsPath, filePath => {
-        if (path.basename(filePath) !== 'readme.enable-multi-api.md') {
+        if (path.basename(filePath) !== 'readme.md') {
             return false;
         }
 


### PR DESCRIPTION
https://github.com/Azure/azure-rest-api-specs/pull/6946 changed the format of the readme files generated by `npm run multiapi`. This PR is just to consume the new format.