### PR TITLE
Temp remove securityinsights from schema autogen

### DIFF
--- a/generator/constants.ts
+++ b/generator/constants.ts
@@ -53,4 +53,5 @@ export const blocklist = [
     'customer-insights/resource-manager',
     /* Temporally moving to blacklist */
     'consumption/resource-manager',
+    'securityinsights/resource-manager',
 ];


### PR DESCRIPTION
Given that security insights has a Swagger issue, fix in this PR: 

https://github.com/Azure/azure-rest-api-specs/pull/10038

We are temporally disabling the RP from the schema auto-generation.