### PR TITLE
Run CI tests before dotnet schema tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,12 +22,12 @@ jobs:
         run: npm ci
         working-directory: ./tools
 
-      - name: Deployments Schema tests
-        run: dotnet test DeploymentsSchemaTests/DeploymentsSchemaTests.csproj
-        working-directory: ./tools
-
       - name: Run CI tests
         run: npm test
+        working-directory: ./tools
+
+      - name: Deployments Schema tests
+        run: dotnet test DeploymentsSchemaTests/DeploymentsSchemaTests.csproj
         working-directory: ./tools
 
   automerge:


### PR DESCRIPTION
The CI test failures are more descriptive when catching basic authoring errors, so best to run those first.