### PR TITLE
Temp blacklist Microsoft.Consumption due to a known issue

### DIFF
--- a/generator/constants.ts
+++ b/generator/constants.ts
@@ -51,4 +51,6 @@ export const blacklist = [
     'azsadmin/resource-manager/user-subscriptions',
     /* Microsoft.CustomerInsights is deprecated */
     'customer-insights/resource-manager',
+    /* Temporally moving to blacklist */
+    'consumption/resource-manager',
 ];


### PR DESCRIPTION
Temporally blacklisting Microsoft.Consumption due to a known cyclic reference issue.