### PR TITLE
Specify full path for autorest invokation

### DIFF
--- a/generator/generate.ts
+++ b/generator/generate.ts
@@ -100,7 +100,7 @@ async function handleGeneratedSchema(readme: string, schemaPath: string, autoGen
 }
 
 async function execAutoRest(tmpFolder: string, params: string[]) {
-    await executeCmd(__dirname, autorestBinary, params);
+    await executeCmd(__dirname, `${__dirname}/node_modules/.bin/${autorestBinary}`, params);
     if (!await fileExists(tmpFolder)) {
         return [];
     }


### PR DESCRIPTION
I noticed that on more recent versions of `node`, the path resolution logic for `autorest.cmd` no longer works.

This should allow it to work in a back-compatible manner.