### PR TITLE
Onboarding privatedns/NETWORK for autogeneration

### DIFF
--- a/generator/whitelist.ts
+++ b/generator/whitelist.ts
@@ -238,6 +238,11 @@ const whitelist: WhitelistConfig[] = [
         namespace: 'Microsoft.DBforPostgreSQL',
     },
     {
+        basePath: 'privatedns/resource-manager',
+        namespace: 'Microsoft.Network',
+        suffix: 'PrivateDNS',
+    },
+    {
         basePath: 'resources/resource-manager',
         namespace: 'Microsoft.Resources',
         resourceConfig: [

--- a/schemas/2018-09-01/Microsoft.Network.PrivateDNS.json
+++ b/schemas/2018-09-01/Microsoft.Network.PrivateDNS.json
@@ -1,0 +1,1292 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2018-09-01/Microsoft.Network.PrivateDNS.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Network",
+  "description": "Microsoft Network Resource Types",
+  "resourceDefinitions": {
+    "privateDnsZones": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the zone."
+        },
+        "location": {
+          "type": "string",
+          "description": "The Azure Region where the resource lives"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the Private DNS zone (without a terminating dot)."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PrivateZoneProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the Private DNS zone."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/privateDnsZones_virtualNetworkLinks_childResource"
+              },
+              {
+                "$ref": "#/definitions/privateDnsZones_A_childResource"
+              },
+              {
+                "$ref": "#/definitions/privateDnsZones_AAAA_childResource"
+              },
+              {
+                "$ref": "#/definitions/privateDnsZones_CNAME_childResource"
+              },
+              {
+                "$ref": "#/definitions/privateDnsZones_MX_childResource"
+              },
+              {
+                "$ref": "#/definitions/privateDnsZones_PTR_childResource"
+              },
+              {
+                "$ref": "#/definitions/privateDnsZones_SOA_childResource"
+              },
+              {
+                "$ref": "#/definitions/privateDnsZones_SRV_childResource"
+              },
+              {
+                "$ref": "#/definitions/privateDnsZones_TXT_childResource"
+              }
+            ]
+          }
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/privateDnsZones"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones"
+    },
+    "privateDnsZones_A": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the record set."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the record set, relative to the name of the zone."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RecordSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the records in the record set."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/privateDnsZones/A"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/A"
+    },
+    "privateDnsZones_AAAA": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the record set."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the record set, relative to the name of the zone."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RecordSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the records in the record set."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/privateDnsZones/AAAA"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/AAAA"
+    },
+    "privateDnsZones_CNAME": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the record set."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the record set, relative to the name of the zone."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RecordSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the records in the record set."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/privateDnsZones/CNAME"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/CNAME"
+    },
+    "privateDnsZones_MX": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the record set."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the record set, relative to the name of the zone."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RecordSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the records in the record set."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/privateDnsZones/MX"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/MX"
+    },
+    "privateDnsZones_PTR": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the record set."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the record set, relative to the name of the zone."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RecordSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the records in the record set."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/privateDnsZones/PTR"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/PTR"
+    },
+    "privateDnsZones_SOA": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the record set."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the record set, relative to the name of the zone."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RecordSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the records in the record set."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/privateDnsZones/SOA"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/SOA"
+    },
+    "privateDnsZones_SRV": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the record set."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the record set, relative to the name of the zone."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RecordSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the records in the record set."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/privateDnsZones/SRV"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/SRV"
+    },
+    "privateDnsZones_TXT": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the record set."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the record set, relative to the name of the zone."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RecordSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the records in the record set."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/privateDnsZones/TXT"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/TXT"
+    },
+    "privateDnsZones_virtualNetworkLinks": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the virtual network link."
+        },
+        "location": {
+          "type": "string",
+          "description": "The Azure Region where the resource lives"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the virtual network link."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/VirtualNetworkLinkProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the Private DNS zone."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/privateDnsZones/virtualNetworkLinks"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/virtualNetworkLinks"
+    }
+  },
+  "definitions": {
+    "AaaaRecord": {
+      "type": "object",
+      "properties": {
+        "ipv6Address": {
+          "type": "string",
+          "description": "The IPv6 address of this AAAA record."
+        }
+      },
+      "description": "An AAAA record."
+    },
+    "ARecord": {
+      "type": "object",
+      "properties": {
+        "ipv4Address": {
+          "type": "string",
+          "description": "The IPv4 address of this A record."
+        }
+      },
+      "description": "An A record."
+    },
+    "CnameRecord": {
+      "type": "object",
+      "properties": {
+        "cname": {
+          "type": "string",
+          "description": "The canonical name for this CNAME record."
+        }
+      },
+      "description": "A CNAME record."
+    },
+    "MxRecord": {
+      "type": "object",
+      "properties": {
+        "exchange": {
+          "type": "string",
+          "description": "The domain name of the mail host for this MX record."
+        },
+        "preference": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The preference value for this MX record."
+        }
+      },
+      "description": "An MX record."
+    },
+    "privateDnsZones_AAAA_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the record set."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the record set, relative to the name of the zone."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RecordSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the records in the record set."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "AAAA"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/AAAA"
+    },
+    "privateDnsZones_A_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the record set."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the record set, relative to the name of the zone."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RecordSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the records in the record set."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "A"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/A"
+    },
+    "privateDnsZones_CNAME_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the record set."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the record set, relative to the name of the zone."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RecordSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the records in the record set."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "CNAME"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/CNAME"
+    },
+    "privateDnsZones_MX_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the record set."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the record set, relative to the name of the zone."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RecordSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the records in the record set."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "MX"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/MX"
+    },
+    "privateDnsZones_PTR_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the record set."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the record set, relative to the name of the zone."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RecordSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the records in the record set."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "PTR"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/PTR"
+    },
+    "privateDnsZones_SOA_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the record set."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the record set, relative to the name of the zone."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RecordSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the records in the record set."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "SOA"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/SOA"
+    },
+    "privateDnsZones_SRV_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the record set."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the record set, relative to the name of the zone."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RecordSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the records in the record set."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "SRV"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/SRV"
+    },
+    "privateDnsZones_TXT_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the record set."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the record set, relative to the name of the zone."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RecordSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the records in the record set."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "TXT"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/TXT"
+    },
+    "privateDnsZones_virtualNetworkLinks_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the virtual network link."
+        },
+        "location": {
+          "type": "string",
+          "description": "The Azure Region where the resource lives"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the virtual network link."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/VirtualNetworkLinkProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Represents the properties of the Private DNS zone."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "virtualNetworkLinks"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/privateDnsZones/virtualNetworkLinks"
+    },
+    "PrivateZoneProperties": {
+      "type": "object",
+      "properties": {},
+      "description": "Represents the properties of the Private DNS zone."
+    },
+    "PtrRecord": {
+      "type": "object",
+      "properties": {
+        "ptrdname": {
+          "type": "string",
+          "description": "The PTR target domain name for this PTR record."
+        }
+      },
+      "description": "A PTR record."
+    },
+    "RecordSetProperties": {
+      "type": "object",
+      "properties": {
+        "aaaaRecords": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AaaaRecord"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of AAAA records in the record set."
+        },
+        "aRecords": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ARecord"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of A records in the record set."
+        },
+        "cnameRecord": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/CnameRecord"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "A CNAME record."
+        },
+        "metadata": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The metadata attached to the record set."
+        },
+        "mxRecords": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/MxRecord"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of MX records in the record set."
+        },
+        "ptrRecords": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PtrRecord"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of PTR records in the record set."
+        },
+        "soaRecord": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SoaRecord"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "An SOA record."
+        },
+        "srvRecords": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SrvRecord"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of SRV records in the record set."
+        },
+        "ttl": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The TTL (time-to-live) of the records in the record set."
+        },
+        "txtRecords": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TxtRecord"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of TXT records in the record set."
+        }
+      },
+      "description": "Represents the properties of the records in the record set."
+    },
+    "SoaRecord": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "description": "The email contact for this SOA record."
+        },
+        "expireTime": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The expire time for this SOA record."
+        },
+        "host": {
+          "type": "string",
+          "description": "The domain name of the authoritative name server for this SOA record."
+        },
+        "minimumTtl": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The minimum value for this SOA record. By convention this is used to determine the negative caching duration."
+        },
+        "refreshTime": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The refresh value for this SOA record."
+        },
+        "retryTime": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The retry time for this SOA record."
+        },
+        "serialNumber": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The serial number for this SOA record."
+        }
+      },
+      "description": "An SOA record."
+    },
+    "SrvRecord": {
+      "type": "object",
+      "properties": {
+        "port": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The port value for this SRV record."
+        },
+        "priority": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The priority value for this SRV record."
+        },
+        "target": {
+          "type": "string",
+          "description": "The target domain name for this SRV record."
+        },
+        "weight": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The weight value for this SRV record."
+        }
+      },
+      "description": "An SRV record."
+    },
+    "SubResource": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID."
+        }
+      },
+      "description": "Reference to another subresource."
+    },
+    "TxtRecord": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The text value of this TXT record."
+        }
+      },
+      "description": "A TXT record."
+    },
+    "VirtualNetworkLinkProperties": {
+      "type": "object",
+      "properties": {
+        "registrationEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Is auto-registration of virtual machine records in the virtual network in the Private DNS zone enabled?"
+        },
+        "virtualNetwork": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SubResource"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Reference to another subresource."
+        }
+      },
+      "description": "Represents the properties of the Private DNS zone."
+    }
+  }
+}

--- a/schemas/common/autogeneratedResources.json
+++ b/schemas/common/autogeneratedResources.json
@@ -2429,6 +2429,36 @@
           "$ref": "https://schema.management.azure.com/schemas/2019-11-01/Microsoft.NetApp.json#/resourceDefinitions/netAppAccounts_capacityPools_volumes_snapshots"
         },
         {
+          "$ref": "https://schema.management.azure.com/schemas/2018-09-01/Microsoft.Network.PrivateDNS.json#/resourceDefinitions/privateDnsZones"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-09-01/Microsoft.Network.PrivateDNS.json#/resourceDefinitions/privateDnsZones_A"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-09-01/Microsoft.Network.PrivateDNS.json#/resourceDefinitions/privateDnsZones_AAAA"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-09-01/Microsoft.Network.PrivateDNS.json#/resourceDefinitions/privateDnsZones_CNAME"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-09-01/Microsoft.Network.PrivateDNS.json#/resourceDefinitions/privateDnsZones_MX"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-09-01/Microsoft.Network.PrivateDNS.json#/resourceDefinitions/privateDnsZones_PTR"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-09-01/Microsoft.Network.PrivateDNS.json#/resourceDefinitions/privateDnsZones_SOA"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-09-01/Microsoft.Network.PrivateDNS.json#/resourceDefinitions/privateDnsZones_SRV"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-09-01/Microsoft.Network.PrivateDNS.json#/resourceDefinitions/privateDnsZones_TXT"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-09-01/Microsoft.Network.PrivateDNS.json#/resourceDefinitions/privateDnsZones_virtualNetworkLinks"
+        },
+        {
           "$ref": "https://schema.management.azure.com/schemas/2015-03-20/Microsoft.OperationalInsights.json#/resourceDefinitions/workspaces_savedSearches"
         },
         {


### PR DESCRIPTION
```
> azure-schema-generator@1.0.0 generate-single /home/leni/workspace/azure-resource-manager-schemas/generator
> ts-node cmd/generatesingle "privatedns/resource-manager"

[/tmp/schm_azspc] executing: git fsck
[/tmp/schm_azspc] executing: git reset -q .
[/tmp/schm_azspc] executing: git checkout -q -- .
[/tmp/schm_azspc] executing: git clean -q -fd
[/tmp/schm_azspc] executing: git gc
[/tmp/schm_azspc] executing: git fetch -q
[/tmp/schm_azspc] executing: git checkout -q origin/master
Using whitelist config:
{
  "basePath": "privatedns/resource-manager",
  "namespace": "Microsoft.Network",
  "suffix": "PrivateDNS"
}
[/home/leni/workspace/azure-resource-manager-schemas/generator] executing: autorest-beta --version=3.0.6242 --use=@autorest/azureresourceschema@3.0.77 --azureresourceschema --output-folder=/tmp/61s7ps2gar3 --tag=all-api-versions --api-version=2018-09-01 --title=none --pass-thru:subset-reducer /tmp/schm_azspc/specification/privatedns/resource-manager/readme.md
AutoRest code generation utility [cli version: 3.0.6187; node: v13.9.0, max-memory: 8192 gb]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest
   Loading AutoRest core      '/home/leni/.autorest/@autorest_core@3.0.6242/node_modules/@autorest/core/dist' (3.0.6242)
   Loading AutoRest extension '@autorest/azureresourceschema' (3.0.77->3.0.77)
[7.06 s] Generation Complete
================================================================================================================================
Filename: /home/leni/workspace/azure-resource-manager-schemas/schemas/2018-09-01/Microsoft.Network.PrivateDNS.json
Provider Namespace: Microsoft.Network
API Version: 2018-09-01
Resource Types (Resource Group Scope):
- privateDnsZones
- privateDnsZones/A
- privateDnsZones/AAAA
- privateDnsZones/CNAME
- privateDnsZones/MX
- privateDnsZones/PTR
- privateDnsZones/SOA
- privateDnsZones/SRV
- privateDnsZones/TXT
- privateDnsZones/virtualNetworkLinks
================================================================================================================================
```