### PR TITLE
Temp excluding ApiManagement - autorest issue

### DIFF
--- a/generator/autogenlist.ts
+++ b/generator/autogenlist.ts
@@ -37,10 +37,10 @@ const autogenlist: AutogenlistConfig[] = [
         basePath: 'appconfiguration/resource-manager',
         namespace: 'Microsoft.AppConfiguration',
     },
-    {
+    /*{ Note(jcotillo) Temp exclusion due to an autorest issue.
         basePath: 'apimanagement/resource-manager',
         namespace: 'Microsoft.ApiManagement',
-    },
+    },*/
     {
         basePath: 'appplatform/resource-manager',
         namespace: 'Microsoft.AppPlatform',


### PR DESCRIPTION
Due to a known autorest issue, temporally blocklisting ApiManagement to allow the schema generation to pass.