### PR TITLE
Temp blocklist mariadb due to autogen issue

### DIFF
--- a/generator/constants.ts
+++ b/generator/constants.ts
@@ -53,4 +53,5 @@ export const blocklist = [
     'customer-insights/resource-manager',
     /* Temporally moving to blacklist */
     'consumption/resource-manager',
+    'mariadb/resource-manager'
 ];


### PR DESCRIPTION
Getting the following error:

2020-07-10T16:07:23.1681797Z [/home/vsts/work/1/s/generator] executing: autorest-beta --version=3.0.6274 --use=@autorest/azureresourceschema@3.0.79 --azureresourceschema --output-folder=/tmp/3jt3who3g5t --tag=all-api-versions --api-version=2018-06-01-preview --title=none --pass-thru:subset-reducer /tmp/schm_azspc/specification/mariadb/resource-manager/readme.md
2020-07-10T16:07:23.5927438Z AutoRest code generation utility [cli version: 3.0.6187; node: v12.18.1, max-memory: 8192 gb]
2020-07-10T16:07:23.5938301Z (C) 2018 Microsoft Corporation.
2020-07-10T16:07:23.5939195Z https://aka.ms/autorest
2020-07-10T16:07:24.5168998Z    Loading AutoRest core      '/home/vsts/.autorest/@autorest_core@3.0.6274/node_modules/@autorest/core/dist' (3.0.6274)
2020-07-10T16:07:24.7340045Z ERROR: Syntax Error Encountered:  Syntax error: end of the stream or a document separator is expected
2020-07-10T16:07:24.7342177Z     - codeBlock_85:1:1
2020-07-10T16:07:24.7346320Z ERROR: Syntax Error Encountered:  Syntax error: expected a single document in the stream, but found more
2020-07-10T16:07:24.7347251Z     - codeBlock_85:1:1
2020-07-10T16:07:24.7347619Z [OperationAbortedException] Error occurred. Exiting.
2020-07-10T16:07:24.7493507Z Caught exception processing autogenlist entry mariadb/resource-manager.
2020-07-10T16:07:24.7494499Z Exited with code 1