### PR TITLE
Add quantum to older deployment schemas

### DIFF
--- a/schemas/2014-04-01-preview/deploymentTemplate.json
+++ b/schemas/2014-04-01-preview/deploymentTemplate.json
@@ -2097,6 +2097,7 @@
                   { "$ref": "https://schema.management.azure.com/schemas/2019-10-17-preview/Microsoft.Insights.json#/resourceDefinitions/privateLinkScopes_scopedResources" },
                   { "$ref": "https://schema.management.azure.com/schemas/2019-11-01-preview/Microsoft.Insights.json#/resourceDefinitions/dataCollectionRules" },
                   { "$ref": "https://schema.management.azure.com/schemas/2020-05-01-preview/Microsoft.Insights.json#/resourceDefinitions/scheduledQueryRules" },
+                  { "$ref": "https://schema.management.azure.com/schemas/2019-11-04-preview/Microsoft.Quantum.json#/resourceDefinitions/workspaces" },
                   { "$ref": "#/definitions/resourceGeneric" }
                 ]
               }

--- a/schemas/2015-01-01/deploymentTemplate.json
+++ b/schemas/2015-01-01/deploymentTemplate.json
@@ -2232,7 +2232,8 @@
                   { "$ref": "https://schema.management.azure.com/schemas/2019-10-17-preview/Microsoft.Insights.json#/resourceDefinitions/privateLinkScopes_privateEndpointConnections" },
                   { "$ref": "https://schema.management.azure.com/schemas/2019-10-17-preview/Microsoft.Insights.json#/resourceDefinitions/privateLinkScopes_scopedResources" },
                   { "$ref": "https://schema.management.azure.com/schemas/2019-11-01-preview/Microsoft.Insights.json#/resourceDefinitions/dataCollectionRules" },
-                  { "$ref": "https://schema.management.azure.com/schemas/2020-05-01-preview/Microsoft.Insights.json#/resourceDefinitions/scheduledQueryRules" }
+                  { "$ref": "https://schema.management.azure.com/schemas/2020-05-01-preview/Microsoft.Insights.json#/resourceDefinitions/scheduledQueryRules" },
+                  { "$ref": "https://schema.management.azure.com/schemas/2019-11-04-preview/Microsoft.Quantum.json#/resourceDefinitions/workspaces" }
                 ]
               }
             ]


### PR DESCRIPTION
Adding Azure Quantum to the deployment template schemas for 2014-04-01-preview and 2015-01-01.