### PR TITLE
fix properties empty

### DIFF
--- a/schemas/2019-11-09/Microsoft.Kusto.json
+++ b/schemas/2019-11-09/Microsoft.Kusto.json
@@ -268,7 +268,7 @@
         "properties": {
           "oneOf": [
             {
-              "$ref": "#/definitions/ClusterPrincipalAssignment"
+              "$ref": "#/definitions/ClusterPrincipalProperties"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
@@ -306,7 +306,7 @@
         "properties": {
           "oneOf": [
             {
-              "$ref": "#/definitions/DatabasePrincipalAssignment"
+              "$ref": "#/definitions/DatabasePrincipalProperties"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
@@ -660,40 +660,6 @@
         "principalType"
       ],
       "description": "A class representing cluster principal property."
-    },
-    "DatabasePrincipalAssignment": {
-      "type": "object",
-      "properties": {
-        "properties": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/DatabasePrincipalProperties"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
-          ],
-          "description": "Class representing the database principal properties."
-        }
-      },
-      "description": "Class representing a database principal assignment."
-    },
-    "ClusterPrincipalAssignment": {
-      "type": "object",
-      "properties": {
-        "properties": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/ClusterPrincipalProperties"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
-          ],
-          "description": "Class representing the cluster principal properties."
-        }
-      },
-      "description": "Class representing a cluster principal assignment."
     },
     "EventGridDataConnection": {
       "type": "object",


### PR DESCRIPTION
In our export template, the properties for principalassignments are empty. I guess there is a mistake in the schema definition. So this PR aims to fix that