### PR TITLE
Add support to output copy

### DIFF
--- a/schemas/2014-04-01-preview/deploymentTemplate.json
+++ b/schemas/2014-04-01-preview/deploymentTemplate.json
@@ -1933,10 +1933,53 @@
             "null"
           ],
           "description": "Value assigned for output"
+        },
+        "copy": {
+          "$ref": "#/definitions/outputCopy",
+          "description": "Output copy"
         }
       },
-      "required": [ "type", "value" ],
+      "required": [ "type" ],
       "description": "Set of output parameters"
+    },
+    "outputCopy": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "oneOf": [
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "description": "Count of the copy"
+        },
+        "input": {
+          "anyOf": [
+            {
+              "type": [
+                "string",
+                "boolean",
+                "integer",
+                "array",
+                "object",
+                "null"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Input of the copy"
+        }
+      },
+      "required": [
+        "count",
+        "input"
+      ],
+      "description": "Output copy"
     }
   }
 }

--- a/schemas/2015-01-01/deploymentTemplate.json
+++ b/schemas/2015-01-01/deploymentTemplate.json
@@ -2057,9 +2057,13 @@
         "value": {
           "$ref": "#/definitions/parameterValueTypes",
           "description": "Value assigned for output"
+        },
+        "copy": {
+          "$ref": "#/definitions/outputCopy",
+          "description": "Output copy"
         }
       },
-      "required": [ "type", "value" ],
+      "required": [ "type" ],
       "description": "Set of output parameters"
     },
     "parameterTypes": {
@@ -2096,6 +2100,45 @@
         "secretName"
       ],
       "additionalProperties": false
+    },
+    "outputCopy": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "oneOf": [
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "description": "Count of the copy"
+        },
+        "input": {
+          "anyOf": [
+            {
+              "type": [
+                "string",
+                "boolean",
+                "integer",
+                "array",
+                "object",
+                "null"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Input of the copy"
+        }
+      },
+      "required": [
+        "count",
+        "input"
+      ],
+      "description": "Output copy"
     }
   }
 }

--- a/schemas/2019-03-01-hybrid/deploymentTemplate.json
+++ b/schemas/2019-03-01-hybrid/deploymentTemplate.json
@@ -3437,12 +3437,13 @@
         "value": {
           "$ref": "#/definitions/parameterValueTypes",
           "description": "Value assigned for output"
+        },
+        "copy": {
+          "$ref": "#/definitions/outputCopy",
+          "description": "Output copy"
         }
       },
-      "required": [
-        "type",
-        "value"
-      ],
+      "required": [ "type" ],
       "description": "Set of output parameters"
     },
     "parameterTypes": {
@@ -3497,6 +3498,45 @@
         "secretName"
       ],
       "additionalProperties": true
+    },
+    "outputCopy": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "oneOf": [
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "description": "Count of the copy"
+        },
+        "input": {
+          "anyOf": [
+            {
+              "type": [
+                "string",
+                "boolean",
+                "integer",
+                "array",
+                "object",
+                "null"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Input of the copy"
+        }
+      },
+      "required": [
+        "count",
+        "input"
+      ],
+      "description": "Output copy"
     }
   }
 }

--- a/schemas/2019-04-01/deploymentTemplate.json
+++ b/schemas/2019-04-01/deploymentTemplate.json
@@ -1780,9 +1780,13 @@
         "value": {
           "$ref": "#/definitions/parameterValueTypes",
           "description": "Value assigned for output"
+        },
+        "copy": {
+          "$ref": "#/definitions/outputCopy",
+          "description": "Output copy"
         }
       },
-      "required": [ "type", "value" ],
+      "required": [ "type" ],
       "description": "Set of output parameters"
     },
     "parameterTypes": {
@@ -1819,6 +1823,45 @@
         "secretName"
       ],
       "additionalProperties": false
+    },
+    "outputCopy": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "oneOf": [
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "description": "Count of the copy"
+        },
+        "input": {
+          "anyOf": [
+            {
+              "type": [
+                "string",
+                "boolean",
+                "integer",
+                "array",
+                "object",
+                "null"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Input of the copy"
+        }
+      },
+      "required": [
+        "count",
+        "input"
+      ],
+      "description": "Output copy"
     }
   }
 }


### PR DESCRIPTION
We will support format like:
```json
"outputs": {
  "outputCopy": {
    "type": "array",
    "copy": {
      "count": 3,
      "input": "[concat('output', copyIndex())]"
    }
  }
}
```

and convert it to:
```json
"outputs": {
  "outputCopy": {
    "type": "array",
    "value": ["output1", "output2", "output3"]
  }
}
```