### PR TITLE
Add scope property to deployment template schema

### DIFF
--- a/schemas/2014-04-01-preview/deploymentTemplate.json
+++ b/schemas/2014-04-01-preview/deploymentTemplate.json
@@ -2144,6 +2144,10 @@
         "tags": {
           "type": "object",
           "description": "Name-value pairs to add to the resource"
+        },
+        "scope": {
+          "type": "string",
+          "description": "Scope for the resource or deployment. Today, this works for two cases: 1) setting the scope for extension resources 2) deploying resources to the tenant scope in non-tenant scope deployments"
         }
       },
       "required": [

--- a/schemas/2015-01-01/deploymentTemplate.json
+++ b/schemas/2015-01-01/deploymentTemplate.json
@@ -2335,6 +2335,10 @@
             "copy": {
               "$ref": "#/definitions/resourceCopy"
             },
+            "scope": {
+              "type": "string",
+              "description": "Scope for the resource or deployment. Today, this works for two cases: 1) setting the scope for extension resources 2) deploying resources to the tenant scope in non-tenant scope deployments"
+            },
             "comments": {
               "type": "string"
             }

--- a/schemas/2018-05-01/subscriptionDeploymentTemplate.json
+++ b/schemas/2018-05-01/subscriptionDeploymentTemplate.json
@@ -399,6 +399,10 @@
             "copy": {
               "$ref": "#/definitions/resourceCopy"
             },
+            "scope": {
+              "type": "string",
+              "description": "Scope property to be used to provide scope for a resource or to be used to specify a scope for Management Group or Tenant level deployments."
+            },
             "comments": {
               "type": "string"
             }

--- a/schemas/2019-03-01-hybrid/deploymentTemplate.json
+++ b/schemas/2019-03-01-hybrid/deploymentTemplate.json
@@ -3129,6 +3129,10 @@
             "copy": {
               "$ref": "#/definitions/resourceCopy"
             },
+            "scope": {
+              "type": "string",
+              "description": "Scope for the resource or deployment. Today, this works for two cases: 1) setting the scope for extension resources 2) deploying resources to the tenant scope in non-tenant scope deployments"
+            },
             "comments": {
               "type": "string"
             }

--- a/schemas/2019-04-01/deploymentTemplate.json
+++ b/schemas/2019-04-01/deploymentTemplate.json
@@ -1622,7 +1622,7 @@
             },
             "scope": {
               "type": "string",
-              "description": "Scope property to be used to provide scope for a resource or to be used to specify a scope for Management Group or Tenant level deployments."
+              "description": "Scope for the resource or deployment. Today, this works for two cases: 1) setting the scope for extension resources 2) deploying resources to the tenant scope in non-tenant scope deployments"
             },
             "comments": {
               "type": "string"

--- a/schemas/2019-04-01/deploymentTemplate.json
+++ b/schemas/2019-04-01/deploymentTemplate.json
@@ -1620,6 +1620,10 @@
             "copy": {
               "$ref": "#/definitions/resourceCopy"
             },
+            "scope": {
+              "type": "string",
+              "description": "Scope property to be used to provide scope for a resource or to be used to specify a scope for Management Group or Tenant level deployments."
+            },
             "comments": {
               "type": "string"
             }

--- a/schemas/2019-08-01/managementGroupDeploymentTemplate.json
+++ b/schemas/2019-08-01/managementGroupDeploymentTemplate.json
@@ -246,6 +246,10 @@
             "copy": {
               "$ref": "#/definitions/resourceCopy"
             },
+            "scope": {
+              "type": "string",
+              "description": "Scope property to be used to provide scope for a resource or to be used to specify a scope for Management Group or Tenant level deployments."
+            },
             "comments": {
               "type": "string"
             }

--- a/schemas/2019-08-01/tenantDeploymentTemplate.json
+++ b/schemas/2019-08-01/tenantDeploymentTemplate.json
@@ -360,6 +360,10 @@
             "copy": {
               "$ref": "#/definitions/resourceCopy"
             },
+            "scope": {
+              "type": "string",
+              "description": "Scope property to be used to provide scope for a resource or to be used to specify a scope for Management Group or Tenant level deployments."
+            },
             "comments": {
               "type": "string"
             }


### PR DESCRIPTION
Adding "scope" property to deployment template schema. 

I wasn't able to test this locally or create a unit test for it - the PR is based on assumption that "scope" property should be recognized as a deployment template property and not a resource property. Please let me know if there is simple way to test it either locally or through unit testing. 


