### PR TITLE
Streamline description for certificate encoding

### DIFF
--- a/schemas/2019-01-01/Microsoft.ApiManagement.json
+++ b/schemas/2019-01-01/Microsoft.ApiManagement.json
@@ -3094,7 +3094,7 @@
       "properties": {
         "data": {
           "type": "string",
-          "description": "Base 64 encoded certificate using the application/x-pkcs12 representation."
+          "description": "Base64 Encoded certificate."
         },
         "password": {
           "type": "string",


### PR DESCRIPTION
The current description is not true, it's just the base64 string of the pfx, not for the specific Pkcs12 type (this will result in a 'password not valid' error when this is tried). 

Suggested to streamline description for certificate encoding to have it similar to:
https://docs.microsoft.com/en-us/azure/templates/Microsoft.ApiManagement/2019-01-01/service#certificateconfiguration-object

