### PR TITLE
Onboarding trafficmanager/Network for autogeneration

### DIFF
--- a/generator/whitelist.ts
+++ b/generator/whitelist.ts
@@ -538,6 +538,11 @@ const whitelist: WhitelistConfig[] = [
         namespace: 'Microsoft.TimeSeriesInsights',
     },
     {
+        basePath: 'trafficmanager/resource-manager',
+        namespace: 'Microsoft.Network',
+        suffix: 'TrafficManager',
+    },
+    {
         basePath: 'imagebuilder/resource-manager',
         namespace: 'Microsoft.VirtualMachineImages',
     },

--- a/schemas/2015-11-01/Microsoft.Network.TrafficManager.json
+++ b/schemas/2015-11-01/Microsoft.Network.TrafficManager.json
@@ -1,0 +1,260 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2015-11-01/Microsoft.Network.TrafficManager.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Network",
+  "description": "Microsoft Network Resource Types",
+  "resourceDefinitions": {
+    "trafficmanagerprofiles": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-11-01"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the Traffic Manager profile."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ProfileProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class representing the Traffic Manager profile properties."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/trafficmanagerprofiles"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/trafficmanagerprofiles"
+    }
+  },
+  "definitions": {
+    "DnsConfig": {
+      "type": "object",
+      "properties": {
+        "fqdn": {
+          "type": "string",
+          "description": "Gets or sets the fully-qualified domain name (FQDN) of the Traffic Manager profile.  This is formed from the concatenation of the RelativeName with the DNS domain used by Azure Traffic Manager."
+        },
+        "relativeName": {
+          "type": "string",
+          "description": "Gets or sets the relative DNS name provided by this Traffic Manager profile.  This value is combined with the DNS domain name used by Azure Traffic Manager to form the fully-qualified domain name (FQDN) of the profile."
+        },
+        "ttl": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the DNS Time-To-Live (TTL), in seconds.  This informs the local DNS resolvers and DNS clients how long to cache DNS responses provided by this Traffic Manager profile."
+        }
+      },
+      "description": "Class containing DNS settings in a Traffic Manager profile."
+    },
+    "Endpoint": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Gets or sets the ID of the Traffic Manager endpoint."
+        },
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the name of the Traffic Manager endpoint."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/EndpointProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class representing a Traffic Manager endpoint properties."
+        },
+        "type": {
+          "type": "string",
+          "description": "Gets or sets the endpoint type of the Traffic Manager endpoint."
+        }
+      },
+      "description": "Class representing a Traffic Manager endpoint."
+    },
+    "EndpointProperties": {
+      "type": "object",
+      "properties": {
+        "endpointLocation": {
+          "type": "string",
+          "description": "Specifies the location of the external or nested endpoints when using the ‘Performance’ traffic routing method."
+        },
+        "endpointMonitorStatus": {
+          "type": "string",
+          "description": "Gets or sets the monitoring status of the endpoint."
+        },
+        "endpointStatus": {
+          "type": "string",
+          "description": "Gets or sets the status of the endpoint..  If the endpoint is Enabled, it is probed for endpoint health and is included in the traffic routing method.  Possible values are 'Enabled' and 'Disabled'."
+        },
+        "minChildEndpoints": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the minimum number of endpoints that must be available in the child profile in order for the parent profile to be considered available. Only applicable to endpoint of type 'NestedEndpoints'."
+        },
+        "priority": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the priority of this endpoint when using the ‘Priority’ traffic routing method. Possible values are from 1 to 1000, lower values represent higher priority. This is an optional parameter.  If specified, it must be specified on all endpoints, and no two endpoints can share the same priority value."
+        },
+        "target": {
+          "type": "string",
+          "description": "Gets or sets the fully-qualified DNS name of the endpoint.  Traffic Manager returns this value in DNS responses to direct traffic to this endpoint."
+        },
+        "targetResourceId": {
+          "type": "string",
+          "description": "Gets or sets the Azure Resource URI of the of the endpoint.  Not applicable to endpoints of type 'ExternalEndpoints'."
+        },
+        "weight": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000."
+        }
+      },
+      "description": "Class representing a Traffic Manager endpoint properties."
+    },
+    "MonitorConfig": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Gets or sets the path relative to the endpoint domain name used to probe for endpoint health."
+        },
+        "port": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the TCP port used to probe for endpoint health."
+        },
+        "profileMonitorStatus": {
+          "type": "string",
+          "description": "Gets or sets the profile-level monitoring status of the Traffic Manager profile."
+        },
+        "protocol": {
+          "type": "string",
+          "description": "Gets or sets the protocol (HTTP or HTTPS) used to probe for endpoint health."
+        }
+      },
+      "description": "Class containing endpoint monitoring settings in a Traffic Manager profile."
+    },
+    "ProfileProperties": {
+      "type": "object",
+      "properties": {
+        "dnsConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DnsConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class containing DNS settings in a Traffic Manager profile."
+        },
+        "endpoints": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Endpoint"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the list of endpoints in the Traffic Manager profile."
+        },
+        "monitorConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitorConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class containing endpoint monitoring settings in a Traffic Manager profile."
+        },
+        "profileStatus": {
+          "type": "string",
+          "description": "Gets or sets the status of the Traffic Manager profile.  Possible values are 'Enabled' and 'Disabled'."
+        },
+        "trafficRoutingMethod": {
+          "type": "string",
+          "description": "Gets or sets the traffic routing method of the Traffic Manager profile.  Possible values are 'Performance', 'Weighted', or 'Priority'."
+        }
+      },
+      "description": "Class representing the Traffic Manager profile properties."
+    }
+  }
+}

--- a/schemas/2017-03-01/Microsoft.Network.TrafficManager.json
+++ b/schemas/2017-03-01/Microsoft.Network.TrafficManager.json
@@ -1,0 +1,274 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2017-03-01/Microsoft.Network.TrafficManager.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Network",
+  "description": "Microsoft Network Resource Types",
+  "resourceDefinitions": {
+    "trafficmanagerprofiles": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-03-01"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the Traffic Manager profile."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ProfileProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class representing the Traffic Manager profile properties."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/trafficmanagerprofiles"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/trafficmanagerprofiles"
+    }
+  },
+  "definitions": {
+    "DnsConfig": {
+      "type": "object",
+      "properties": {
+        "fqdn": {
+          "type": "string",
+          "description": "Gets or sets the fully-qualified domain name (FQDN) of the Traffic Manager profile.  This is formed from the concatenation of the RelativeName with the DNS domain used by Azure Traffic Manager."
+        },
+        "relativeName": {
+          "type": "string",
+          "description": "Gets or sets the relative DNS name provided by this Traffic Manager profile.  This value is combined with the DNS domain name used by Azure Traffic Manager to form the fully-qualified domain name (FQDN) of the profile."
+        },
+        "ttl": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the DNS Time-To-Live (TTL), in seconds.  This informs the local DNS resolvers and DNS clients how long to cache DNS responses provided by this Traffic Manager profile."
+        }
+      },
+      "description": "Class containing DNS settings in a Traffic Manager profile."
+    },
+    "Endpoint": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Gets or sets the ID of the Traffic Manager endpoint."
+        },
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the name of the Traffic Manager endpoint."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/EndpointProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class representing a Traffic Manager endpoint properties."
+        },
+        "type": {
+          "type": "string",
+          "description": "Gets or sets the endpoint type of the Traffic Manager endpoint."
+        }
+      },
+      "description": "Class representing a Traffic Manager endpoint."
+    },
+    "EndpointProperties": {
+      "type": "object",
+      "properties": {
+        "endpointLocation": {
+          "type": "string",
+          "description": "Specifies the location of the external or nested endpoints when using the ‘Performance’ traffic routing method."
+        },
+        "endpointMonitorStatus": {
+          "type": "string",
+          "description": "Gets or sets the monitoring status of the endpoint."
+        },
+        "endpointStatus": {
+          "type": "string",
+          "description": "Gets or sets the status of the endpoint..  If the endpoint is Enabled, it is probed for endpoint health and is included in the traffic routing method.  Possible values are 'Enabled' and 'Disabled'."
+        },
+        "geoMapping": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the list of countries/regions mapped to this endpoint when using the ‘Geographic’ traffic routing method. Please consult Traffic Manager Geographic documentation for a full list of accepted values."
+        },
+        "minChildEndpoints": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the minimum number of endpoints that must be available in the child profile in order for the parent profile to be considered available. Only applicable to endpoint of type 'NestedEndpoints'."
+        },
+        "priority": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the priority of this endpoint when using the ‘Priority’ traffic routing method. Possible values are from 1 to 1000, lower values represent higher priority. This is an optional parameter.  If specified, it must be specified on all endpoints, and no two endpoints can share the same priority value."
+        },
+        "target": {
+          "type": "string",
+          "description": "Gets or sets the fully-qualified DNS name of the endpoint.  Traffic Manager returns this value in DNS responses to direct traffic to this endpoint."
+        },
+        "targetResourceId": {
+          "type": "string",
+          "description": "Gets or sets the Azure Resource URI of the of the endpoint.  Not applicable to endpoints of type 'ExternalEndpoints'."
+        },
+        "weight": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000."
+        }
+      },
+      "description": "Class representing a Traffic Manager endpoint properties."
+    },
+    "MonitorConfig": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Gets or sets the path relative to the endpoint domain name used to probe for endpoint health."
+        },
+        "port": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the TCP port used to probe for endpoint health."
+        },
+        "profileMonitorStatus": {
+          "type": "string",
+          "description": "Gets or sets the profile-level monitoring status of the Traffic Manager profile."
+        },
+        "protocol": {
+          "type": "string",
+          "description": "Gets or sets the protocol (HTTP or HTTPS) used to probe for endpoint health."
+        }
+      },
+      "description": "Class containing endpoint monitoring settings in a Traffic Manager profile."
+    },
+    "ProfileProperties": {
+      "type": "object",
+      "properties": {
+        "dnsConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DnsConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class containing DNS settings in a Traffic Manager profile."
+        },
+        "endpoints": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Endpoint"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the list of endpoints in the Traffic Manager profile."
+        },
+        "monitorConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitorConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class containing endpoint monitoring settings in a Traffic Manager profile."
+        },
+        "profileStatus": {
+          "type": "string",
+          "description": "Gets or sets the status of the Traffic Manager profile.  Possible values are 'Enabled' and 'Disabled'."
+        },
+        "trafficRoutingMethod": {
+          "type": "string",
+          "description": "Gets or sets the traffic routing method of the Traffic Manager profile.  Possible values are 'Performance', 'Weighted', 'Priority' or 'Geographic'."
+        }
+      },
+      "description": "Class representing the Traffic Manager profile properties."
+    }
+  }
+}

--- a/schemas/2017-05-01/Microsoft.Network.TrafficManager.json
+++ b/schemas/2017-05-01/Microsoft.Network.TrafficManager.json
@@ -1,0 +1,367 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2017-05-01/Microsoft.Network.TrafficManager.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Network",
+  "description": "Microsoft Network Resource Types",
+  "resourceDefinitions": {
+    "trafficmanagerprofiles": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-05-01"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The Azure Region where the resource lives"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the Traffic Manager profile."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ProfileProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class representing the Traffic Manager profile properties."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/trafficmanagerprofiles"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/trafficmanagerprofiles"
+    }
+  },
+  "definitions": {
+    "DnsConfig": {
+      "type": "object",
+      "properties": {
+        "relativeName": {
+          "type": "string",
+          "description": "The relative DNS name provided by this Traffic Manager profile. This value is combined with the DNS domain name used by Azure Traffic Manager to form the fully-qualified domain name (FQDN) of the profile."
+        },
+        "ttl": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The DNS Time-To-Live (TTL), in seconds. This informs the local DNS resolvers and DNS clients how long to cache DNS responses provided by this Traffic Manager profile."
+        }
+      },
+      "description": "Class containing DNS settings in a Traffic Manager profile."
+    },
+    "Endpoint": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/EndpointProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class representing a Traffic Manager endpoint properties."
+        }
+      },
+      "description": "Class representing a Traffic Manager endpoint."
+    },
+    "EndpointProperties": {
+      "type": "object",
+      "properties": {
+        "endpointLocation": {
+          "type": "string",
+          "description": "Specifies the location of the external or nested endpoints when using the ‘Performance’ traffic routing method."
+        },
+        "endpointMonitorStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "CheckingEndpoint",
+                "Online",
+                "Degraded",
+                "Disabled",
+                "Inactive",
+                "Stopped"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The monitoring status of the endpoint."
+        },
+        "endpointStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The status of the endpoint. If the endpoint is Enabled, it is probed for endpoint health and is included in the traffic routing method."
+        },
+        "geoMapping": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of countries/regions mapped to this endpoint when using the ‘Geographic’ traffic routing method. Please consult Traffic Manager Geographic documentation for a full list of accepted values."
+        },
+        "minChildEndpoints": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The minimum number of endpoints that must be available in the child profile in order for the parent profile to be considered available. Only applicable to endpoint of type 'NestedEndpoints'."
+        },
+        "priority": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The priority of this endpoint when using the ‘Priority’ traffic routing method. Possible values are from 1 to 1000, lower values represent higher priority. This is an optional parameter.  If specified, it must be specified on all endpoints, and no two endpoints can share the same priority value."
+        },
+        "target": {
+          "type": "string",
+          "description": "The fully-qualified DNS name of the endpoint. Traffic Manager returns this value in DNS responses to direct traffic to this endpoint."
+        },
+        "targetResourceId": {
+          "type": "string",
+          "description": "The Azure Resource URI of the of the endpoint. Not applicable to endpoints of type 'ExternalEndpoints'."
+        },
+        "weight": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000."
+        }
+      },
+      "description": "Class representing a Traffic Manager endpoint properties."
+    },
+    "MonitorConfig": {
+      "type": "object",
+      "properties": {
+        "intervalInSeconds": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The monitor interval for endpoints in this profile. This is the interval at which Traffic Manager will check the health of each endpoint in this profile."
+        },
+        "path": {
+          "type": "string",
+          "description": "The path relative to the endpoint domain name used to probe for endpoint health."
+        },
+        "port": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The TCP port used to probe for endpoint health."
+        },
+        "profileMonitorStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "CheckingEndpoints",
+                "Online",
+                "Degraded",
+                "Disabled",
+                "Inactive"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The profile-level monitoring status of the Traffic Manager profile."
+        },
+        "protocol": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "HTTP",
+                "HTTPS",
+                "TCP"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The protocol (HTTP, HTTPS or TCP) used to probe for endpoint health."
+        },
+        "timeoutInSeconds": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The monitor timeout for endpoints in this profile. This is the time that Traffic Manager allows endpoints in this profile to response to the health check."
+        },
+        "toleratedNumberOfFailures": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The number of consecutive failed health check that Traffic Manager tolerates before declaring an endpoint in this profile Degraded after the next failed health check."
+        }
+      },
+      "description": "Class containing endpoint monitoring settings in a Traffic Manager profile."
+    },
+    "ProfileProperties": {
+      "type": "object",
+      "properties": {
+        "dnsConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DnsConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class containing DNS settings in a Traffic Manager profile."
+        },
+        "endpoints": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Endpoint"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of endpoints in the Traffic Manager profile."
+        },
+        "monitorConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitorConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class containing endpoint monitoring settings in a Traffic Manager profile."
+        },
+        "profileStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The status of the Traffic Manager profile."
+        },
+        "trafficRoutingMethod": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Performance",
+                "Priority",
+                "Weighted",
+                "Geographic"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The traffic routing method of the Traffic Manager profile."
+        }
+      },
+      "description": "Class representing the Traffic Manager profile properties."
+    }
+  }
+}

--- a/schemas/2017-09-01-preview/Microsoft.Network.TrafficManager.json
+++ b/schemas/2017-09-01-preview/Microsoft.Network.TrafficManager.json
@@ -1,0 +1,39 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2017-09-01-preview/Microsoft.Network.TrafficManager.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Network",
+  "description": "Microsoft Network Resource Types",
+  "resourceDefinitions": {},
+  "subscription_resourceDefinitions": {
+    "trafficManagerUserMetricsKeys": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-09-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "trafficManagerUserMetricsKeys"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/trafficManagerUserMetricsKeys"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Network/trafficManagerUserMetricsKeys"
+    }
+  },
+  "definitions": {}
+}

--- a/schemas/2018-02-01/Microsoft.Network.TrafficManager.json
+++ b/schemas/2018-02-01/Microsoft.Network.TrafficManager.json
@@ -1,0 +1,382 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2018-02-01/Microsoft.Network.TrafficManager.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Network",
+  "description": "Microsoft Network Resource Types",
+  "resourceDefinitions": {
+    "trafficmanagerprofiles": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-02-01"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The Azure Region where the resource lives"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the Traffic Manager profile."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ProfileProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class representing the Traffic Manager profile properties."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/trafficmanagerprofiles"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/trafficmanagerprofiles"
+    }
+  },
+  "definitions": {
+    "DnsConfig": {
+      "type": "object",
+      "properties": {
+        "relativeName": {
+          "type": "string",
+          "description": "The relative DNS name provided by this Traffic Manager profile. This value is combined with the DNS domain name used by Azure Traffic Manager to form the fully-qualified domain name (FQDN) of the profile."
+        },
+        "ttl": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The DNS Time-To-Live (TTL), in seconds. This informs the local DNS resolvers and DNS clients how long to cache DNS responses provided by this Traffic Manager profile."
+        }
+      },
+      "description": "Class containing DNS settings in a Traffic Manager profile."
+    },
+    "Endpoint": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/EndpointProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class representing a Traffic Manager endpoint properties."
+        }
+      },
+      "description": "Class representing a Traffic Manager endpoint."
+    },
+    "EndpointProperties": {
+      "type": "object",
+      "properties": {
+        "endpointLocation": {
+          "type": "string",
+          "description": "Specifies the location of the external or nested endpoints when using the ‘Performance’ traffic routing method."
+        },
+        "endpointMonitorStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "CheckingEndpoint",
+                "Online",
+                "Degraded",
+                "Disabled",
+                "Inactive",
+                "Stopped"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The monitoring status of the endpoint."
+        },
+        "endpointStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The status of the endpoint. If the endpoint is Enabled, it is probed for endpoint health and is included in the traffic routing method."
+        },
+        "geoMapping": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of countries/regions mapped to this endpoint when using the ‘Geographic’ traffic routing method. Please consult Traffic Manager Geographic documentation for a full list of accepted values."
+        },
+        "minChildEndpoints": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The minimum number of endpoints that must be available in the child profile in order for the parent profile to be considered available. Only applicable to endpoint of type 'NestedEndpoints'."
+        },
+        "priority": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The priority of this endpoint when using the ‘Priority’ traffic routing method. Possible values are from 1 to 1000, lower values represent higher priority. This is an optional parameter.  If specified, it must be specified on all endpoints, and no two endpoints can share the same priority value."
+        },
+        "target": {
+          "type": "string",
+          "description": "The fully-qualified DNS name of the endpoint. Traffic Manager returns this value in DNS responses to direct traffic to this endpoint."
+        },
+        "targetResourceId": {
+          "type": "string",
+          "description": "The Azure Resource URI of the of the endpoint. Not applicable to endpoints of type 'ExternalEndpoints'."
+        },
+        "weight": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000."
+        }
+      },
+      "description": "Class representing a Traffic Manager endpoint properties."
+    },
+    "MonitorConfig": {
+      "type": "object",
+      "properties": {
+        "intervalInSeconds": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The monitor interval for endpoints in this profile. This is the interval at which Traffic Manager will check the health of each endpoint in this profile."
+        },
+        "path": {
+          "type": "string",
+          "description": "The path relative to the endpoint domain name used to probe for endpoint health."
+        },
+        "port": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The TCP port used to probe for endpoint health."
+        },
+        "profileMonitorStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "CheckingEndpoints",
+                "Online",
+                "Degraded",
+                "Disabled",
+                "Inactive"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The profile-level monitoring status of the Traffic Manager profile."
+        },
+        "protocol": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "HTTP",
+                "HTTPS",
+                "TCP"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The protocol (HTTP, HTTPS or TCP) used to probe for endpoint health."
+        },
+        "timeoutInSeconds": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The monitor timeout for endpoints in this profile. This is the time that Traffic Manager allows endpoints in this profile to response to the health check."
+        },
+        "toleratedNumberOfFailures": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The number of consecutive failed health check that Traffic Manager tolerates before declaring an endpoint in this profile Degraded after the next failed health check."
+        }
+      },
+      "description": "Class containing endpoint monitoring settings in a Traffic Manager profile."
+    },
+    "ProfileProperties": {
+      "type": "object",
+      "properties": {
+        "dnsConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DnsConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class containing DNS settings in a Traffic Manager profile."
+        },
+        "endpoints": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Endpoint"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of endpoints in the Traffic Manager profile."
+        },
+        "monitorConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitorConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class containing endpoint monitoring settings in a Traffic Manager profile."
+        },
+        "profileStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The status of the Traffic Manager profile."
+        },
+        "trafficRoutingMethod": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Performance",
+                "Priority",
+                "Weighted",
+                "Geographic"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The traffic routing method of the Traffic Manager profile."
+        },
+        "trafficViewEnrollmentStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Indicates whether Traffic View is 'Enabled' or 'Disabled' for the Traffic Manager profile. Null, indicates 'Disabled'. Enabling this feature will increase the cost of the Traffic Manage profile."
+        }
+      },
+      "description": "Class representing the Traffic Manager profile properties."
+    }
+  }
+}

--- a/schemas/2018-03-01/Microsoft.Network.TrafficManager.json
+++ b/schemas/2018-03-01/Microsoft.Network.TrafficManager.json
@@ -1,0 +1,496 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2018-03-01/Microsoft.Network.TrafficManager.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Network",
+  "description": "Microsoft Network Resource Types",
+  "resourceDefinitions": {
+    "trafficmanagerprofiles": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-03-01"
+          ]
+        },
+        "id": {
+          "type": "string",
+          "description": "Fully qualified resource Id for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}"
+        },
+        "location": {
+          "type": "string",
+          "description": "The Azure Region where the resource lives"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the Traffic Manager profile."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ProfileProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class representing the Traffic Manager profile properties."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/trafficmanagerprofiles"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/trafficmanagerprofiles"
+    }
+  },
+  "definitions": {
+    "DnsConfig": {
+      "type": "object",
+      "properties": {
+        "relativeName": {
+          "type": "string",
+          "description": "The relative DNS name provided by this Traffic Manager profile. This value is combined with the DNS domain name used by Azure Traffic Manager to form the fully-qualified domain name (FQDN) of the profile."
+        },
+        "ttl": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The DNS Time-To-Live (TTL), in seconds. This informs the local DNS resolvers and DNS clients how long to cache DNS responses provided by this Traffic Manager profile."
+        }
+      },
+      "description": "Class containing DNS settings in a Traffic Manager profile."
+    },
+    "Endpoint": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Fully qualified resource Id for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/EndpointProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class representing a Traffic Manager endpoint properties."
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles."
+        }
+      },
+      "description": "Class representing a Traffic Manager endpoint."
+    },
+    "EndpointProperties": {
+      "type": "object",
+      "properties": {
+        "customHeaders": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/EndpointPropertiesCustomHeadersItem"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of custom headers."
+        },
+        "endpointLocation": {
+          "type": "string",
+          "description": "Specifies the location of the external or nested endpoints when using the ‘Performance’ traffic routing method."
+        },
+        "endpointMonitorStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "CheckingEndpoint",
+                "Online",
+                "Degraded",
+                "Disabled",
+                "Inactive",
+                "Stopped"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The monitoring status of the endpoint."
+        },
+        "endpointStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The status of the endpoint. If the endpoint is Enabled, it is probed for endpoint health and is included in the traffic routing method."
+        },
+        "geoMapping": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of countries/regions mapped to this endpoint when using the ‘Geographic’ traffic routing method. Please consult Traffic Manager Geographic documentation for a full list of accepted values."
+        },
+        "minChildEndpoints": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The minimum number of endpoints that must be available in the child profile in order for the parent profile to be considered available. Only applicable to endpoint of type 'NestedEndpoints'."
+        },
+        "priority": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The priority of this endpoint when using the ‘Priority’ traffic routing method. Possible values are from 1 to 1000, lower values represent higher priority. This is an optional parameter.  If specified, it must be specified on all endpoints, and no two endpoints can share the same priority value."
+        },
+        "target": {
+          "type": "string",
+          "description": "The fully-qualified DNS name or IP address of the endpoint. Traffic Manager returns this value in DNS responses to direct traffic to this endpoint."
+        },
+        "targetResourceId": {
+          "type": "string",
+          "description": "The Azure Resource URI of the of the endpoint. Not applicable to endpoints of type 'ExternalEndpoints'."
+        },
+        "weight": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000."
+        }
+      },
+      "description": "Class representing a Traffic Manager endpoint properties."
+    },
+    "EndpointPropertiesCustomHeadersItem": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Header name."
+        },
+        "value": {
+          "type": "string",
+          "description": "Header value."
+        }
+      },
+      "description": "Custom header name and value."
+    },
+    "MonitorConfig": {
+      "type": "object",
+      "properties": {
+        "customHeaders": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/MonitorConfigCustomHeadersItem"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of custom headers."
+        },
+        "expectedStatusCodeRanges": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/MonitorConfigExpectedStatusCodeRangesItem"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of expected status code ranges."
+        },
+        "intervalInSeconds": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The monitor interval for endpoints in this profile. This is the interval at which Traffic Manager will check the health of each endpoint in this profile."
+        },
+        "path": {
+          "type": "string",
+          "description": "The path relative to the endpoint domain name used to probe for endpoint health."
+        },
+        "port": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The TCP port used to probe for endpoint health."
+        },
+        "profileMonitorStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "CheckingEndpoints",
+                "Online",
+                "Degraded",
+                "Disabled",
+                "Inactive"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The profile-level monitoring status of the Traffic Manager profile."
+        },
+        "protocol": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "HTTP",
+                "HTTPS",
+                "TCP"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The protocol (HTTP, HTTPS or TCP) used to probe for endpoint health."
+        },
+        "timeoutInSeconds": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The monitor timeout for endpoints in this profile. This is the time that Traffic Manager allows endpoints in this profile to response to the health check."
+        },
+        "toleratedNumberOfFailures": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The number of consecutive failed health check that Traffic Manager tolerates before declaring an endpoint in this profile Degraded after the next failed health check."
+        }
+      },
+      "description": "Class containing endpoint monitoring settings in a Traffic Manager profile."
+    },
+    "MonitorConfigCustomHeadersItem": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Header name."
+        },
+        "value": {
+          "type": "string",
+          "description": "Header value."
+        }
+      },
+      "description": "Custom header name and value."
+    },
+    "MonitorConfigExpectedStatusCodeRangesItem": {
+      "type": "object",
+      "properties": {
+        "max": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Max status code."
+        },
+        "min": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Min status code."
+        }
+      },
+      "description": "Min and max value of a status code range."
+    },
+    "ProfileProperties": {
+      "type": "object",
+      "properties": {
+        "dnsConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DnsConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class containing DNS settings in a Traffic Manager profile."
+        },
+        "endpoints": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Endpoint"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of endpoints in the Traffic Manager profile."
+        },
+        "monitorConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitorConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class containing endpoint monitoring settings in a Traffic Manager profile."
+        },
+        "profileStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The status of the Traffic Manager profile."
+        },
+        "trafficRoutingMethod": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Performance",
+                "Priority",
+                "Weighted",
+                "Geographic"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The traffic routing method of the Traffic Manager profile."
+        },
+        "trafficViewEnrollmentStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Indicates whether Traffic View is 'Enabled' or 'Disabled' for the Traffic Manager profile. Null, indicates 'Disabled'. Enabling this feature will increase the cost of the Traffic Manage profile."
+        }
+      },
+      "description": "Class representing the Traffic Manager profile properties."
+    }
+  }
+}

--- a/schemas/2018-04-01/Microsoft.Network.TrafficManager.json
+++ b/schemas/2018-04-01/Microsoft.Network.TrafficManager.json
@@ -1,0 +1,579 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2018-04-01/Microsoft.Network.TrafficManager.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Network",
+  "description": "Microsoft Network Resource Types",
+  "resourceDefinitions": {
+    "trafficmanagerprofiles": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-04-01"
+          ]
+        },
+        "id": {
+          "type": "string",
+          "description": "Fully qualified resource Id for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}"
+        },
+        "location": {
+          "type": "string",
+          "description": "The Azure Region where the resource lives"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the Traffic Manager profile."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ProfileProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class representing the Traffic Manager profile properties."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/trafficmanagerprofiles"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Network/trafficmanagerprofiles"
+    }
+  },
+  "subscription_resourceDefinitions": {
+    "trafficManagerUserMetricsKeys": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-04-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "default"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Network/trafficManagerUserMetricsKeys"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Network/trafficManagerUserMetricsKeys"
+    }
+  },
+  "definitions": {
+    "DnsConfig": {
+      "type": "object",
+      "properties": {
+        "relativeName": {
+          "type": "string",
+          "description": "The relative DNS name provided by this Traffic Manager profile. This value is combined with the DNS domain name used by Azure Traffic Manager to form the fully-qualified domain name (FQDN) of the profile."
+        },
+        "ttl": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The DNS Time-To-Live (TTL), in seconds. This informs the local DNS resolvers and DNS clients how long to cache DNS responses provided by this Traffic Manager profile."
+        }
+      },
+      "description": "Class containing DNS settings in a Traffic Manager profile."
+    },
+    "Endpoint": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Fully qualified resource Id for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/EndpointProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class representing a Traffic Manager endpoint properties."
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the resource. Ex- Microsoft.Network/trafficManagerProfiles."
+        }
+      },
+      "description": "Class representing a Traffic Manager endpoint."
+    },
+    "EndpointProperties": {
+      "type": "object",
+      "properties": {
+        "customHeaders": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/EndpointPropertiesCustomHeadersItem"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of custom headers."
+        },
+        "endpointLocation": {
+          "type": "string",
+          "description": "Specifies the location of the external or nested endpoints when using the 'Performance' traffic routing method."
+        },
+        "endpointMonitorStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "CheckingEndpoint",
+                "Online",
+                "Degraded",
+                "Disabled",
+                "Inactive",
+                "Stopped"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The monitoring status of the endpoint."
+        },
+        "endpointStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The status of the endpoint. If the endpoint is Enabled, it is probed for endpoint health and is included in the traffic routing method."
+        },
+        "geoMapping": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of countries/regions mapped to this endpoint when using the 'Geographic' traffic routing method. Please consult Traffic Manager Geographic documentation for a full list of accepted values."
+        },
+        "minChildEndpoints": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The minimum number of endpoints that must be available in the child profile in order for the parent profile to be considered available. Only applicable to endpoint of type 'NestedEndpoints'."
+        },
+        "priority": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The priority of this endpoint when using the 'Priority' traffic routing method. Possible values are from 1 to 1000, lower values represent higher priority. This is an optional parameter.  If specified, it must be specified on all endpoints, and no two endpoints can share the same priority value."
+        },
+        "subnets": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/EndpointPropertiesSubnetsItem"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of subnets, IP addresses, and/or address ranges mapped to this endpoint when using the 'Subnet' traffic routing method. An empty list will match all ranges not covered by other endpoints."
+        },
+        "target": {
+          "type": "string",
+          "description": "The fully-qualified DNS name or IP address of the endpoint. Traffic Manager returns this value in DNS responses to direct traffic to this endpoint."
+        },
+        "targetResourceId": {
+          "type": "string",
+          "description": "The Azure Resource URI of the of the endpoint. Not applicable to endpoints of type 'ExternalEndpoints'."
+        },
+        "weight": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The weight of this endpoint when using the 'Weighted' traffic routing method. Possible values are from 1 to 1000."
+        }
+      },
+      "description": "Class representing a Traffic Manager endpoint properties."
+    },
+    "EndpointPropertiesCustomHeadersItem": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Header name."
+        },
+        "value": {
+          "type": "string",
+          "description": "Header value."
+        }
+      },
+      "description": "Custom header name and value."
+    },
+    "EndpointPropertiesSubnetsItem": {
+      "type": "object",
+      "properties": {
+        "first": {
+          "type": "string",
+          "description": "First address in the subnet."
+        },
+        "last": {
+          "type": "string",
+          "description": "Last address in the subnet."
+        },
+        "scope": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Block size (number of leading bits in the subnet mask)."
+        }
+      },
+      "description": "Subnet first address, scope, and/or last address."
+    },
+    "MonitorConfig": {
+      "type": "object",
+      "properties": {
+        "customHeaders": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/MonitorConfigCustomHeadersItem"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of custom headers."
+        },
+        "expectedStatusCodeRanges": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/MonitorConfigExpectedStatusCodeRangesItem"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of expected status code ranges."
+        },
+        "intervalInSeconds": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The monitor interval for endpoints in this profile. This is the interval at which Traffic Manager will check the health of each endpoint in this profile."
+        },
+        "path": {
+          "type": "string",
+          "description": "The path relative to the endpoint domain name used to probe for endpoint health."
+        },
+        "port": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The TCP port used to probe for endpoint health."
+        },
+        "profileMonitorStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "CheckingEndpoints",
+                "Online",
+                "Degraded",
+                "Disabled",
+                "Inactive"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The profile-level monitoring status of the Traffic Manager profile."
+        },
+        "protocol": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "HTTP",
+                "HTTPS",
+                "TCP"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The protocol (HTTP, HTTPS or TCP) used to probe for endpoint health."
+        },
+        "timeoutInSeconds": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The monitor timeout for endpoints in this profile. This is the time that Traffic Manager allows endpoints in this profile to response to the health check."
+        },
+        "toleratedNumberOfFailures": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The number of consecutive failed health check that Traffic Manager tolerates before declaring an endpoint in this profile Degraded after the next failed health check."
+        }
+      },
+      "description": "Class containing endpoint monitoring settings in a Traffic Manager profile."
+    },
+    "MonitorConfigCustomHeadersItem": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Header name."
+        },
+        "value": {
+          "type": "string",
+          "description": "Header value."
+        }
+      },
+      "description": "Custom header name and value."
+    },
+    "MonitorConfigExpectedStatusCodeRangesItem": {
+      "type": "object",
+      "properties": {
+        "max": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Max status code."
+        },
+        "min": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Min status code."
+        }
+      },
+      "description": "Min and max value of a status code range."
+    },
+    "ProfileProperties": {
+      "type": "object",
+      "properties": {
+        "dnsConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DnsConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class containing DNS settings in a Traffic Manager profile."
+        },
+        "endpoints": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Endpoint"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of endpoints in the Traffic Manager profile."
+        },
+        "maxReturn": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Maximum number of endpoints to be returned for MultiValue routing type."
+        },
+        "monitorConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitorConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Class containing endpoint monitoring settings in a Traffic Manager profile."
+        },
+        "profileStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The status of the Traffic Manager profile."
+        },
+        "trafficRoutingMethod": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Performance",
+                "Priority",
+                "Weighted",
+                "Geographic",
+                "MultiValue",
+                "Subnet"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The traffic routing method of the Traffic Manager profile."
+        },
+        "trafficViewEnrollmentStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Indicates whether Traffic View is 'Enabled' or 'Disabled' for the Traffic Manager profile. Null, indicates 'Disabled'. Enabling this feature will increase the cost of the Traffic Manage profile."
+        }
+      },
+      "description": "Class representing the Traffic Manager profile properties."
+    }
+  }
+}

--- a/schemas/2018-05-01/subscriptionDeploymentTemplate.json
+++ b/schemas/2018-05-01/subscriptionDeploymentTemplate.json
@@ -197,6 +197,12 @@
                 "$ref": "https://schema.management.azure.com/schemas/2019-06-01-preview/Microsoft.ManagedNetwork.json#/unknown_resourceDefinitions/scopeAssignments"
               },
               {
+                "$ref": "https://schema.management.azure.com/schemas/2017-09-01-preview/Microsoft.Network.TrafficManager.json#/subscription_resourceDefinitions/trafficManagerUserMetricsKeys"
+              },
+              {
+                "$ref": "https://schema.management.azure.com/schemas/2018-04-01/Microsoft.Network.TrafficManager.json#/subscription_resourceDefinitions/trafficManagerUserMetricsKeys"
+              },
+              {
                 "$ref": "https://schema.management.azure.com/schemas/2019-08-01-preview/Microsoft.Peering.json#/subscription_resourceDefinitions/peerAsns"
               },
               {

--- a/schemas/common/autogeneratedResources.json
+++ b/schemas/common/autogeneratedResources.json
@@ -3302,6 +3302,24 @@
           "$ref": "https://schema.management.azure.com/schemas/2020-05-01/Microsoft.Network.FrontDoor.json#/resourceDefinitions/frontDoors_rulesEngines"
         },
         {
+          "$ref": "https://schema.management.azure.com/schemas/2015-11-01/Microsoft.Network.TrafficManager.json#/resourceDefinitions/trafficmanagerprofiles"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2017-03-01/Microsoft.Network.TrafficManager.json#/resourceDefinitions/trafficmanagerprofiles"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2017-05-01/Microsoft.Network.TrafficManager.json#/resourceDefinitions/trafficmanagerprofiles"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-02-01/Microsoft.Network.TrafficManager.json#/resourceDefinitions/trafficmanagerprofiles"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-03-01/Microsoft.Network.TrafficManager.json#/resourceDefinitions/trafficmanagerprofiles"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-04-01/Microsoft.Network.TrafficManager.json#/resourceDefinitions/trafficmanagerprofiles"
+        },
+        {
           "$ref": "https://schema.management.azure.com/schemas/2014-09-01/Microsoft.NotificationHubs.json#/resourceDefinitions/namespaces"
         },
         {


### PR DESCRIPTION
```
> azure-schema-generator@1.0.0 generate-single /home/leni/workspace/azure-resource-manager-schemas/generator
> ts-node cmd/generatesingle "trafficmanager/resource-manager"

[/tmp/schm_azspc] executing: git fsck
[/tmp/schm_azspc] executing: git reset -q .
[/tmp/schm_azspc] executing: git checkout -q -- .
[/tmp/schm_azspc] executing: git clean -q -fd
[/tmp/schm_azspc] executing: git gc
[/tmp/schm_azspc] executing: git fetch -q
[/tmp/schm_azspc] executing: git checkout -q origin/master
Using whitelist config:
{
  "basePath": "trafficmanager/resource-manager",
  "namespace": "Microsoft.Network",
  "suffix": "TrafficManager"
}
[/home/leni/workspace/azure-resource-manager-schemas/generator] executing: autorest-beta --version=3.0.6274 --use=@autorest/azureresourceschema@3.0.79 --azureresourceschema --output-folder=/tmp/h5xq93cg7e --tag=all-api-versions --api-version=2017-09-01-preview --title=none --pass-thru:subset-reducer /tmp/schm_azspc/specification/trafficmanager/resource-manager/readme.md
AutoRest code generation utility [cli version: 3.0.6187; node: v13.9.0, max-memory: 8192 gb]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest
   Loading AutoRest core      '/home/leni/.autorest/@autorest_core@3.0.6274/node_modules/@autorest/core/dist' (3.0.6274)
   Loading AutoRest extension '@autorest/azureresourceschema' (3.0.79->3.0.79)
[5.93 s] Generation Complete
================================================================================================================================
Filename: /home/leni/workspace/azure-resource-manager-schemas/schemas/2017-09-01-preview/Microsoft.Network.TrafficManager.json
Provider Namespace: Microsoft.Network
API Version: 2017-09-01-preview
Resource Types (Subscription Scope):
- trafficManagerUserMetricsKeys
================================================================================================================================
[/home/leni/workspace/azure-resource-manager-schemas/generator] executing: autorest-beta --version=3.0.6274 --use=@autorest/azureresourceschema@3.0.79 --azureresourceschema --output-folder=/tmp/9k4wjgudho --tag=all-api-versions --api-version=2015-11-01 --title=none --pass-thru:subset-reducer /tmp/schm_azspc/specification/trafficmanager/resource-manager/readme.md
AutoRest code generation utility [cli version: 3.0.6187; node: v13.9.0, max-memory: 8192 gb]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest
   Loading AutoRest core      '/home/leni/.autorest/@autorest_core@3.0.6274/node_modules/@autorest/core/dist' (3.0.6274)
   Loading AutoRest extension '@autorest/azureresourceschema' (3.0.79->3.0.79)
WARNING: Skipping path '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficmanagerprofiles/{profileName}/{endpointType}/{endpointName}': Parameter reference {endpointType} is not defined as an enum
[6.37 s] Generation Complete
================================================================================================================================
Filename: /home/leni/workspace/azure-resource-manager-schemas/schemas/2015-11-01/Microsoft.Network.TrafficManager.json
Provider Namespace: Microsoft.Network
API Version: 2015-11-01
Resource Types (Resource Group Scope):
- trafficmanagerprofiles
================================================================================================================================
[/home/leni/workspace/azure-resource-manager-schemas/generator] executing: autorest-beta --version=3.0.6274 --use=@autorest/azureresourceschema@3.0.79 --azureresourceschema --output-folder=/tmp/0chfalzlkh6 --tag=all-api-versions --api-version=2017-03-01 --title=none --pass-thru:subset-reducer /tmp/schm_azspc/specification/trafficmanager/resource-manager/readme.md
AutoRest code generation utility [cli version: 3.0.6187; node: v13.9.0, max-memory: 8192 gb]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest
   Loading AutoRest core      '/home/leni/.autorest/@autorest_core@3.0.6274/node_modules/@autorest/core/dist' (3.0.6274)
   Loading AutoRest extension '@autorest/azureresourceschema' (3.0.79->3.0.79)
WARNING: Skipping path '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficmanagerprofiles/{profileName}/{endpointType}/{endpointName}': Parameter reference {endpointType} is not defined as an enum
[6.44 s] Generation Complete
================================================================================================================================
Filename: /home/leni/workspace/azure-resource-manager-schemas/schemas/2017-03-01/Microsoft.Network.TrafficManager.json
Provider Namespace: Microsoft.Network
API Version: 2017-03-01
Resource Types (Resource Group Scope):
- trafficmanagerprofiles
================================================================================================================================
[/home/leni/workspace/azure-resource-manager-schemas/generator] executing: autorest-beta --version=3.0.6274 --use=@autorest/azureresourceschema@3.0.79 --azureresourceschema --output-folder=/tmp/1rqf7zp7hfc --tag=all-api-versions --api-version=2017-05-01 --title=none --pass-thru:subset-reducer /tmp/schm_azspc/specification/trafficmanager/resource-manager/readme.md
AutoRest code generation utility [cli version: 3.0.6187; node: v13.9.0, max-memory: 8192 gb]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest
   Loading AutoRest core      '/home/leni/.autorest/@autorest_core@3.0.6274/node_modules/@autorest/core/dist' (3.0.6274)
   Loading AutoRest extension '@autorest/azureresourceschema' (3.0.79->3.0.79)
WARNING: Skipping path '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficmanagerprofiles/{profileName}/{endpointType}/{endpointName}': Parameter reference {endpointType} is not defined as an enum
[6.78 s] Generation Complete
================================================================================================================================
Filename: /home/leni/workspace/azure-resource-manager-schemas/schemas/2017-05-01/Microsoft.Network.TrafficManager.json
Provider Namespace: Microsoft.Network
API Version: 2017-05-01
Resource Types (Resource Group Scope):
- trafficmanagerprofiles
================================================================================================================================
[/home/leni/workspace/azure-resource-manager-schemas/generator] executing: autorest-beta --version=3.0.6274 --use=@autorest/azureresourceschema@3.0.79 --azureresourceschema --output-folder=/tmp/xw05pou8pv --tag=all-api-versions --api-version=2018-02-01 --title=none --pass-thru:subset-reducer /tmp/schm_azspc/specification/trafficmanager/resource-manager/readme.md
AutoRest code generation utility [cli version: 3.0.6187; node: v13.9.0, max-memory: 8192 gb]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest
   Loading AutoRest core      '/home/leni/.autorest/@autorest_core@3.0.6274/node_modules/@autorest/core/dist' (3.0.6274)
   Loading AutoRest extension '@autorest/azureresourceschema' (3.0.79->3.0.79)
WARNING: Skipping path '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficmanagerprofiles/{profileName}/{endpointType}/{endpointName}': Parameter reference {endpointType} is not defined as an enum
[6.77 s] Generation Complete
================================================================================================================================
Filename: /home/leni/workspace/azure-resource-manager-schemas/schemas/2018-02-01/Microsoft.Network.TrafficManager.json
Provider Namespace: Microsoft.Network
API Version: 2018-02-01
Resource Types (Resource Group Scope):
- trafficmanagerprofiles
================================================================================================================================
[/home/leni/workspace/azure-resource-manager-schemas/generator] executing: autorest-beta --version=3.0.6274 --use=@autorest/azureresourceschema@3.0.79 --azureresourceschema --output-folder=/tmp/wg7y1ipo6ng --tag=all-api-versions --api-version=2018-03-01 --title=none --pass-thru:subset-reducer /tmp/schm_azspc/specification/trafficmanager/resource-manager/readme.md
AutoRest code generation utility [cli version: 3.0.6187; node: v13.9.0, max-memory: 8192 gb]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest
   Loading AutoRest core      '/home/leni/.autorest/@autorest_core@3.0.6274/node_modules/@autorest/core/dist' (3.0.6274)
   Loading AutoRest extension '@autorest/azureresourceschema' (3.0.79->3.0.79)
WARNING: Skipping path '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficmanagerprofiles/{profileName}/{endpointType}/{endpointName}': Parameter reference {endpointType} is not defined as an enum
[7.04 s] Generation Complete
================================================================================================================================
Filename: /home/leni/workspace/azure-resource-manager-schemas/schemas/2018-03-01/Microsoft.Network.TrafficManager.json
Provider Namespace: Microsoft.Network
API Version: 2018-03-01
Resource Types (Resource Group Scope):
- trafficmanagerprofiles
================================================================================================================================
[/home/leni/workspace/azure-resource-manager-schemas/generator] executing: autorest-beta --version=3.0.6274 --use=@autorest/azureresourceschema@3.0.79 --azureresourceschema --output-folder=/tmp/klmkcyylo3m --tag=all-api-versions --api-version=2018-04-01 --title=none --pass-thru:subset-reducer /tmp/schm_azspc/specification/trafficmanager/resource-manager/readme.md
AutoRest code generation utility [cli version: 3.0.6187; node: v13.9.0, max-memory: 8192 gb]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest
   Loading AutoRest core      '/home/leni/.autorest/@autorest_core@3.0.6274/node_modules/@autorest/core/dist' (3.0.6274)
   Loading AutoRest extension '@autorest/azureresourceschema' (3.0.79->3.0.79)
WARNING: Skipping path '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficmanagerprofiles/{profileName}/{endpointType}/{endpointName}': Parameter reference {endpointType} is not defined as an enum
[6.87 s] Generation Complete
================================================================================================================================
Filename: /home/leni/workspace/azure-resource-manager-schemas/schemas/2018-04-01/Microsoft.Network.TrafficManager.json
Provider Namespace: Microsoft.Network
API Version: 2018-04-01
Resource Types (Subscription Scope):
- trafficManagerUserMetricsKeys
Resource Types (Resource Group Scope):
- trafficmanagerprofiles
================================================================================================================================
```
Replaces https://github.com/Azure/azure-resource-manager-schemas/pull/900