### PR TITLE
Make autoUpgradeMinorVersion & protectedSettings optional

### DIFF
--- a/schemas/2019-07-01/Microsoft.Compute.Extensions.json
+++ b/schemas/2019-07-01/Microsoft.Compute.Extensions.json
@@ -1,6 +1,6 @@
 {
   "id": "https://schema.management.azure.com/schemas/2019-07-01/Microsoft.Compute.Extensions.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Microsoft.Compute.Extensions",
   "description": "Microsoft Compute Extensions Resource Types",
   "resourceDefinitions": {
@@ -524,14 +524,14 @@
             "commandToExecute": {
               "type": "string"
             }
-          },
-          "required": [
-            "commandToExecute"
-          ]
+          }
         },
         "protectedSettings": {
           "type": "object",
           "properties": {
+            "commandToExecute": {
+              "type": "string"
+            },
             "storageAccountName": {
               "type": "string"
             },
@@ -541,11 +541,20 @@
           }
         }
       },
+      "if": {
+        "properties": { "settings": { "required": ["commandToExecute"] } },
+        "required": ["settings"]
+      },
+      "then": {
+      },
+      "else": {
+        "properties": { "protectedSettings": { "required": ["commandToExecute"] } },
+        "required": ["protectedSettings"]
+      },
       "required": [
         "publisher",
         "type",
-        "typeHandlerVersion",
-        "settings"
+        "typeHandlerVersion"
       ]
     },
     "customScriptForLinux": {
@@ -596,6 +605,16 @@
             "commandToExecute"
           ]
         }
+      },
+      "if": {
+        "properties": { "settings": { "required": ["commandToExecute"] } },
+        "required": ["settings"]
+      },
+      "then": {
+      },
+      "else": {
+        "properties": { "protectedSettings": { "required": ["commandToExecute"] } },
+        "required": ["protectedSettings"]
       },
       "required": [
         "publisher",

--- a/schemas/2019-07-01/Microsoft.Compute.Extensions.json
+++ b/schemas/2019-07-01/Microsoft.Compute.Extensions.json
@@ -545,9 +545,7 @@
         "publisher",
         "type",
         "typeHandlerVersion",
-        "autoUpgradeMinorVersion",
-        "settings",
-        "protectedSettings"
+        "settings"
       ]
     },
     "customScriptForLinux": {
@@ -603,9 +601,7 @@
         "publisher",
         "type",
         "typeHandlerVersion",
-        "autoUpgradeMinorVersion",
-        "settings",
-        "protectedSettings"
+        "settings"
       ]
     },
     "linuxDiagnostic": {

--- a/schemas/2019-07-01/Microsoft.Compute.Extensions.json
+++ b/schemas/2019-07-01/Microsoft.Compute.Extensions.json
@@ -1,6 +1,6 @@
 {
   "id": "https://schema.management.azure.com/schemas/2019-07-01/Microsoft.Compute.Extensions.json#",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Microsoft.Compute.Extensions",
   "description": "Microsoft Compute Extensions Resource Types",
   "resourceDefinitions": {
@@ -515,14 +515,14 @@
         "settings": {
           "type": "object",
           "properties": {
+            "commandToExecute": {
+              "type": "string"
+            },
             "fileUris": {
               "type": "array",
               "items": {
                 "type": "string"
               }
-            },
-            "commandToExecute": {
-              "type": "string"
             }
           }
         },
@@ -540,16 +540,6 @@
             }
           }
         }
-      },
-      "if": {
-        "properties": { "settings": { "required": ["commandToExecute"] } },
-        "required": ["settings"]
-      },
-      "then": {
-      },
-      "else": {
-        "properties": { "protectedSettings": { "required": ["commandToExecute"] } },
-        "required": ["protectedSettings"]
       },
       "required": [
         "publisher",
@@ -580,6 +570,9 @@
         "settings": {
           "type": "object",
           "properties": {
+            "commandToExecute": {
+              "type": "string"
+            },
             "fileUris": {
               "type": "array",
               "items": {
@@ -600,27 +593,13 @@
             "storageAccountKey": {
               "type": "string"
             }
-          },
-          "required": [
-            "commandToExecute"
-          ]
+          }
         }
-      },
-      "if": {
-        "properties": { "settings": { "required": ["commandToExecute"] } },
-        "required": ["settings"]
-      },
-      "then": {
-      },
-      "else": {
-        "properties": { "protectedSettings": { "required": ["commandToExecute"] } },
-        "required": ["protectedSettings"]
       },
       "required": [
         "publisher",
         "type",
-        "typeHandlerVersion",
-        "settings"
+        "typeHandlerVersion"
       ]
     },
     "linuxDiagnostic": {


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/azure/templates/microsoft.compute/2019-07-01/virtualmachinescalesets#virtualmachinescalesetextensionproperties-object:
![autoUpgradeMinorVersion and protectedSettings are optional](https://user-images.githubusercontent.com/2766036/99757578-b2177780-2abd-11eb-8b29-9d19817c301c.png)

Technically, all the properties are optional, but in particular I think it makes sense to not mark autoUpgradeMinorVersion & protectedSettings as required.

The CustomScriptExtension I am currently using for one of my ARM deployments only has settings and not protectedSettings, and it works fine.