### PR TITLE
Update nodegit to 0.27.0

### DIFF
--- a/generator/cmd/postprocessor.ts
+++ b/generator/cmd/postprocessor.ts
@@ -21,10 +21,10 @@ function getStatus(file: any){
 }
 
 async function getChangedSchemas(repoPath: string) {
-    var Git = require("nodegit");
+    const Git = require('nodegit');
     const repo = await Git.Repository.open(repoPath);
     const files = await repo.getStatus();
-    let status = [];
+    let status: any[] = [];
     if (files.length) {
         status = files.map(getStatus);
     }

--- a/generator/package-lock.json
+++ b/generator/package-lock.json
@@ -22,17 +22,59 @@
         "jsonpath": "1.0.0"
       }
     },
+    "@sindresorhus/is": {
+      "version": "2.1.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/@sindresorhus/is/-/is-2.1.1.tgz",
+      "integrity": "sha1-zv9qKKW0hnwt1KG6UT3ieMy+i7E=",
+      "dev": true
+    },
+    "@szmarczak/http-timer": {
+      "version": "4.0.5",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+      "integrity": "sha1-v71QIR6d+lG6B9pYoUzf0zMgUVI=",
+      "dev": true,
+      "requires": {
+        "defer-to-connect": "^2.0.0"
+      }
+    },
     "@types/async": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.5.tgz",
       "integrity": "sha512-fdtHUdfIxSfU6crUgUOEb6vxdquAOa75bh1sQVL/ePkmQDNo8Aj1056eGGI9cPls5tLRhnAyfoXljEk+hmhbxg==",
       "dev": true
     },
+    "@types/cacheable-request": {
+      "version": "6.0.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
+      "integrity": "sha1-XSLz3e0f06hMC761A5p0GcLJGXY=",
+      "dev": true,
+      "requires": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "*",
+        "@types/node": "*",
+        "@types/responselike": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
+    },
+    "@types/http-cache-semantics": {
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
+      "integrity": "sha1-kUB3lzaqJlVjXudW4kZ9eHz+iio=",
+      "dev": true
+    },
+    "@types/keyv": {
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/@types/keyv/-/keyv-3.1.1.tgz",
+      "integrity": "sha1-5FpFMk/KnatxarEjDuJJyftSz6c=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/lodash": {
       "version": "4.14.168",
@@ -46,10 +88,43 @@
       "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==",
       "dev": true
     },
+    "@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha1-JR9P59FU0rrRJavhtCmyOv0mLik=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "JSONSelect": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz",
       "integrity": "sha1-oI7cxn6z/L6Z7WMIVTRKDPKCu40=",
+      "dev": true
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
@@ -62,10 +137,41 @@
         "color-convert": "^2.0.1"
       }
     },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
+      "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
+      "dev": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "async": {
@@ -74,16 +180,122 @@
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
     "autorest": {
       "version": "3.0.6339",
       "resolved": "https://registry.npmjs.org/autorest/-/autorest-3.0.6339.tgz",
       "integrity": "sha512-OCCmAxi5gUnh7yPho5A4n8kDrnp5uz4DdFrqwMmp/bU5DVByIdVwrWERlB7EnCFqQ9jz86oZtsjy91B07+zLnw==",
       "dev": true
     },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.11.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha1-1h9G2DslGSUOJ4Ta9bCUeai0HFk=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "bl": {
+      "version": "1.2.3",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha1-Ho3YAULqyA1xWMnczAR/tiDgNec=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha1-iQ3ZDZI6hz4I4Q5f1RpX5bfM4Ow=",
+      "dev": true,
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha1-vX3CauKXLQ7aJTvgYdupkjScGfA=",
+      "dev": true
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "cacheable-lookup": {
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
+      "integrity": "sha1-h75koYuSUjSHXhCpux68pK3Oazg=",
+      "dev": true,
+      "requires": {
+        "@types/keyv": "^3.1.1",
+        "keyv": "^4.0.0"
+      }
+    },
+    "cacheable-request": {
+      "version": "7.0.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/cacheable-request/-/cacheable-request-7.0.1.tgz",
+      "integrity": "sha1-BiAxwoViMngu1pSiV/o12pOUKlg=",
+      "dev": true,
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^2.0.0"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "chalk": {
@@ -96,10 +308,39 @@
         "supports-color": "^7.1.0"
       }
     },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs=",
+      "dev": true
+    },
     "cjson": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.2.1.tgz",
       "integrity": "sha1-c82KrWXZ4VBfmvF0TTt5wVJ2gqU=",
+      "dev": true
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      },
+      "dependencies": {
+        "mimic-response": {
+          "version": "1.0.1",
+          "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/mimic-response/-/mimic-response-1.0.1.tgz",
+          "integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs=",
+          "dev": true
+        }
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "color-convert": {
@@ -123,16 +364,100 @@
       "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "debug": {
+      "version": "3.2.7",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "decompress-response": {
+      "version": "5.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/decompress-response/-/decompress-response-5.0.0.tgz",
+      "integrity": "sha1-eEk5boDj0euoyy9170kw92Rhyw8=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^2.0.0"
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "defer-to-connect": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
+      "integrity": "sha1-g9axmdsEFZOshNeBtSIjCMz0wsE=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "dev": true
     },
     "diff": {
@@ -147,11 +472,36 @@
       "integrity": "sha512-KDbUncVUhwkJH2wjL9gbUWQ5NcZIe+PFEI0CGTMtX5TImFG6Nlt9CABVGBBG+oWf13zLARaBVenkD20moz1NPw==",
       "dev": true
     },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
     "ebnf-parser": {
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/ebnf-parser/-/ebnf-parser-0.1.10.tgz",
       "integrity": "sha1-zR9rpHfFY4xAyX7ZtXLbW6tdgzE=",
       "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "escodegen": {
       "version": "0.0.21",
@@ -190,16 +540,278 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
+      "dev": true
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
+      "dev": true
+    },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha1-zP+FcIQef+QmVpPaiJNsVa7X98c=",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.6.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "got": {
+      "version": "10.7.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/got/-/got-10.7.0.tgz",
+      "integrity": "sha1-YoidvNbMoyzWoVTMLQxolRIdCR8=",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/is": "^2.0.0",
+        "@szmarczak/http-timer": "^4.0.0",
+        "@types/cacheable-request": "^6.0.1",
+        "cacheable-lookup": "^2.0.0",
+        "cacheable-request": "^7.0.1",
+        "decompress-response": "^5.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^5.0.0",
+        "lowercase-keys": "^2.0.0",
+        "mimic-response": "^2.1.0",
+        "p-cancelable": "^2.0.0",
+        "p-event": "^4.0.0",
+        "responselike": "^2.0.0",
+        "to-readable-stream": "^2.0.0",
+        "type-fest": "^0.10.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha1-/wQLKwhTsjw9MQJ1I3BvGIXXa+4=",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
+    },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha1-SekcXL82yblLz81xwj1SSex045A=",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore-walk": {
+      "version": "3.0.3",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha1-AX4kRxhL/q3nwjjkrv3R6PlbHjc=",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha1-op2kJbSIBvNHZ6Tvzjlyaa8oQyw=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "jison": {
@@ -236,6 +848,54 @@
         "nomnom": "1.5.2"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json5": {
+      "version": "2.2.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha1-Lf7+cgxrpSXZ69kJlQ8FFTFsiaM=",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsonpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.0.0.tgz",
@@ -246,6 +906,27 @@
         "jison": "0.4.13",
         "static-eval": "2.0.0",
         "underscore": "1.7.0"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "keyv": {
+      "version": "4.0.3",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/keyv/-/keyv-4.0.3.tgz",
+      "integrity": "sha1-TzqpjeJUgDyvzSiWc0EI2qNeQlQ=",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.1"
       }
     },
     "levn": {
@@ -270,11 +951,170 @@
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
+    "lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk=",
+      "dev": true
+    },
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
+    },
+    "mime-db": {
+      "version": "1.45.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/mime-db/-/mime-db-1.45.0.tgz",
+      "integrity": "sha1-zO7aIczXw6dF66LezVXUtz54eeo=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.28",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/mime-types/-/mime-types-2.1.28.tgz",
+      "integrity": "sha1-EWDEdX6rLFNjiI4AUnPs950qDs0=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.45.0"
+      }
+    },
+    "mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha1-0Tdj019hPQnsN+uzC6wEacDuj0M=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
+      "dev": true
+    },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha1-5xN2Ln0+Mv7YAxFc+T4EvKn8yaY=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha1-IpDeloGKNMKVUcio0wEha9Zahh0=",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.9.0"
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha1-9TdkAGlRaPTMaUrJOT0MlYXu6hk=",
+      "dev": true
+    },
+    "needle": {
+      "version": "2.6.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/needle/-/needle-2.6.0.tgz",
+      "integrity": "sha1-JNu1XyUJ4jJLSpnWH0E5ggE8zb4=",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      }
+    },
+    "node-gyp": {
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/node-gyp/-/node-gyp-4.0.0.tgz",
+      "integrity": "sha1-lyZUr05d0M0qGQgbS0b+BEK6b0U=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^4.4.8",
+        "which": "1"
+      }
+    },
+    "node-pre-gyp": {
+      "version": "0.13.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz",
+      "integrity": "sha1-35q3to3WSYE3cXg45PkqM/ydqkI=",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "needle": "^2.2.1",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "4.0.3",
+          "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/nopt/-/nopt-4.0.3.tgz",
+          "integrity": "sha1-o3XK2dAv2SEnjZVMIlTVqlfhXkg=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        }
+      }
+    },
+    "nodegit": {
+      "version": "0.27.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/nodegit/-/nodegit-0.27.0.tgz",
+      "integrity": "sha1-TozCNvYOHJcySlrP+ZBW/hFqbr4=",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^7.0.0",
+        "got": "^10.7.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.14",
+        "nan": "^2.14.0",
+        "node-gyp": "^4.0.0",
+        "node-pre-gyp": "^0.13.0",
+        "ramda": "^0.25.0",
+        "tar-fs": "^1.16.3"
+      }
     },
     "nomnom": {
       "version": "1.5.2",
@@ -294,6 +1134,86 @@
         }
       }
     },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "normalize-url": {
+      "version": "4.5.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha1-RTNUCH5sqWlXvY9br3U/WYIUISk=",
+      "dev": true
+    },
+    "npm-bundled": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/npm-bundled/-/npm-bundled-1.1.1.tgz",
+      "integrity": "sha1-Ht1XCGWpTNsbyCIHdeKUZsn7I0s=",
+      "dev": true,
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha1-bnmkHyP9I1wGIyGCKNp9nCO49uI=",
+      "dev": true
+    },
+    "npm-packlist": {
+      "version": "1.4.8",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/npm-packlist/-/npm-packlist-1.4.8.tgz",
+      "integrity": "sha1-Vu5swTW5+YrT1Rwcldoiu7my7z4=",
+      "dev": true,
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -308,10 +1228,223 @@
         "word-wrap": "~1.2.3"
       }
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "p-cancelable": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/p-cancelable/-/p-cancelable-2.0.0.tgz",
+      "integrity": "sha1-SjdA9b2vXtXXw+NIgsb7XWsmam4=",
+      "dev": true
+    },
+    "p-event": {
+      "version": "4.2.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/p-event/-/p-event-4.2.0.tgz",
+      "integrity": "sha1-r0sEnIrNka6BCD69Hm9criBEwbU=",
+      "dev": true,
+      "requires": {
+        "p-timeout": "^3.1.0"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha1-x+F6vJcdKnli74NiazXWNazyPf4=",
+      "dev": true,
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ=",
+      "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
+      "dev": true
+    },
+    "ramda": {
+      "version": "0.25.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/ramda/-/ramda-0.25.0.tgz",
+      "integrity": "sha1-j99oIxz/qQvC+UYDkKDLdKKbKak=",
+      "dev": true
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/request/-/request-2.88.2.tgz",
+      "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "responselike": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/responselike/-/responselike-2.0.0.tgz",
+      "integrity": "sha1-JjkbzDF091D5p56sxAoSpcQtdyM=",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^2.0.0"
+      }
+    },
+    "rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.3.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw=",
       "dev": true
     },
     "source-map": {
@@ -337,6 +1470,23 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
+      }
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "static-eval": {
@@ -382,6 +1532,41 @@
         }
       }
     },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -389,6 +1574,82 @@
       "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
+      }
+    },
+    "tar": {
+      "version": "4.4.13",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha1-Q7NkvFKIjVVSmGN7ENYHkCVKtSU=",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.8.6",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
+      }
+    },
+    "tar-fs": {
+      "version": "1.16.3",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/tar-fs/-/tar-fs-1.16.3.tgz",
+      "integrity": "sha1-lmpiiEHaLEAQQGqCFny9Xgxy1Qk=",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "1.0.3",
+          "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/pump/-/pump-1.0.3.tgz",
+          "integrity": "sha1-Xf6DEcM7v2/BgmH580cCxHwIqVQ=",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
+    "tar-stream": {
+      "version": "1.6.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha1-jqVdqzeXIlPZqa+Q/c1VmuQ1xVU=",
+      "dev": true,
+      "requires": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      }
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha1-STvUj2LXxD/N7TE6A9ytsuEhOoA=",
+      "dev": true
+    },
+    "to-readable-stream": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/to-readable-stream/-/to-readable-stream-2.1.0.tgz",
+      "integrity": "sha1-gogDFhIb6mYs3CJq2zCt21DLBug=",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "ts-node": {
@@ -405,6 +1666,21 @@
         "yn": "3.1.1"
       }
     },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -413,6 +1689,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.10.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/type-fest/-/type-fest-0.10.0.tgz",
+      "integrity": "sha1-fwayufv8WBBo0TQf+r0DSc6vxkI=",
+      "dev": true
     },
     "typescript": {
       "version": "4.1.5",
@@ -426,10 +1708,84 @@
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
       "dev": true
     },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/which/-/which-1.3.1.tgz",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
       "dev": true
     },
     "yn": {

--- a/generator/package.json
+++ b/generator/package.json
@@ -13,13 +13,14 @@
     "postprocessor": "ts-node cmd/postprocessor"
   },
   "devDependencies": {
-    "autorest": "^3.0.6339",
     "@autorest/azureresourceschema": "^3.0.92",
     "@autorest/core": "^3.0.6373",
     "@types/async": "^3.2.5",
     "@types/lodash": "^4.14.168",
     "@types/node": "^14.14.25",
+    "nodegit": "^0.27.0",
     "async": "^3.2.0",
+    "autorest": "^3.0.6339",
     "chalk": "^4.0.0",
     "lodash": "^4.17.19",
     "ts-node": "^9.1.1",


### PR DESCRIPTION
This is to fix schemas generation on SDK automation pipeline, as the Node.js version used inside has been upgraded to 14. (see https://dev.azure.com/azure-sdk/internal/_build/results?buildId=734856&view=logs&j=2b4a2910-f027-53b2-4397-cc9d62dced0f&t=8fe74585-9ae7-5a68-f9f7-b583ed4cb967)