### PR TITLE
Onboarding redhatopenshift for autogeneration

### DIFF
--- a/generator/autogenlist.ts
+++ b/generator/autogenlist.ts
@@ -415,6 +415,10 @@ const autogenlist: AutogenlistConfig[] = [
         namespace: 'Microsoft.PowerBI',
     },
     {
+        basePath: 'redhatopenshift/resource-manager',
+        namespace: 'Microsoft.RedHatOpenShift',
+    },
+    {
         basePath: 'resources/resource-manager',
         namespace: 'Microsoft.Resources',
         resourceConfig: [

--- a/schemas/2020-04-30/Microsoft.RedHatOpenShift.json
+++ b/schemas/2020-04-30/Microsoft.RedHatOpenShift.json
@@ -1,0 +1,384 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2020-04-30/Microsoft.RedHatOpenShift.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.RedHatOpenShift",
+  "description": "Microsoft RedHatOpenShift Resource Types",
+  "resourceDefinitions": {
+    "openShiftClusters": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-04-30"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the OpenShift cluster resource."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/OpenShiftClusterProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "OpenShiftClusterProperties represents an OpenShift cluster's properties."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.RedHatOpenShift/openShiftClusters"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.RedHatOpenShift/openShiftClusters"
+    }
+  },
+  "definitions": {
+    "APIServerProfile": {
+      "type": "object",
+      "properties": {
+        "ip": {
+          "type": "string",
+          "description": "The IP of the cluster API server (immutable)."
+        },
+        "url": {
+          "type": "string",
+          "description": "The URL to access the cluster API server (immutable)."
+        },
+        "visibility": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Private",
+                "Public"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "API server visibility (immutable)."
+        }
+      },
+      "description": "APIServerProfile represents an API server profile."
+    },
+    "ClusterProfile": {
+      "type": "object",
+      "properties": {
+        "domain": {
+          "type": "string",
+          "description": "The domain for the cluster (immutable)."
+        },
+        "pullSecret": {
+          "type": "string",
+          "description": "The pull secret for the cluster (immutable)."
+        },
+        "resourceGroupId": {
+          "type": "string",
+          "description": "The ID of the cluster resource group (immutable)."
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of the cluster (immutable)."
+        }
+      },
+      "description": "ClusterProfile represents a cluster profile."
+    },
+    "ConsoleProfile": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "The URL to access the cluster console (immutable)."
+        }
+      },
+      "description": "ConsoleProfile represents a console profile."
+    },
+    "IngressProfile": {
+      "type": "object",
+      "properties": {
+        "ip": {
+          "type": "string",
+          "description": "The IP of the ingress (immutable)."
+        },
+        "name": {
+          "type": "string",
+          "description": "The ingress profile name.  Must be \"default\" (immutable)."
+        },
+        "visibility": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Private",
+                "Public"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Ingress visibility (immutable)."
+        }
+      },
+      "description": "IngressProfile represents an ingress profile."
+    },
+    "MasterProfile": {
+      "type": "object",
+      "properties": {
+        "subnetId": {
+          "type": "string",
+          "description": "The Azure resource ID of the master subnet (immutable)."
+        },
+        "vmSize": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Standard_D2s_v3",
+                "Standard_D4s_v3",
+                "Standard_D8s_v3"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The size of the master VMs (immutable)."
+        }
+      },
+      "description": "MasterProfile represents a master profile."
+    },
+    "NetworkProfile": {
+      "type": "object",
+      "properties": {
+        "podCidr": {
+          "type": "string",
+          "description": "The CIDR used for OpenShift/Kubernetes Pods (immutable)."
+        },
+        "serviceCidr": {
+          "type": "string",
+          "description": "The CIDR used for OpenShift/Kubernetes Services (immutable)."
+        }
+      },
+      "description": "NetworkProfile represents a network profile."
+    },
+    "OpenShiftClusterProperties": {
+      "type": "object",
+      "properties": {
+        "apiserverProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/APIServerProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "APIServerProfile represents an API server profile."
+        },
+        "clusterProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ClusterProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "ClusterProfile represents a cluster profile."
+        },
+        "consoleProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ConsoleProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "ConsoleProfile represents a console profile."
+        },
+        "ingressProfiles": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/IngressProfile"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The cluster ingress profiles."
+        },
+        "masterProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MasterProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "MasterProfile represents a master profile."
+        },
+        "networkProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/NetworkProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "NetworkProfile represents a network profile."
+        },
+        "provisioningState": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "AdminUpdating",
+                "Creating",
+                "Deleting",
+                "Failed",
+                "Succeeded",
+                "Updating"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The cluster provisioning state (immutable)."
+        },
+        "servicePrincipalProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServicePrincipalProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "ServicePrincipalProfile represents a service principal profile."
+        },
+        "workerProfiles": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/WorkerProfile"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The cluster worker profiles."
+        }
+      },
+      "description": "OpenShiftClusterProperties represents an OpenShift cluster's properties."
+    },
+    "ServicePrincipalProfile": {
+      "type": "object",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The client ID used for the cluster (immutable)."
+        },
+        "clientSecret": {
+          "type": "string",
+          "description": "The client secret used for the cluster (immutable)."
+        }
+      },
+      "description": "ServicePrincipalProfile represents a service principal profile."
+    },
+    "WorkerProfile": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The number of worker VMs.  Must be between 3 and 20 (immutable)."
+        },
+        "diskSizeGB": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The disk size of the worker VMs.  Must be 128 or greater (immutable)."
+        },
+        "name": {
+          "type": "string",
+          "description": "The worker profile name.  Must be \"worker\" (immutable)."
+        },
+        "subnetId": {
+          "type": "string",
+          "description": "The Azure resource ID of the worker subnet (immutable)."
+        },
+        "vmSize": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Standard_D2s_v3",
+                "Standard_D4s_v3",
+                "Standard_D8s_v3"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The size of the worker VMs (immutable)."
+        }
+      },
+      "description": "WorkerProfile represents a worker profile."
+    }
+  }
+}

--- a/schemas/common/autogeneratedResources.json
+++ b/schemas/common/autogeneratedResources.json
@@ -3527,6 +3527,9 @@
           "$ref": "https://schema.management.azure.com/schemas/2017-10-01/Microsoft.PowerBIDedicated.json#/resourceDefinitions/capacities"
         },
         {
+          "$ref": "https://schema.management.azure.com/schemas/2020-04-30/Microsoft.RedHatOpenShift.json#/resourceDefinitions/openShiftClusters"
+        },
+        {
           "$ref": "https://schema.management.azure.com/schemas/2016-07-01/Microsoft.Relay.json#/resourceDefinitions/namespaces"
         },
         {


### PR DESCRIPTION
```
> azure-schema-generator@1.0.0 generate-single /home/leni/workspace/azure-resource-manager-schemas/generator
> ts-node cmd/generatesingle "redhatopenshift/resource-manager"

[/tmp/schm_azspc] executing: git fsck
[/tmp/schm_azspc] executing: git reset -q .
[/tmp/schm_azspc] executing: git checkout -q -- .
[/tmp/schm_azspc] executing: git clean -q -fd
[/tmp/schm_azspc] executing: git gc
[/tmp/schm_azspc] executing: git fetch -q
[/tmp/schm_azspc] executing: git checkout -q origin/master
Using autogenlist config:
{
  "basePath": "redhatopenshift/resource-manager",
  "namespace": "Microsoft.RedHatOpenShift"
}
[/home/leni/workspace/azure-resource-manager-schemas/generator] executing: autorest-beta --version=3.0.6274 --use=@autorest/azureresourceschema@3.0.79 --azureresourceschema --output-folder=/tmp/t05rx0vndu --tag=all-api-versions --api-version=2020-04-30 --title=none --pass-thru:subset-reducer /tmp/schm_azspc/specification/redhatopenshift/resource-manager/readme.md
AutoRest code generation utility [cli version: 3.0.6187; node: v13.9.0, max-memory: 8192 gb]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest
   Loading AutoRest core      '/home/leni/.autorest/@autorest_core@3.0.6274/node_modules/@autorest/core/dist' (3.0.6274)
   Loading AutoRest extension '@autorest/azureresourceschema' (3.0.79->3.0.79)
[4.59 s] Generation Complete
================================================================================================================================
Filename: /home/leni/workspace/azure-resource-manager-schemas/schemas/2020-04-30/Microsoft.RedHatOpenShift.json
Provider Namespace: Microsoft.RedHatOpenShift
API Version: 2020-04-30
Resource Types (Resource Group Scope):
- openShiftClusters
================================================================================================================================
```