### PR TITLE
Update policy rule schema to 2020-09-01

### DIFF
--- a/schemas/2020-09-01/policyDefinition.json
+++ b/schemas/2020-09-01/policyDefinition.json
@@ -1,0 +1,442 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2019-09-01/policyDefinition.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Policy Definition",
+  "description": "This schema defines Azure resource policy definition, please see https://azure.microsoft.com/documentation/articles/resource-manager-policy/ for more details.",
+  "type": "object",
+  "properties": {
+    "if": {
+      "oneOf": [
+        { "$ref": "#/definitions/condition" },
+        { "$ref": "#/definitions/operatorNot" },
+        { "$ref": "#/definitions/operatorAnyOf" },
+        { "$ref": "#/definitions/operatorAllOf" }
+      ]
+    },
+    "then": {
+      "type": "object",
+      "properties": {
+        "effect": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [ "append", "audit", "auditIfNotExists", "deny", "deployIfNotExists", "modify", "disabled" ]
+            },
+            { "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression" }
+          ]
+        },
+        "details": {
+          "oneOf": [
+            { "$ref": "#/definitions/ifNotExistsDetails" },
+            { "$ref": "#/definitions/appendDetails" },
+            { "$ref": "#/definitions/modifyDetails" }
+          ]
+        }
+      },
+      "required": [ "effect" ],
+      "additionalProperties": false
+    }
+  },
+  "required": [ "if", "then" ],
+  "additionalProperties": false,
+  "definitions": {
+    "appendDetails": {
+      "type": "array",
+      "items": {
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {
+          }
+        },
+        "required": [ "field", "value" ],
+        "additionalProperties": false
+      },
+      "minItems": 1,
+      "additionalItems": false
+    },
+    "ifNotExistsDetails": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "resourceGroupName": {
+          "type": "string"
+        },
+        "existenceScope": {
+          "type": "string",
+          "enum": [ "resourceGroup", "subscription" ]
+        },
+        "deploymentScope": {
+          "type": "string",
+          "enum": [ "resourceGroup", "subscription" ]
+        },
+        "roleDefinitionIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "existenceCondition": {
+          "oneOf": [
+            { "$ref": "#/definitions/condition" },
+            { "$ref": "#/definitions/operatorNot" },
+            { "$ref": "#/definitions/operatorAnyOf" },
+            { "$ref": "#/definitions/operatorAllOf" }
+          ]
+        },
+        "deployment": {
+          "type": "object",
+          "properties": {
+            "properties": {
+              "$ref": "https://schema.management.azure.com/schemas/2018-05-01/Microsoft.Resources.json#/definitions/DeploymentProperties"
+            }
+          }
+        }
+      },
+      "required": [ "type" ],
+      "additionalProperties": false
+    },
+    "modifyDetails": {
+      "type": "object",
+      "properties": {
+        "conflictEffect": {
+          "type": "string",
+          "enum": [ "deny", "audit" ]
+        },
+        "roleDefinitionIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "operations": {
+          "type": "array",
+          "items": {
+            "properties": {
+              "operation": {
+                "type": "string",
+                "enum": [ "add", "addOrReplace", "remove" ]
+              },
+              "field": {
+                "type": "string"
+              },
+              "value": {
+              },
+              "condition": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "operation",
+              "field"
+            ],
+            "additionalProperties": false
+          },
+          "minItems": 1,
+          "additionalItems": false
+        }
+      },
+      "required": [ "roleDefinitionIds", "operations" ],
+      "additionalProperties": false
+    },
+    "condition": {
+      "allOf": [
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "source": {
+                  "type": "string"
+                }
+              },
+              "required": [ "source" ]
+            },
+            {
+              "properties": {
+                "field": {
+                  "type": "string"
+                }
+              },
+              "required": [ "field" ]
+            },
+            {
+              "properties": {
+                "value": {
+                  "type": "string"
+                }
+              },
+              "required": [ "value" ]
+            },
+            {
+              "properties": {
+                "count": {
+                  "$ref": "#/definitions/countExpression"
+                }
+              },
+              "required": [ "count" ]
+            }
+          ]
+        },
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "equals": {
+                  "type": [ "number", "string" ]
+                }
+              },
+              "required": [ "equals" ]
+            },
+            {
+              "properties": {
+                "notEquals": {
+                  "type": [ "number", "string" ]
+                }
+              },
+              "required": [ "notEquals" ]
+            },
+            {
+              "properties": {
+                "like": {
+                  "type": "string"
+                }
+              },
+              "required": [ "like" ]
+            },
+            {
+              "properties": {
+                "notLike": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notLike" ]
+            },
+            {
+              "properties": {
+                "contains": {
+                  "type": "string"
+                }
+              },
+              "required": [ "contains" ]
+            },
+            {
+              "properties": {
+                "notContains": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notContains" ]
+            },
+            {
+              "properties": {
+                "in": {
+                  "oneOf": [
+                    { "type": "array" },
+                    { "type": "string" }
+                  ]
+                }
+              },
+              "required": [ "in" ]
+            },
+            {
+              "properties": {
+                "notIn": {
+                  "oneOf": [
+                    { "type": "array" },
+                    { "type": "string" }
+                  ]
+                }
+              },
+              "required": [ "notIn" ]
+            },
+            {
+              "properties": {
+                "containsKey": {
+                  "type": "string"
+                }
+              },
+              "required": [ "containsKey" ]
+            },
+            {
+              "properties": {
+                "notContainsKey": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notContainsKey" ]
+            },
+            {
+              "properties": {
+                "match": {
+                  "type": "string"
+                }
+              },
+              "required": [ "match" ]
+            },
+            {
+              "properties": {
+                "matchInsensitively": {
+                  "type": "string"
+                }
+              },
+              "required": [ "matchInsensitively" ]
+            },
+            {
+              "properties": {
+                "notMatch": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notMatch" ]
+            },
+            {
+              "properties": {
+                "notMatchInsensitively": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notMatchInsensitively" ]
+            },
+            {
+              "properties": {
+                "exists": {
+                  "type": [ "string", "boolean" ]
+                }
+              },
+              "required": [ "exists" ]
+            },
+            {
+              "properties": {
+                "greater": {
+                  "type": [ "number", "string" ]
+                }
+              },
+              "required": [ "greater" ]
+            },
+            {
+              "properties": {
+                "less": {
+                  "type": [ "number", "string" ]
+                }
+              },
+              "required": [ "less" ]
+            },
+            {
+              "properties": {
+                "greaterOrEquals": {
+                  "type": [ "number", "string" ]
+                }
+              },
+              "required": [ "greaterOrEquals" ]
+            },
+            {
+              "properties": {
+                "lessOrEquals": {
+                  "type": [ "number", "string" ]
+                }
+              },
+              "required": [ "lessOrEquals" ]
+            }
+          ]
+        }
+      ]
+    },
+    "countExpression": {
+      "oneOf": [
+        {
+          "properties": {
+            "field": {
+              "type": "string"
+            },
+            "where": {
+              "oneOf": [
+                { "$ref": "#/definitions/condition" },
+                { "$ref": "#/definitions/operatorNot" },
+                { "$ref": "#/definitions/operatorAnyOf" },
+                { "$ref": "#/definitions/operatorAllOf" }
+              ]
+            }
+          },
+          "required": [ "field" ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "value": {
+              "type": [ "array", "string" ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "where": {
+              "oneOf": [
+                { "$ref": "#/definitions/condition" },
+                { "$ref": "#/definitions/operatorNot" },
+                { "$ref": "#/definitions/operatorAnyOf" },
+                { "$ref": "#/definitions/operatorAllOf" }
+              ]
+            }
+          },
+          "required": [ "value" ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "operatorNot": {
+      "properties": {
+        "not": {
+          "oneOf": [
+            { "$ref": "#/definitions/condition" },
+            { "$ref": "#/definitions/operatorNot" },
+            { "$ref": "#/definitions/operatorAnyOf" },
+            { "$ref": "#/definitions/operatorAllOf" }
+          ]
+        }
+      },
+      "required": [ "not" ],
+      "additionalProperties": false
+    },
+    "operatorAnyOf": {
+      "properties": {
+        "anyOf": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              { "$ref": "#/definitions/condition" },
+              { "$ref": "#/definitions/operatorNot" },
+              { "$ref": "#/definitions/operatorAnyOf" },
+              { "$ref": "#/definitions/operatorAllOf" }
+            ]
+          }
+        }
+      },
+      "required": [ "anyOf" ],
+      "additionalProperties": false
+    },
+    "operatorAllOf": {
+      "properties": {
+        "allOf": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              { "$ref": "#/definitions/condition" },
+              { "$ref": "#/definitions/operatorNot" },
+              { "$ref": "#/definitions/operatorAnyOf" },
+              { "$ref": "#/definitions/operatorAllOf" }
+            ]
+          }
+        }
+      },
+      "required": [ "allOf" ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/2020-09-01/policyDefinition.json
+++ b/schemas/2020-09-01/policyDefinition.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://schema.management.azure.com/schemas/2019-09-01/policyDefinition.json#",
+  "id": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Policy Definition",
   "description": "This schema defines Azure resource policy definition, please see https://azure.microsoft.com/documentation/articles/resource-manager-policy/ for more details.",
@@ -20,7 +20,7 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": [ "append", "audit", "auditIfNotExists", "deny", "deployIfNotExists", "modify", "disabled" ]
+              "enum": [ "append", "audit", "auditIfNotExists", "deny", "deployIfNotExists", "manual", "modify", "disabled" ]
             },
             { "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression" }
           ]
@@ -29,7 +29,8 @@
           "oneOf": [
             { "$ref": "#/definitions/ifNotExistsDetails" },
             { "$ref": "#/definitions/appendDetails" },
-            { "$ref": "#/definitions/modifyDetails" }
+            { "$ref": "#/definitions/modifyDetails" },
+            { "$ref": "#/definitions/manualDetails" }
           ]
         }
       },
@@ -106,8 +107,15 @@
       "type": "object",
       "properties": {
         "conflictEffect": {
-          "type": "string",
-          "enum": [ "deny", "audit" ]
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [ "audit", "deny" ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "roleDefinitionIds": {
           "type": "array",
@@ -129,7 +137,7 @@
               "value": {
               },
               "condition": {
-                "type": "string"
+                "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
               }
             },
             "required": [
@@ -143,6 +151,23 @@
         }
       },
       "required": [ "roleDefinitionIds", "operations" ],
+      "additionalProperties": false
+    },
+    "manualDetails": {
+      "type": "object",
+      "properties": {
+        "defaultState": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [ "Compliant", "NonCompliant", "Unknown" ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
       "additionalProperties": false
     },
     "condition": {
@@ -369,7 +394,10 @@
         {
           "properties": {
             "value": {
-              "type": [ "array", "string" ]
+              "oneOf": [
+                { "type": "array" },
+                { "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression" }
+              ]
             },
             "name": {
               "type": "string"

--- a/tests/2020-09-01/policyDefinition.tests.json
+++ b/tests/2020-09-01/policyDefinition.tests.json
@@ -1,0 +1,958 @@
+{
+  "tests": [
+    {
+      "name": "PolicyDefinition tests - valid minimal rule",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "location",
+          "equals": "westus"
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - valid complex rule",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "not": {
+            "anyOf": [
+              {
+                "field": "type",
+                "equals": "Microsoft.SQL/servers"
+              },
+              {
+                "source": "action",
+                "equals": "asdkfjkladsf"
+              },
+              {
+                "value": "string literal",
+                "notLike": "string*"
+              },
+              {
+                "count": {
+                  "field": "Microsoft.Compute/virtualMachines/networkInterfaces[*]"
+                },
+                "greater": 10
+              },
+              {
+                "not": {
+                  "allOf": [
+                    {
+                      "field": "foo",
+                      "notIn": [ "foo12", "asdf", "asdf" ]
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "then": {
+          "effect": "[parameters('effect')]"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - valid complex field count condition",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+            "allOf": [
+              {
+                "field": "type",
+                "equals": "Microsoft.Compute/virtualMachines"
+              },
+              {
+                "count": {
+                  "field": "Microsoft.Compute/virtualMachines/ipConfigurations[*]",
+                  "where": {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/virtualMachines/ipConfigurations[*].networkInterface.id",
+                        "contains": "[concat('/resourcegroups/', parameters('myRG'))]"
+                      },
+                      {
+                        "count": {
+                          "field": "Microsoft.Compute/virtualMachines/ipConfigurations[*].networkInterface.ports[*]"
+                        },
+                        "equals": 0
+                      }
+                    ]
+                  }
+                },
+                "greater": 10
+              }
+            ]
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - valid value count conditions",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "allOf": [
+            {
+              "count": {
+                "value": []
+              },
+              "greater": 0
+            },
+            {
+              "count": {
+                "value": [],
+                "name": "currentValue"
+              },
+              "greater": 0
+            },
+            {
+              "count": {
+                "value": [],
+                "name": "currentValue",
+                "where": {
+                  "value": "[current('currentValue')]",
+                  "equals": 1
+                }
+              },
+              "greater": 0
+            },
+            {
+              "count": {
+                "value": "[parameters('arrayParam')]"
+              },
+              "greater": 0
+            },
+            {
+              "count": {
+                "value": "[parameters('arrayParam')]",
+                "name": "currentValue"
+              },
+              "greater": 0
+            },
+            {
+              "count": {
+                "value": "[parameters('arrayParam')]",
+                "name": "currentValue",
+                "where": {
+                  "value": "[current('currentValue')]",
+                  "equals": 1
+                }
+              },
+              "greater": 0
+            }
+          ]
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - valid append details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "append",
+          "details": [
+            {
+              "field": "tags.location",
+              "value": "westus"
+            },
+            {
+              "field": "tags.foo",
+              "value": "bar"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - minimal ifNotExists details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "auditIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions"
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - complex ifNotExists details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "auditIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "resourceGroupName": "myRG",
+            "name": "myResource",
+            "existenceCondition": {
+              "not": {
+                "field": "location",
+                "in": [ "eastus", "westeurope" ]
+              }
+            },
+            "existenceScope": "subscription",
+            "roleDefinitionIds": [ "/providers/microsoft.authorization/roleDefinitions/d0610b27-9663-4c05-89f8-5b4be01e86a5" ],
+            "deployment": {
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "resources": [
+                    {
+                      "type": "Microsoft.Compute/virtualMachines",
+                      "name": "MyVirtualMachine",
+                      "apiVersion": "2018-06-01"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid deployIfNotExists deployment template",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "type",
+          "equals": "Microsoft.Compute/virtualMachines"
+        },
+        "then": {
+          "effect": "deployIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "existenceCondition": {
+              "field": "Microsoft.Compute/virtualMachines/extensions/type",
+              "equals": "OmsAgentForLinux"
+            },
+            "roleDefinitionIds": [
+              "/providers/microsoft.authorization/roleDefinitions/d0610b27-9663-4c05-89f8-5b4be01e86a5"
+            ],
+            "deployment": {
+              "properties": {
+                "template": {
+                  "resources": [
+                    {
+                      "type": "Microsoft.Compute/virtualMachines",
+                      "name": "MyVirtualMachine",
+                      "apiVersion": "2018-06-01"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - complex deployIfNotExists deployment",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.Compute/virtualMachines"
+            },
+            {
+              "anyOf": [
+                {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "RedHat"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "in": [
+                        "RHEL",
+                        "RHEL-SAP-HANA"
+                      ]
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "6.*"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "7*"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "SUSE"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "in": [
+                        "SLES",
+                        "SLES-SAP",
+                        "SLES-SAP-BYOS",
+                        "SLES-Priority",
+                        "SLES-BYOS",
+                        "SLES-SAPCAL",
+                        "sles-byos"
+                      ]
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "12*"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "Canonical"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "equals": "UbuntuServer"
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "14.04*LTS"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "16.04*LTS"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "18.04*LTS"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "Oracle"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "equals": "Oracle-Linux"
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "6.*"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "7.*"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "OpenLogic"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "in": [
+                        "CentOS",
+                        "Centos-LVM"
+                      ]
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "6.*"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "7*"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "then": {
+          "effect": "deployIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "roleDefinitionIds": [
+              "/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293"
+            ],
+            "existenceCondition": {
+              "allOf": [
+                {
+                  "field": "Microsoft.Compute/virtualMachines/extensions/type",
+                  "equals": "OmsAgentForLinux"
+                },
+                {
+                  "field": "Microsoft.Compute/virtualMachines/extensions/publisher",
+                  "equals": "Microsoft.EnterpriseCloud.Monitoring"
+                },
+                {
+                  "field": "Microsoft.Compute/virtualMachines/extensions/provisioningState",
+                  "equals": "Succeeded"
+                }
+              ]
+            },
+            "deploymentScope": "subscription",
+            "deployment": {
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {
+                    "vmName": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "logAnalytics": {
+                      "type": "string"
+                    }
+                  },
+                  "variables": {
+                    "vmExtensionName": "MMAExtension",
+                    "vmExtensionPublisher": "Microsoft.EnterpriseCloud.Monitoring",
+                    "vmExtensionType": "OmsAgentForLinux",
+                    "vmExtensionTypeHandlerVersion": "1.7"
+                  },
+                  "resources": [
+                    {
+                      "name": "[concat(parameters('vmName'), '/', variables('vmExtensionName'))]",
+                      "type": "Microsoft.Compute/virtualMachines/extensions",
+                      "location": "[parameters('location')]",
+                      "apiVersion": "2018-06-01",
+                      "properties": {
+                        "publisher": "[variables('vmExtensionPublisher')]",
+                        "type": "[variables('vmExtensionType')]",
+                        "typeHandlerVersion": "[variables('vmExtensionTypeHandlerVersion')]",
+                        "autoUpgradeMinorVersion": true,
+                        "settings": {
+                          "workspaceId": "[reference(parameters('logAnalytics'), '2015-03-20').customerId]",
+                          "stopOnMultipleConnections": "true"
+                        },
+                        "protectedSettings": {
+                          "workspaceKey": "[listKeys(parameters('logAnalytics'), '2015-03-20').primarySharedKey]"
+                        }
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "policy": {
+                      "type": "string",
+                      "value": "[concat('Enabled extension for VM', ': ', parameters('vmName'))]"
+                    }
+                  }
+                },
+                "parameters": {
+                  "vmName": {
+                    "value": "[field('name')]"
+                  },
+                  "location": {
+                    "value": "[field('location')]"
+                  },
+                  "logAnalytics": {
+                    "value": "[parameters('logAnalytics')]"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid ifNotExists existenceCondition",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "auditIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "existenceCondition": {
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid ifNotExists existenceScope",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "auditIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "existenceScope": "foo"
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid ifNotExists deploymentScope",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "auditIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "deploymentScope": "foo"
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - missing append details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "append",
+          "details": []
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid effect",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/effect",
+          "schemaPath": "/properties/then/properties/effect/oneOf",
+          "subErrors": [
+            {
+              "message": "No enum match for: \"foo\"",
+              "dataPath": "/then/effect",
+              "schemaPath": "/properties/then/properties/effect/oneOf/0/type",
+              "subErrors": []
+            },
+            {
+              "message": "String does not match pattern: ^\\[([^\\[].*)?\\]$",
+              "dataPath": "/then/effect",
+              "schemaPath": "/properties/then/properties/effect/oneOf/1/pattern",
+              "subErrors": []
+            }
+          ]
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "location",
+          "equals": "westus"
+        },
+        "then": {
+          "effect": "foo"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid field property",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/if"
+        }
+      ],
+      "json": {
+        "if": {
+          "field2": "location",
+          "equals": "westus"
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid operator",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/if"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "location",
+          "notEqualTo": "westus"
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - array for non-array operator",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/if"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "location",
+          "equals": [ "foo" ]
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - string for array operator",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "location",
+          "notIn": "[parameters('foo')]"
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - minimal modify details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "notContainsKey": "westus"
+        },
+        "then": {
+          "effect": "modify",
+          "details": {
+            "roleDefinitionIds": [
+              "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+            ],
+            "operations": [
+              { "field": "tags.westus", "value": "present", "operation": "add" }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid modify details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "notContainsKey": "westus"
+        },
+        "then": {
+          "effect": "modify",
+          "details": {
+            "operations": [ 
+              { "field": "tags.westus", "value": "present", "operation": "foo" } 
+            ]
+          }
+        }
+      },
+      "expectedErrors": [
+        {
+          "dataPath": "/then/details",
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "schemaPath": "/properties/then/properties/details/oneOf",
+          "subErrors": [
+            {
+              "dataPath": "/then/details",
+              "message": "Missing required property: type",
+              "schemaPath": "/properties/then/properties/details/oneOf/0/required/0",
+              "subErrors": []
+            },
+            {
+              "dataPath": "/then/details/operations",
+              "message": "Additional properties not allowed",
+              "schemaPath": "/properties/then/properties/details/oneOf/0/additionalProperties",
+              "subErrors": []
+            },
+            {
+              "dataPath": "/then/details",
+              "message": "Invalid type: object (expected array)",
+              "schemaPath": "/properties/then/properties/details/oneOf/1/type",
+              "subErrors": []
+            },
+            {
+              "dataPath": "/then/details",
+              "message": "Missing required property: roleDefinitionIds",
+              "schemaPath": "/properties/then/properties/details/oneOf/2/required/0",
+              "subErrors": []
+            },
+            {
+              "dataPath": "/then/details/operations/0/operation",
+              "message": "No enum match for: \"foo\"",
+              "schemaPath": "/properties/then/properties/details/oneOf/2/properties/operations/items/properties/operation/type",
+              "subErrors": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PolicyDefinition tests - complex modify details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "notContainsKey": "westus"
+        },
+        "then": {
+          "effect": "modify",
+          "details": {
+            "conflictEffect": "audit",
+            "roleDefinitionIds": [
+              "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+              "/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+            ],
+            "operations": [
+              { "field": "tags.westus", "value": "present", "operation": "add" },
+              { "field": "tags.tagOne", "value": "present", "operation": "add", "condition": "[greater(requestContext().apiVersion, '2019-01-01')]" },
+              { "field": "tags.tagTwo", "operation": "remove" },
+              { "field": "[concat('tags.', parameters('tagName'))]", "value": "[parameters('tagValue')]", "operation": "addOrReplace" }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - valid manual details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "type",
+          "equals": "Microsoft.Resources/subscriptions"
+        },
+        "then": {
+          "effect": "manual",
+          "details": {
+            "defaultState": "NonCompliant"
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - no manual details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "type",
+          "equals": "Microsoft.Resources/subscriptions"
+        },
+        "then": {
+          "effect": "manual"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - empty manual details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "type",
+          "equals": "Microsoft.Resources/subscriptions"
+        },
+        "then": {
+          "effect": "manual",
+          "details": {}
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - parameterized manual details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "type",
+          "equals": "Microsoft.Resources/subscriptions"
+        },
+        "then": {
+          "effect": "manual",
+          "details": {
+            "defaultState": "[parameters('defaultState')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid manual details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "type",
+          "equals": "Microsoft.Resources/subscriptions"
+        },
+        "then": {
+          "effect": "manual",
+          "details": {
+            "defaultState": "Conflict"
+          }
+        }
+      },
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details",
+          "schemaPath": "/properties/then/properties/details/oneOf",
+          "subErrors": [
+            {
+              "message": "Missing required property: type",
+              "dataPath": "/then/details",
+              "schemaPath": "/properties/then/properties/details/oneOf/0/required/0",
+              "subErrors": []
+            },
+            {
+              "message": "Additional properties not allowed",
+              "dataPath": "/then/details/defaultState",
+              "schemaPath": "/properties/then/properties/details/oneOf/0/additionalProperties",
+              "subErrors": []
+            },
+            {
+              "message": "Invalid type: object (expected array)",
+              "dataPath": "/then/details",
+              "schemaPath": "/properties/then/properties/details/oneOf/1/type",
+              "subErrors": []
+            },
+            {
+              "message": "Missing required property: roleDefinitionIds",
+              "dataPath": "/then/details",
+              "schemaPath": "/properties/then/properties/details/oneOf/2/required/0",
+              "subErrors": []
+            },
+            {
+              "message": "Missing required property: operations",
+              "dataPath": "/then/details",
+              "schemaPath": "/properties/then/properties/details/oneOf/2/required/1",
+              "subErrors": []
+            },
+            {
+              "message": "Additional properties not allowed",
+              "dataPath": "/then/details/defaultState",
+              "schemaPath": "/properties/then/properties/details/oneOf/2/additionalProperties",
+              "subErrors": []
+            },
+            {
+              "message": "Data does not match any schemas from \"oneOf\"",
+              "dataPath": "/then/details/defaultState",
+              "schemaPath": "/properties/then/properties/details/oneOf/3/properties/defaultState/oneOf",
+              "subErrors": [
+                {
+                  "message": "No enum match for: \"Conflict\"",
+                  "dataPath": "/then/details/defaultState",
+                  "schemaPath": "/properties/then/properties/details/oneOf/3/properties/defaultState/oneOf/0/type",
+                  "subErrors": []
+                },
+                {
+                  "message": "String does not match pattern: ^\\[([^\\[].*)?\\]$",
+                  "dataPath": "/then/details/defaultState",
+                  "schemaPath": "/properties/then/properties/details/oneOf/3/properties/defaultState/oneOf/1/pattern",
+                  "subErrors": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tools/tests.ts
+++ b/tools/tests.ts
@@ -121,6 +121,7 @@ const schemasToSkip = [
   '2019-01-01/policyDefinition.json',
   '2019-06-01/policyDefinition.json',
   '2019-09-01/policyDefinition.json',
+  '2020-09-01/policyDefinition.json',
   '2018-05-01/subscriptionDeploymentParameters.json',
   '2018-05-01/subscriptionDeploymentTemplate.json',
   '2019-04-01/deploymentParameters.json',


### PR DESCRIPTION
The policy rule schema is kept in this repo but is not a pure resource schema.  Its only the schema for the complex policy rules found inside policyDefinitions.  Updating to the latest version and adding tests for the changes.

Commit 1 was just a copy of the old version, commit 2 has then changes.