### PR TITLE
Added Microsoft.VMware resource schema

### DIFF
--- a/schemas/2019-12-20-privatepreview/Microsoft.VMware.json
+++ b/schemas/2019-12-20-privatepreview/Microsoft.VMware.json
@@ -1,0 +1,893 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.VMware",
+  "description": "Microsoft VMware Resource Types",
+  "resourceDefinitions": {
+    "ArcZones": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2019-12-20-privatepreview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Gets or sets the location."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the arcZone."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ArcZoneProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Defines the resource properties."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.VMware/ArcZones"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.VMware/ArcZones"
+    },
+    "ResourcePools": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2019-12-20-privatepreview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Gets or sets the location."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resourcePool."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ResourcePoolProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Defines the resource properties."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.VMware/ResourcePools"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.VMware/ResourcePools"
+    },
+    "VCenters": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2019-12-20-privatepreview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Gets or sets the location."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the vCenter."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/VCenterProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Defines the resource properties."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.VMware/VCenters"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.VMware/VCenters"
+    },
+    "VirtualMachines": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2019-12-20-privatepreview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Gets or sets the location."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the virtual machine resource."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/VirtualMachineProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Defines the resource properties."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.VMware/VirtualMachines"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.VMware/VirtualMachines"
+    },
+    "VirtualMachineTemplates": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2019-12-20-privatepreview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Gets or sets the location."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the virtual machine template resource."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/VirtualMachineTemplateProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Defines the resource properties."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.VMware/VirtualMachineTemplates"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.VMware/VirtualMachineTemplates"
+    },
+    "VirtualNetworks": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2019-12-20-privatepreview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Gets or sets the location."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the virtual network resource."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/VirtualNetworkProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Defines the resource properties."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.VMware/VirtualNetworks"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.VMware/VirtualNetworks"
+    }
+  },
+  "definitions": {
+    "ArcZoneProperties": {
+      "type": "object",
+      "properties": {
+        "authentication": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/KubernetesAuthentication"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Defines the kubernetes authentication class."
+        },
+        "hostId": {
+          "type": "string",
+          "description": "Gets or Sets the Arm Id of the cluster resource (AKS Cluster Id)."
+        }
+      },
+      "required": [
+        "hostId"
+      ],
+      "description": "Defines the resource properties."
+    },
+    "HardwareProfile": {
+      "type": "object",
+      "properties": {
+        "memorySizeMB": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets memory size in MBs for the vm."
+        },
+        "numCoresPerSocket": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the number of cores per socket for the vm. Defaults to 1 if unspecified."
+        },
+        "numCPUs": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the number of vCPUs for the vm."
+        }
+      },
+      "description": "Defines the resource properties."
+    },
+    "KubernetesAuthentication": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "KubeConfig",
+                "ListCredential"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets kubernetes authentication type."
+        },
+        "value": {
+          "type": "string",
+          "description": "Gets or sets kubernetes authentication value."
+        }
+      },
+      "description": "Defines the kubernetes authentication class."
+    },
+    "KubernetesSecret": {
+      "type": "object",
+      "properties": {
+        "secretName": {
+          "type": "string",
+          "description": "Gets or sets the name of the secret in Kubernetes."
+        },
+        "secretNamespace": {
+          "type": "string",
+          "description": "Gets or sets a namespace in which the specified secret exists."
+        }
+      },
+      "description": "A k8s secret identifier."
+    },
+    "NetworkInterface": {
+      "type": "object",
+      "properties": {
+        "deviceKey": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the device key value."
+        },
+        "ipSettings": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/NicIPSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Defines the network interface ip settings."
+        },
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the name of the network interface."
+        },
+        "networkId": {
+          "type": "string",
+          "description": "Gets or sets the ARM Id of the network resource to connect the virtual machine."
+        },
+        "nicType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "vmxnet3",
+                "vmxnet2",
+                "vmxnet",
+                "e1000",
+                "e1000e",
+                "pcnet32"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "NIC type."
+        },
+        "powerOnBoot": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "enabled",
+                "disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the power on boot."
+        }
+      },
+      "description": "Network Interface model"
+    },
+    "NetworkProfile": {
+      "type": "object",
+      "properties": {
+        "networkInterfaces": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/NetworkInterface"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the list of network interfaces associated with the virtual machine."
+        }
+      },
+      "description": "Defines the resource properties."
+    },
+    "NicIPSettings": {
+      "type": "object",
+      "properties": {
+        "allocationMethod": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "unset",
+                "dynamic",
+                "static",
+                "linklayer",
+                "random",
+                "other"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the nic allocation method."
+        },
+        "gateway": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the gateway."
+        },
+        "ipAddress": {
+          "type": "string",
+          "description": "Gets or sets the ip address for the nic."
+        },
+        "subnetMask": {
+          "type": "string",
+          "description": "Gets or sets the mask."
+        }
+      },
+      "description": "Defines the network interface ip settings."
+    },
+    "OsProfile": {
+      "type": "object",
+      "properties": {
+        "adminPassword": {
+          "type": "string",
+          "description": "Gets or sets administrator password."
+        },
+        "adminUsername": {
+          "type": "string",
+          "description": "Gets or sets administrator username."
+        }
+      },
+      "description": "Defines the resource properties."
+    },
+    "ResourcePoolProperties": {
+      "type": "object",
+      "properties": {
+        "arcZoneId": {
+          "type": "string",
+          "description": "Gets or sets the ARM Id of the arcZone of the vCenter."
+        },
+        "moRefId": {
+          "type": "string",
+          "description": "Gets or sets the vCenter MoRef (Managed Object Reference) ID for the resource pool."
+        },
+        "vCenterId": {
+          "type": "string",
+          "description": "Gets or sets the ARM Id of the vCenter resource in which this resource pool resides."
+        }
+      },
+      "required": [
+        "arcZoneId",
+        "moRefId",
+        "vCenterId"
+      ],
+      "description": "Defines the resource properties."
+    },
+    "StorageProfile": {
+      "type": "object",
+      "properties": {
+        "disks": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/VirtualDisk"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the list of virtual disks associated with the virtual machine."
+        }
+      },
+      "description": "Defines the resource properties."
+    },
+    "VCenterProperties": {
+      "type": "object",
+      "properties": {
+        "arcZoneId": {
+          "type": "string",
+          "description": "Gets or sets the ARM Id of the arcZone of the vCenter."
+        },
+        "credentials": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/KubernetesSecret"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "A k8s secret identifier."
+        },
+        "fqdn": {
+          "type": "string",
+          "description": "Gets or sets the FQDN/IPAddress of the vCenter."
+        },
+        "port": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the port of the vCenter."
+        }
+      },
+      "required": [
+        "arcZoneId",
+        "fqdn"
+      ],
+      "description": "Defines the resource properties."
+    },
+    "VirtualDisk": {
+      "type": "object",
+      "properties": {
+        "controllerKey": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the controller id."
+        },
+        "deviceKey": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the device key value."
+        },
+        "diskMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "persistent",
+                "nonpersistent",
+                "undoable",
+                "independent_persistent",
+                "independent_nonpersistent",
+                "append"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the disk mode."
+        },
+        "diskSizeGB": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the disk total size."
+        },
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the name of the virtual disk."
+        },
+        "unitNumber": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Gets or sets the unit number of the disk on the controller."
+        }
+      },
+      "description": "Virtual disk model"
+    },
+    "VirtualMachineProperties": {
+      "type": "object",
+      "properties": {
+        "arcZoneId": {
+          "type": "string",
+          "description": "Gets or sets the ARM Id of the arcZone of the vCenter."
+        },
+        "hardwareProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/HardwareProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Defines the resource properties."
+        },
+        "networkProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/NetworkProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Defines the resource properties."
+        },
+        "osProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/OsProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Defines the resource properties."
+        },
+        "resourcePoolId": {
+          "type": "string",
+          "description": "Gets or sets the ARM Id of the resourcePool resource on which this virtual machine will\r\ndeploy."
+        },
+        "storageProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/StorageProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Defines the resource properties."
+        },
+        "templateId": {
+          "type": "string",
+          "description": "Gets or sets the ARM Id of the template resource to deploy the virtual machine."
+        },
+        "vCenterId": {
+          "type": "string",
+          "description": "Gets or sets the ARM Id of the vCenter resource in which this resource pool resides."
+        }
+      },
+      "required": [
+        "arcZoneId",
+        "resourcePoolId",
+        "templateId",
+        "vCenterId"
+      ],
+      "description": "Defines the resource properties."
+    },
+    "VirtualMachineTemplateProperties": {
+      "type": "object",
+      "properties": {
+        "arcZoneId": {
+          "type": "string",
+          "description": "Gets or sets the ARM Id of the arcZone of the vCenter."
+        },
+        "moRefId": {
+          "type": "string",
+          "description": "Gets or sets the vCenter MoRef (Managed Object Reference) ID for the virtual machine\r\ntemplate."
+        },
+        "vCenterId": {
+          "type": "string",
+          "description": "Gets or sets the ARM Id of the vCenter resource in which this template resides."
+        }
+      },
+      "required": [
+        "arcZoneId",
+        "moRefId",
+        "vCenterId"
+      ],
+      "description": "Defines the resource properties."
+    },
+    "VirtualNetworkProperties": {
+      "type": "object",
+      "properties": {
+        "arcZoneId": {
+          "type": "string",
+          "description": "Gets or sets the ARM Id of the arcZone of the vCenter."
+        },
+        "moRefId": {
+          "type": "string",
+          "description": "Gets or sets the vCenter MoRef (Managed Object Reference) ID for the virtual network."
+        },
+        "vCenterId": {
+          "type": "string",
+          "description": "Gets or sets the ARM Id of the vCenter resource in which this template resides."
+        }
+      },
+      "required": [
+        "arcZoneId",
+        "moRefId",
+        "vCenterId"
+      ],
+      "description": "Defines the resource properties."
+    }
+  }
+}

--- a/schemas/common/autogeneratedResources.json
+++ b/schemas/common/autogeneratedResources.json
@@ -4733,6 +4733,24 @@
           "$ref": "https://schema.management.azure.com/schemas/2014-04-01-preview/Microsoft.VisualStudio.json#/resourceDefinitions/account_project"
         },
         {
+          "$ref": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/ArcZones"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/ResourcePools"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/VCenters"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/VirtualMachines"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/VirtualMachineTemplates"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/VirtualNetworks"
+        },
+        {
           "$ref": "https://schema.management.azure.com/schemas/2019-04-01/Microsoft.VMwareCloudSimple.json#/resourceDefinitions/dedicatedCloudNodes"
         },
         {

--- a/tests/2019-12-20-privatepreview/Microsoft.VMware.tests.json
+++ b/tests/2019-12-20-privatepreview/Microsoft.VMware.tests.json
@@ -1,0 +1,513 @@
+{
+  "tests": [
+    {
+      "name": "arczone - valid inputs",
+      "definition": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/ArcZones",
+      "json": {
+        "name": "arcZone",
+        "type": "Microsoft.VMware/ArcZones",
+        "location": "West Us",
+        "apiVersion": "2019-12-20-privatepreview",
+        "properties": {
+          "authentication": {
+            "properties": {
+              "type": "ListCredential",
+              "value": "creds"
+            }
+          },
+          "hostId": "host-id-1"
+        }
+      }
+    },
+    {
+      "name": "arczone - Missing all required",
+      "definition": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/ArcZones",
+      "json": {
+        "properties": {}
+      },
+      "expectedErrors": [
+        {
+          "message": "Missing required property: apiVersion",
+          "dataPath": "/",
+          "schemaPath": "/required/0",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: location",
+          "dataPath": "/",
+          "schemaPath": "/required/1",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: name",
+          "dataPath": "/",
+          "schemaPath": "/required/2",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: type",
+          "dataPath": "/",
+          "schemaPath": "/required/4",
+          "subErrors": []
+        },
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/properties",
+          "schemaPath": "/properties/properties/oneOf",
+          "subErrors": [
+            {
+              "message": "Missing required property: hostId",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/0/required/0",
+              "subErrors": []
+            },
+            {
+              "message": "Invalid type: object (expected string)",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/1/type",
+              "subErrors": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Resource Pool - valid inputs",
+      "definition": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/ResourcePools",
+      "json": {
+        "name": "ResourcePool1",
+        "type": "Microsoft.VMware/ResourcePools",
+        "location": "West Us",
+        "apiVersion": "2019-12-20-privatepreview",
+        "properties": {
+          "arcZoneId": "arczoneid1",
+          "moRefId": "moRefId1",
+          "vCenterId": "vCenterId1"
+        }
+      }
+    },
+    {
+      "name": "Resource Pool - Missing all required",
+      "definition": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/ResourcePools",
+      "json": {
+        "properties": {}
+      },
+      "expectedErrors": [
+        {
+          "message": "Missing required property: apiVersion",
+          "dataPath": "/",
+          "schemaPath": "/required/0",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: location",
+          "dataPath": "/",
+          "schemaPath": "/required/1",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: name",
+          "dataPath": "/",
+          "schemaPath": "/required/2",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: type",
+          "dataPath": "/",
+          "schemaPath": "/required/4",
+          "subErrors": []
+        },
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/properties",
+          "schemaPath": "/properties/properties/oneOf",
+          "subErrors": [
+            {
+              "message": "Missing required property: arcZoneId",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/0/required/0",
+              "subErrors": []
+            },
+            {
+              "message": "Missing required property: moRefId",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/0/required/1",
+              "subErrors": []
+            },
+            {
+              "message": "Missing required property: vCenterId",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/0/required/2",
+              "subErrors": []
+            },
+            {
+              "message": "Invalid type: object (expected string)",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/1/type",
+              "subErrors": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "VCenters - valid inputs",
+      "definition": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/VCenters",
+      "json": {
+        "name": "vCenter1",
+        "type": "Microsoft.VMware/VCenters",
+        "location": "West Us",
+        "apiVersion": "2019-12-20-privatepreview",
+        "properties": {
+          "arcZoneId": "arcZoneId1",
+          "credentials": {
+            "secretName": "secret1",
+            "secretNamespace": "secretNamespace1"
+          },
+          "fqdn": "vcenter.microsoft.com",
+          "port": 443
+        }
+      }
+    },
+    {
+      "name": "VCenters - Missing all required",
+      "definition": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/VCenters",
+      "json": {
+        "properties": {}
+      },
+      "expectedErrors": [
+        {
+          "message": "Missing required property: apiVersion",
+          "dataPath": "/",
+          "schemaPath": "/required/0",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: location",
+          "dataPath": "/",
+          "schemaPath": "/required/1",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: name",
+          "dataPath": "/",
+          "schemaPath": "/required/2",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: type",
+          "dataPath": "/",
+          "schemaPath": "/required/4",
+          "subErrors": []
+        },
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/properties",
+          "schemaPath": "/properties/properties/oneOf",
+          "subErrors": [
+            {
+              "message": "Missing required property: arcZoneId",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/0/required/0",
+              "subErrors": []
+            },
+            {
+              "message": "Missing required property: fqdn",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/0/required/1",
+              "subErrors": []
+            },
+            {
+              "message": "Invalid type: object (expected string)",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/1/type",
+              "subErrors": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "VirtualMachines - valid inputs",
+      "definition": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/VirtualMachines",
+      "json": {
+        "name": "VirtualMachines1",
+        "type": "Microsoft.VMware/VirtualMachines",
+        "location": "West Us",
+        "apiVersion": "2019-12-20-privatepreview",
+        "properties": {
+          "arcZoneId": "arcZoneId1",
+          "hardwareProfile": {
+            "memorySizeMB": 1024,
+            "numCoresPerSocket": 2,
+            "numCPUs": 4
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "deviceKey": 1234567890,
+                "ipSettings": {
+                  "allocationMethod": "dynamic",
+                  "gateway": ["10.0.0.1"],
+                  "ipAddress": "10.0.0.5",
+                  "subnetMask": "255.255.0.0"
+                },
+                "name": "networkInterfaces1",
+                "networkId": "networkId1",
+                "nicType": "vmxnet3",
+                "powerOnBoot": "enabled"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminPassword": "password",
+            "adminUsername": "username"
+          },
+          "resourcePoolId": "resourcePoolId1",
+          "storageProfile": {
+            "disks": [
+              {
+                "controllerKey": 123456,
+                "deviceKey": 7890,
+                "diskMode": "persistent",
+                "diskSizeGB": 1024,
+                "name": "disk1",
+                "unitNumber": 1
+              }
+            ]
+          },
+          "templateId": "templateId1",
+          "vCenterId": "vCenterId1"
+        }
+      }
+    },
+    {
+      "name": "VirtualMachines - Missing all required",
+      "definition": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/VirtualMachines",
+      "json": {
+        "properties": {}
+      },
+      "expectedErrors": [
+        {
+          "message": "Missing required property: apiVersion",
+          "dataPath": "/",
+          "schemaPath": "/required/0",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: location",
+          "dataPath": "/",
+          "schemaPath": "/required/1",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: name",
+          "dataPath": "/",
+          "schemaPath": "/required/2",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: type",
+          "dataPath": "/",
+          "schemaPath": "/required/4",
+          "subErrors": []
+        },
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/properties",
+          "schemaPath": "/properties/properties/oneOf",
+          "subErrors": [
+            {
+              "message": "Missing required property: arcZoneId",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/0/required/0",
+              "subErrors": []
+            },
+            {
+              "message": "Missing required property: resourcePoolId",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/0/required/1",
+              "subErrors": []
+            },
+            {
+              "message": "Missing required property: templateId",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/0/required/2",
+              "subErrors": []
+            },
+            {
+              "message": "Missing required property: vCenterId",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/0/required/3",
+              "subErrors": []
+            },
+            {
+              "message": "Invalid type: object (expected string)",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/1/type",
+              "subErrors": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "VirtualMachineTemplates - valid inputs",
+      "definition": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/VirtualMachineTemplates",
+      "json": {
+        "name": "VirtualMachineTemplates1",
+        "type": "Microsoft.VMware/VirtualMachineTemplates",
+        "location": "West Us",
+        "apiVersion": "2019-12-20-privatepreview",
+        "properties": {
+          "arcZoneId": "arcZoneId1",
+          "moRefId": "moRefId1",
+          "vCenterId": "vCenterId1"
+        }
+      }
+    },
+    {
+      "name": "VirtualMachineTemplates - Missing all required",
+      "definition": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/VirtualMachineTemplates",
+      "json": {
+        "properties": {}
+      },
+      "expectedErrors": [
+        {
+          "message": "Missing required property: apiVersion",
+          "dataPath": "/",
+          "schemaPath": "/required/0",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: location",
+          "dataPath": "/",
+          "schemaPath": "/required/1",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: name",
+          "dataPath": "/",
+          "schemaPath": "/required/2",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: type",
+          "dataPath": "/",
+          "schemaPath": "/required/4",
+          "subErrors": []
+        },
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/properties",
+          "schemaPath": "/properties/properties/oneOf",
+          "subErrors": [
+            {
+              "message": "Missing required property: arcZoneId",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/0/required/0",
+              "subErrors": []
+            },
+            {
+              "message": "Missing required property: moRefId",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/0/required/1",
+              "subErrors": []
+            },
+            {
+              "message": "Missing required property: vCenterId",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/0/required/2",
+              "subErrors": []
+            },
+            {
+              "message": "Invalid type: object (expected string)",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/1/type",
+              "subErrors": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "VirtualNetworks - valid inputs",
+      "definition": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/VirtualNetworks",
+      "json": {
+        "name": "VirtualNetworks1",
+        "type": "Microsoft.VMware/VirtualNetworks",
+        "location": "West Us",
+        "apiVersion": "2019-12-20-privatepreview",
+        "properties": {
+          "arcZoneId": "arcZoneId1",
+          "moRefId": "moRefId1",
+          "vCenterId": "vCenterId1"
+        }
+      }
+    },
+    {
+      "name": "VirtualNetworks - Missing all required",
+      "definition": "https://schema.management.azure.com/schemas/2019-12-20-privatepreview/Microsoft.VMware.json#/resourceDefinitions/VirtualNetworks",
+      "json": {
+        "properties": {}
+      },
+      "expectedErrors": [
+        {
+          "message": "Missing required property: apiVersion",
+          "dataPath": "/",
+          "schemaPath": "/required/0",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: location",
+          "dataPath": "/",
+          "schemaPath": "/required/1",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: name",
+          "dataPath": "/",
+          "schemaPath": "/required/2",
+          "subErrors": []
+        },
+        {
+          "message": "Missing required property: type",
+          "dataPath": "/",
+          "schemaPath": "/required/4",
+          "subErrors": []
+        },
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/properties",
+          "schemaPath": "/properties/properties/oneOf",
+          "subErrors": [
+            {
+              "message": "Missing required property: arcZoneId",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/0/required/0",
+              "subErrors": []
+            },
+            {
+              "message": "Missing required property: moRefId",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/0/required/1",
+              "subErrors": []
+            },
+            {
+              "message": "Missing required property: vCenterId",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/0/required/2",
+              "subErrors": []
+            },
+            {
+              "message": "Invalid type: object (expected string)",
+              "dataPath": "/properties",
+              "schemaPath": "/properties/properties/oneOf/1/type",
+              "subErrors": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Command output:
```
D:\azure-resource-manager-schemas\generator>npm run generate-single arcvmware/resource-manager

> azure-schema-generator@1.0.0 generate-single D:\azure-resource-manager-schemas\generator
> ts-node cmd/generatesingle "arcvmware/resource-manager"

[D:\azure-resource-manager-schemas\generator] executing: autorest-beta.cmd --version=3.0.6274 --use=@autorest/azureresourceschema@3.0.79 --azureresourceschema --output-folder=C:\Users\parkuma\AppData\Local\Temp\n515lvzixvi --tag=all-api-versions --api-version=2019-12-20-privatepreview --title=none --pass-thru:subset-reducer C:\Users\parkuma\AppData\Local\Temp\schm_azspc\specification\arcvmware\resource-manager\readme.md
AutoRest code generation utility [cli version: 3.0.6187; node: v12.16.1, max-memory: 8192 gb]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest
   Loading AutoRest core      'C:\Users\parkuma\.autorest\@autorest_core@3.0.6274\node_modules\@autorest\core\dist' (3.0.6274)
   Loading AutoRest extension '@autorest/azureresourceschema' (3.0.79->3.0.79)
[9.63 s] Generation Complete
================================================================================================================================
Filename: D:\azure-resource-manager-schemas\schemas\2019-12-20-privatepreview\Microsoft.VMware.json
Provider Namespace: Microsoft.VMware
API Version: 2019-12-20-privatepreview
Resource Types (Resource Group Scope):
- ArcZones
- ResourcePools
- VCenters
- VirtualMachines
- VirtualMachineTemplates
- VirtualNetworks
================================================================================================================================
```