### PR TITLE
Inline deployment expression evaluation options

### DIFF
--- a/schemas/2015-01-01/Microsoft.Resources.json
+++ b/schemas/2015-01-01/Microsoft.Resources.json
@@ -33,6 +33,17 @@
         "properties": {
           "type": "object",
           "properties": {
+            "templateExpressionEvaluationOptions": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/TemplateExpressionEvaluationOptions"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ],
+              "description": "Template expression evaluation options'"
+            },
             "mode": {
               "oneOf": [
                 {
@@ -199,6 +210,26 @@
         "uri"
       ],
       "description": "Parameter file reference in a deployment"
+    },
+    "TemplateExpressionEvaluationOptions": {
+      "type": "object",
+      "properties": {
+        "scope": {
+          "$ref": "#/definitions/TemplateExpressionEvaluationScope"
+        }
+      },
+      "required": [
+        "scope"
+      ],
+      "description": "Template expression evaluation options"
+    },
+    "TemplateExpressionEvaluationScope": {
+      "type": "string",
+      "enum": [
+        "inner",
+        "outer"
+      ],
+      "description": "Template expression evaluation scope"
     }
   }
 }

--- a/schemas/2015-01-01/Microsoft.Resources.json
+++ b/schemas/2015-01-01/Microsoft.Resources.json
@@ -33,7 +33,7 @@
         "properties": {
           "type": "object",
           "properties": {
-            "templateExpressionEvaluationOptions": {
+            "expressionEvaluationOptions": {
               "oneOf": [
                 {
                   "$ref": "#/definitions/TemplateExpressionEvaluationOptions"

--- a/schemas/2016-02-01/Microsoft.Resources.json
+++ b/schemas/2016-02-01/Microsoft.Resources.json
@@ -52,7 +52,7 @@
     "DeploymentProperties": {
       "type": "object",
       "properties": {
-        "templateExpressionEvaluationOptions": {
+        "expressionEvaluationOptions": {
           "oneOf": [
             {
               "$ref": "#/definitions/TemplateExpressionEvaluationOptions"

--- a/schemas/2016-02-01/Microsoft.Resources.json
+++ b/schemas/2016-02-01/Microsoft.Resources.json
@@ -52,6 +52,17 @@
     "DeploymentProperties": {
       "type": "object",
       "properties": {
+        "templateExpressionEvaluationOptions": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TemplateExpressionEvaluationOptions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Template expression evaluation options'"
+        },
         "template": {
           "oneOf": [
             {
@@ -161,6 +172,26 @@
         "uri"
       ],
       "description": "Entity representing the reference to the template."
+    },
+    "TemplateExpressionEvaluationOptions": {
+      "type": "object",
+      "properties": {
+        "scope": {
+          "$ref": "#/definitions/TemplateExpressionEvaluationScope"
+        }
+      },
+      "required": [
+        "scope"
+      ],
+      "description": "Template expression evaluation options"
+    },
+    "TemplateExpressionEvaluationScope": {
+      "type": "string",
+      "enum": [
+        "inner",
+        "outer"
+      ],
+      "description": "Template expression evaluation scope"
     }
   }
 }

--- a/schemas/2016-09-01/Microsoft.Resources.json
+++ b/schemas/2016-09-01/Microsoft.Resources.json
@@ -52,7 +52,7 @@
     "DeploymentProperties": {
       "type": "object",
       "properties": {
-        "templateExpressionEvaluationOptions": {
+        "expressionEvaluationOptions": {
           "oneOf": [
             {
               "$ref": "#/definitions/TemplateExpressionEvaluationOptions"

--- a/schemas/2016-09-01/Microsoft.Resources.json
+++ b/schemas/2016-09-01/Microsoft.Resources.json
@@ -52,6 +52,17 @@
     "DeploymentProperties": {
       "type": "object",
       "properties": {
+        "templateExpressionEvaluationOptions": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TemplateExpressionEvaluationOptions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Template expression evaluation options'"
+        },
         "template": {
           "oneOf": [
             {
@@ -161,6 +172,26 @@
         "uri"
       ],
       "description": "Entity representing the reference to the template."
+    },
+    "TemplateExpressionEvaluationOptions": {
+      "type": "object",
+      "properties": {
+        "scope": {
+          "$ref": "#/definitions/TemplateExpressionEvaluationScope"
+        }
+      },
+      "required": [
+        "scope"
+      ],
+      "description": "Template expression evaluation options"
+    },
+    "TemplateExpressionEvaluationScope": {
+      "type": "string",
+      "enum": [
+        "inner",
+        "outer"
+      ],
+      "description": "Template expression evaluation scope"
     }
   }
 }

--- a/schemas/2017-05-10/Microsoft.Resources.json
+++ b/schemas/2017-05-10/Microsoft.Resources.json
@@ -62,6 +62,17 @@
     "DeploymentProperties": {
       "type": "object",
       "properties": {
+        "templateExpressionEvaluationOptions": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TemplateExpressionEvaluationOptions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Template expression evaluation options'"
+        },
         "template": {
           "oneOf": [
             {
@@ -171,6 +182,26 @@
         "uri"
       ],
       "description": "Entity representing the reference to the template."
+    },
+    "TemplateExpressionEvaluationOptions": {
+      "type": "object",
+      "properties": {
+        "scope": {
+          "$ref": "#/definitions/TemplateExpressionEvaluationScope"
+        }
+      },
+      "required": [
+        "scope"
+      ],
+      "description": "Template expression evaluation options"
+    },
+    "TemplateExpressionEvaluationScope": {
+      "type": "string",
+      "enum": [
+        "inner",
+        "outer"
+      ],
+      "description": "Template expression evaluation scope"
     }
   }
 }

--- a/schemas/2017-05-10/Microsoft.Resources.json
+++ b/schemas/2017-05-10/Microsoft.Resources.json
@@ -62,7 +62,7 @@
     "DeploymentProperties": {
       "type": "object",
       "properties": {
-        "templateExpressionEvaluationOptions": {
+        "expressionEvaluationOptions": {
           "oneOf": [
             {
               "$ref": "#/definitions/TemplateExpressionEvaluationOptions"

--- a/schemas/2019-05-01/Microsoft.Resources.json
+++ b/schemas/2019-05-01/Microsoft.Resources.json
@@ -130,7 +130,7 @@
     "DeploymentProperties": {
       "type": "object",
       "properties": {
-        "templateExpressionEvaluationOptions": {
+        "expressionEvaluationOptions": {
           "oneOf": [
             {
               "$ref": "#/definitions/TemplateExpressionEvaluationOptions"

--- a/schemas/2019-05-01/Microsoft.Resources.json
+++ b/schemas/2019-05-01/Microsoft.Resources.json
@@ -130,6 +130,17 @@
     "DeploymentProperties": {
       "type": "object",
       "properties": {
+        "templateExpressionEvaluationOptions": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TemplateExpressionEvaluationOptions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Template expression evaluation options'"
+        },
         "template": {
           "oneOf": [
             {
@@ -239,6 +250,26 @@
         "uri"
       ],
       "description": "Entity representing the reference to the template."
+    },
+    "TemplateExpressionEvaluationOptions": {
+      "type": "object",
+      "properties": {
+        "scope": {
+          "$ref": "#/definitions/TemplateExpressionEvaluationScope"
+        }
+      },
+      "required": [
+        "scope"
+      ],
+      "description": "Template expression evaluation options"
+    },
+    "TemplateExpressionEvaluationScope": {
+      "type": "string",
+      "enum": [
+        "inner",
+        "outer"
+      ],
+      "description": "Template expression evaluation scope"
     }
   }
 }


### PR DESCRIPTION
Supporting new property under `Microsoft.Resources/deployments` resource.

```json
"expressionEvaluationOptions": {
    "scope": "inner",  // "outer" for today's behavior
}
```