### PR TITLE
Update ANF volume description

### DIFF
--- a/schemas/2021-02-01/Microsoft.NetApp.json
+++ b/schemas/2021-02-01/Microsoft.NetApp.json
@@ -1,7 +1,7 @@
 {
   "id": "https://schema.management.azure.com/schemas/2021-02-01/Microsoft.NetApp.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Microsoft.NetApp",
+  "title": "Microsoft.NetApp",  
   "description": "Microsoft NetApp Resource Types",
   "resourceDefinitions": {
     "netAppAccounts": {
@@ -1844,7 +1844,7 @@
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
             }
           ],
-          "description": "Maximum storage quota allowed for a file system in bytes. This is a soft quota used for alerting only. Minimum size is 100 GiB. Upper limit is 100TiB. Specified in bytes."
+          "description": "The actual configured size (hard quota) without automatic capacity increase"
         },
         "volumeType": {
           "type": "string",


### PR DESCRIPTION
Regarding the change in  2021 April-30 Azure NetApp Files volumes will no longer be thin provisioned at (the maximum) 100 TiB and the soft quota will be hard quota.
https://docs.microsoft.com/en-us/azure/azure-netapp-files/volume-hard-quota-guidelines