### PR TITLE
Fix Network schemas

### DIFF
--- a/schemas/2019-04-01/Microsoft.Network.json
+++ b/schemas/2019-04-01/Microsoft.Network.json
@@ -6138,6 +6138,20 @@
     "ExpressRouteCircuitPeeringConfig": {
       "type": "object",
       "properties": {
+        "advertisedPublicPrefixes": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+            }
+          ],
+          "description": "The reference of AdvertisedPublicPrefixes."
+        },
         "advertisedCommunities": {
           "oneOf": [
             {
@@ -6151,23 +6165,6 @@
             }
           ],
           "description": "The communities of bgp peering. Specified for microsoft peering."
-        },
-        "advertisedPublicPrefixesState": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "NotConfigured",
-                "Configuring",
-                "Configured",
-                "ValidationNeeded"
-              ]
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-            }
-          ],
-          "description": "The advertised public prefix state of the Peering resource."
         },
         "legacyMode": {
           "oneOf": [

--- a/schemas/2019-06-01/Microsoft.Network.json
+++ b/schemas/2019-06-01/Microsoft.Network.json
@@ -6366,6 +6366,20 @@
     "ExpressRouteCircuitPeeringConfig": {
       "type": "object",
       "properties": {
+        "advertisedPublicPrefixes": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+            }
+          ],
+          "description": "The reference of AdvertisedPublicPrefixes."
+        },
         "advertisedCommunities": {
           "oneOf": [
             {
@@ -6379,23 +6393,6 @@
             }
           ],
           "description": "The communities of bgp peering. Specified for microsoft peering."
-        },
-        "advertisedPublicPrefixesState": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "NotConfigured",
-                "Configuring",
-                "Configured",
-                "ValidationNeeded"
-              ]
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-            }
-          ],
-          "description": "The advertised public prefix state of the Peering resource."
         },
         "legacyMode": {
           "oneOf": [

--- a/schemas/2019-07-01/Microsoft.Network.json
+++ b/schemas/2019-07-01/Microsoft.Network.json
@@ -6332,6 +6332,20 @@
     "ExpressRouteCircuitPeeringConfig": {
       "type": "object",
       "properties": {
+        "advertisedPublicPrefixes": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+            }
+          ],
+          "description": "The reference of AdvertisedPublicPrefixes."
+        },
         "advertisedCommunities": {
           "oneOf": [
             {
@@ -6345,23 +6359,6 @@
             }
           ],
           "description": "The communities of bgp peering. Specified for microsoft peering."
-        },
-        "advertisedPublicPrefixesState": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "NotConfigured",
-                "Configuring",
-                "Configured",
-                "ValidationNeeded"
-              ]
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-            }
-          ],
-          "description": "The advertised public prefix state of the Peering resource."
         },
         "legacyMode": {
           "oneOf": [

--- a/schemas/2019-08-01/Microsoft.Network.json
+++ b/schemas/2019-08-01/Microsoft.Network.json
@@ -6405,6 +6405,20 @@
     "ExpressRouteCircuitPeeringConfig": {
       "type": "object",
       "properties": {
+        "advertisedPublicPrefixes": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
+            }
+          ],
+          "description": "The reference of AdvertisedPublicPrefixes."
+        },
         "advertisedCommunities": {
           "oneOf": [
             {
@@ -6418,23 +6432,6 @@
             }
           ],
           "description": "The communities of bgp peering. Specified for microsoft peering."
-        },
-        "advertisedPublicPrefixesState": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "NotConfigured",
-                "Configuring",
-                "Configured",
-                "ValidationNeeded"
-              ]
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#/definitions/expression"
-            }
-          ],
-          "description": "The advertised public prefix state of the Peering resource."
         },
         "legacyMode": {
           "oneOf": [


### PR DESCRIPTION
There was an error in our preprocessing where incorrect property was marked as read-only (`advertisedPublicPrefixes` instead of `advertisedPublicPrefixesState`). We fixed that and re-generate affected schemas