### PR TITLE
Removed basepaths from blocklist

### DIFF
--- a/generator/constants.ts
+++ b/generator/constants.ts
@@ -51,7 +51,4 @@ export const blocklist = [
     'azsadmin/resource-manager/user-subscriptions',
     /* Microsoft.CustomerInsights is deprecated */
     'customer-insights/resource-manager',
-    /* Temporally moving to blacklist */
-    'consumption/resource-manager',
-    'mariadb/resource-manager',
 ];


### PR DESCRIPTION
Seems like basepaths added to blocklist are not prevented from being generated, to prevent the autogeneration we need to temp remove the basepath from autogenlist instead.