### PR TITLE
Allow empty and missing accessPolicies in healthcareapis/services

### DIFF
--- a/schemas/2018-08-20-preview/Microsoft.HealthcareApis.json
+++ b/schemas/2018-08-20-preview/Microsoft.HealthcareApis.json
@@ -279,7 +279,6 @@
           "oneOf": [
             {
               "type": "array",
-              "minItems": 1,
               "items": {
                 "$ref": "#/definitions/ServiceAccessPolicyEntry"
               }
@@ -324,9 +323,6 @@
             "description": "The settings for the CORS configuration of the service instance."
         }
       },
-      "required": [
-        "accessPolicies"
-      ],
       "description": "The properties of a service instance."
     }
   }

--- a/schemas/2019-09-16/Microsoft.HealthcareApis.json
+++ b/schemas/2019-09-16/Microsoft.HealthcareApis.json
@@ -316,7 +316,6 @@
           "oneOf": [
             {
               "type": "array",
-              "minItems": 1,
               "items": {
                 "$ref": "#/definitions/ServiceAccessPolicyEntry"
               }
@@ -372,9 +371,6 @@
           "description": "The settings for the export operation of the service instance."
         }
       },
-      "required": [
-        "accessPolicies"
-      ],
       "description": "The properties of a service instance."
     },
     "Identity": {

--- a/tests/2018-08-20-preview/Microsoft.HealthcareApis.tests.json
+++ b/tests/2018-08-20-preview/Microsoft.HealthcareApis.tests.json
@@ -37,6 +37,69 @@
     },
 
     {
+      "name": "services - empty accessPolicies",
+      "definition": "https://schema.management.azure.com/schemas/2018-08-20-preview/Microsoft.HealthcareApis.json#/resourceDefinitions/services",
+      "json": {
+        "name": "service1",
+        "type": "Microsoft.HealthcareApis/services",
+        "apiVersion": "2018-08-20-preview",
+        "location": "westus2",
+        "kind": "fhir",
+        "properties": {
+          "accessPolicies": [],
+          "cosmosDbConfiguration": {
+            "offerThroughput": 1000
+          },
+          "corsConfiguration": {
+            "origins": [
+              "https://www.example.com"
+            ],
+            "maxAge": 2,
+            "methods": [
+              "DELETE",
+              "GET",
+              "OPTIONS",
+              "PATCH",
+              "POST",
+              "PUT"
+            ]
+          }
+        }
+      }
+    },
+
+    {
+      "name": "services - missing accessPolicies",
+      "definition": "https://schema.management.azure.com/schemas/2018-08-20-preview/Microsoft.HealthcareApis.json#/resourceDefinitions/services",
+      "json": {
+        "name": "service1",
+        "type": "Microsoft.HealthcareApis/services",
+        "apiVersion": "2018-08-20-preview",
+        "location": "westus2",
+        "kind": "fhir",
+        "properties": {
+          "cosmosDbConfiguration": {
+            "offerThroughput": 1000
+          },
+          "corsConfiguration": {
+            "origins": [
+              "https://www.example.com"
+            ],
+            "maxAge": 2,
+            "methods": [
+              "DELETE",
+              "GET",
+              "OPTIONS",
+              "PATCH",
+              "POST",
+              "PUT"
+            ]
+          }
+        }
+      }
+    },
+
+    {
       "name": "services - no type property",
       "expectedErrors": [
         {
@@ -79,24 +142,6 @@
       }
     },
 
-    {
-      "name": "services - no accessPolicies",
-      "expectedErrors": [
-        {
-          "message": "Data does not match any schemas from \"oneOf\"",
-          "dataPath": "/properties"
-        }
-      ],
-      "definition": "https://schema.management.azure.com/schemas/2018-08-20-preview/Microsoft.HealthcareApis.json#/resourceDefinitions/services",
-      "json": {
-        "name": "service1",
-        "apiVersion": "2018-08-20-preview",
-        "type": "Microsoft.HealthcareApis/services",
-        "location": "westus2",
-        "kind": "fhir",
-        "properties": {}
-      }
-    },
     {
       "name": "services - Invalid guid in accessPolicies",
       "expectedErrors": [

--- a/tests/2019-09-16/Microsoft.HealthcareApis.tests.json
+++ b/tests/2019-09-16/Microsoft.HealthcareApis.tests.json
@@ -76,6 +76,74 @@
         }
       }
     },
+    {
+      "name": "services - empty access policies",
+      "definition": "https://schema.management.azure.com/schemas/2019-09-16/Microsoft.HealthcareApis.json#/resourceDefinitions/services",
+      "json": {
+        "name": "service1",
+        "type": "Microsoft.HealthcareApis/services",
+        "apiVersion": "2019-09-16",
+        "location": "westus2",
+        "kind": "fhir",
+        "identity": {
+          "type": "None"
+        },
+        "properties": {
+          "accessPolicies": [],
+          "cosmosDbConfiguration": {
+            "offerThroughput": 1000
+          },
+          "corsConfiguration": {
+            "origins": [
+              "https://www.example.com"
+            ],
+            "maxAge": 2,
+            "methods": [
+              "DELETE",
+              "GET",
+              "OPTIONS",
+              "PATCH",
+              "POST",
+              "PUT"
+            ]
+          }
+        }
+      }
+    },
+
+    {
+      "name": "services - missing access policies",
+      "definition": "https://schema.management.azure.com/schemas/2019-09-16/Microsoft.HealthcareApis.json#/resourceDefinitions/services",
+      "json": {
+        "name": "service1",
+        "type": "Microsoft.HealthcareApis/services",
+        "apiVersion": "2019-09-16",
+        "location": "westus2",
+        "kind": "fhir",
+        "identity": {
+          "type": "None"
+        },
+        "properties": {
+          "cosmosDbConfiguration": {
+            "offerThroughput": 1000
+          },
+          "corsConfiguration": {
+            "origins": [
+              "https://www.example.com"
+            ],
+            "maxAge": 2,
+            "methods": [
+              "DELETE",
+              "GET",
+              "OPTIONS",
+              "PATCH",
+              "POST",
+              "PUT"
+            ]
+          }
+        }
+      }
+    },
 
     {
       "name": "services - no type property",
@@ -126,27 +194,6 @@
       }
     },
 
-    {
-      "name": "services - no accessPolicies",
-      "expectedErrors": [
-        {
-          "message": "Data does not match any schemas from \"oneOf\"",
-          "dataPath": "/properties"
-        }
-      ],
-      "definition": "https://schema.management.azure.com/schemas/2019-09-16/Microsoft.HealthcareApis.json#/resourceDefinitions/services",
-      "json": {
-        "name": "service1",
-        "apiVersion": "2019-09-16",
-        "type": "Microsoft.HealthcareApis/services",
-        "location": "westus2",
-        "kind": "fhir",
-        "identity": {
-          "type": "None"
-        },
-        "properties": {}
-      }
-    },
     {
       "name": "services - Invalid guid in accessPolicies",
       "expectedErrors": [


### PR DESCRIPTION
We no longer require at least one access policy in  `Microsoft.HealthcareApis/services`