### PR TITLE
Added B1ls sku for autocomplete

### DIFF
--- a/schemas/2017-12-01/Microsoft.Compute.json
+++ b/schemas/2017-12-01/Microsoft.Compute.json
@@ -868,6 +868,7 @@
                 "Standard_A2m_v2",
                 "Standard_A4m_v2",
                 "Standard_A8m_v2",
+                "Standard_B1ls",
                 "Standard_B1s",
                 "Standard_B1ms",
                 "Standard_B2s",


### PR DESCRIPTION
The autocomplete for the B1ls virtualmachine sku is missing. I added reference to the Microsoft.Compute.json.

Microsoft documentation: https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-b-series-burstable