### PR TITLE
Add evaluationDelay to policyDefinition rule schema

### DIFF
--- a/schemas/2020-10-01/policyDefinition.json
+++ b/schemas/2020-10-01/policyDefinition.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+  "id": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Policy Definition",
   "description": "This schema defines Azure resource policy definition, please see https://azure.microsoft.com/documentation/articles/resource-manager-policy/ for more details.",
@@ -82,6 +82,9 @@
           "items": {
             "type": "string"
           }
+        },
+        "evaluationDelay": {
+          "type": "string"
         },
         "existenceCondition": {
           "oneOf": [

--- a/schemas/2020-10-01/policyDefinition.json
+++ b/schemas/2020-10-01/policyDefinition.json
@@ -1,0 +1,470 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Policy Definition",
+  "description": "This schema defines Azure resource policy definition, please see https://azure.microsoft.com/documentation/articles/resource-manager-policy/ for more details.",
+  "type": "object",
+  "properties": {
+    "if": {
+      "oneOf": [
+        { "$ref": "#/definitions/condition" },
+        { "$ref": "#/definitions/operatorNot" },
+        { "$ref": "#/definitions/operatorAnyOf" },
+        { "$ref": "#/definitions/operatorAllOf" }
+      ]
+    },
+    "then": {
+      "type": "object",
+      "properties": {
+        "effect": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [ "append", "audit", "auditIfNotExists", "deny", "deployIfNotExists", "manual", "modify", "disabled" ]
+            },
+            { "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression" }
+          ]
+        },
+        "details": {
+          "oneOf": [
+            { "$ref": "#/definitions/ifNotExistsDetails" },
+            { "$ref": "#/definitions/appendDetails" },
+            { "$ref": "#/definitions/modifyDetails" },
+            { "$ref": "#/definitions/manualDetails" }
+          ]
+        }
+      },
+      "required": [ "effect" ],
+      "additionalProperties": false
+    }
+  },
+  "required": [ "if", "then" ],
+  "additionalProperties": false,
+  "definitions": {
+    "appendDetails": {
+      "type": "array",
+      "items": {
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {
+          }
+        },
+        "required": [ "field", "value" ],
+        "additionalProperties": false
+      },
+      "minItems": 1,
+      "additionalItems": false
+    },
+    "ifNotExistsDetails": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "resourceGroupName": {
+          "type": "string"
+        },
+        "existenceScope": {
+          "type": "string",
+          "enum": [ "resourceGroup", "subscription" ]
+        },
+        "deploymentScope": {
+          "type": "string",
+          "enum": [ "resourceGroup", "subscription" ]
+        },
+        "roleDefinitionIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "existenceCondition": {
+          "oneOf": [
+            { "$ref": "#/definitions/condition" },
+            { "$ref": "#/definitions/operatorNot" },
+            { "$ref": "#/definitions/operatorAnyOf" },
+            { "$ref": "#/definitions/operatorAllOf" }
+          ]
+        },
+        "deployment": {
+          "type": "object",
+          "properties": {
+            "properties": {
+              "$ref": "https://schema.management.azure.com/schemas/2018-05-01/Microsoft.Resources.json#/definitions/DeploymentProperties"
+            }
+          }
+        }
+      },
+      "required": [ "type" ],
+      "additionalProperties": false
+    },
+    "modifyDetails": {
+      "type": "object",
+      "properties": {
+        "conflictEffect": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [ "audit", "deny" ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "roleDefinitionIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "operations": {
+          "type": "array",
+          "items": {
+            "properties": {
+              "operation": {
+                "type": "string",
+                "enum": [ "add", "addOrReplace", "remove" ]
+              },
+              "field": {
+                "type": "string"
+              },
+              "value": {
+              },
+              "condition": {
+                "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+              }
+            },
+            "required": [
+              "operation",
+              "field"
+            ],
+            "additionalProperties": false
+          },
+          "minItems": 1,
+          "additionalItems": false
+        }
+      },
+      "required": [ "roleDefinitionIds", "operations" ],
+      "additionalProperties": false
+    },
+    "manualDetails": {
+      "type": "object",
+      "properties": {
+        "defaultState": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [ "Compliant", "NonCompliant", "Unknown" ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "condition": {
+      "allOf": [
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "source": {
+                  "type": "string"
+                }
+              },
+              "required": [ "source" ]
+            },
+            {
+              "properties": {
+                "field": {
+                  "type": "string"
+                }
+              },
+              "required": [ "field" ]
+            },
+            {
+              "properties": {
+                "value": {
+                  "type": "string"
+                }
+              },
+              "required": [ "value" ]
+            },
+            {
+              "properties": {
+                "count": {
+                  "$ref": "#/definitions/countExpression"
+                }
+              },
+              "required": [ "count" ]
+            }
+          ]
+        },
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "equals": {
+                  "type": [ "number", "string" ]
+                }
+              },
+              "required": [ "equals" ]
+            },
+            {
+              "properties": {
+                "notEquals": {
+                  "type": [ "number", "string" ]
+                }
+              },
+              "required": [ "notEquals" ]
+            },
+            {
+              "properties": {
+                "like": {
+                  "type": "string"
+                }
+              },
+              "required": [ "like" ]
+            },
+            {
+              "properties": {
+                "notLike": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notLike" ]
+            },
+            {
+              "properties": {
+                "contains": {
+                  "type": "string"
+                }
+              },
+              "required": [ "contains" ]
+            },
+            {
+              "properties": {
+                "notContains": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notContains" ]
+            },
+            {
+              "properties": {
+                "in": {
+                  "oneOf": [
+                    { "type": "array" },
+                    { "type": "string" }
+                  ]
+                }
+              },
+              "required": [ "in" ]
+            },
+            {
+              "properties": {
+                "notIn": {
+                  "oneOf": [
+                    { "type": "array" },
+                    { "type": "string" }
+                  ]
+                }
+              },
+              "required": [ "notIn" ]
+            },
+            {
+              "properties": {
+                "containsKey": {
+                  "type": "string"
+                }
+              },
+              "required": [ "containsKey" ]
+            },
+            {
+              "properties": {
+                "notContainsKey": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notContainsKey" ]
+            },
+            {
+              "properties": {
+                "match": {
+                  "type": "string"
+                }
+              },
+              "required": [ "match" ]
+            },
+            {
+              "properties": {
+                "matchInsensitively": {
+                  "type": "string"
+                }
+              },
+              "required": [ "matchInsensitively" ]
+            },
+            {
+              "properties": {
+                "notMatch": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notMatch" ]
+            },
+            {
+              "properties": {
+                "notMatchInsensitively": {
+                  "type": "string"
+                }
+              },
+              "required": [ "notMatchInsensitively" ]
+            },
+            {
+              "properties": {
+                "exists": {
+                  "type": [ "string", "boolean" ]
+                }
+              },
+              "required": [ "exists" ]
+            },
+            {
+              "properties": {
+                "greater": {
+                  "type": [ "number", "string" ]
+                }
+              },
+              "required": [ "greater" ]
+            },
+            {
+              "properties": {
+                "less": {
+                  "type": [ "number", "string" ]
+                }
+              },
+              "required": [ "less" ]
+            },
+            {
+              "properties": {
+                "greaterOrEquals": {
+                  "type": [ "number", "string" ]
+                }
+              },
+              "required": [ "greaterOrEquals" ]
+            },
+            {
+              "properties": {
+                "lessOrEquals": {
+                  "type": [ "number", "string" ]
+                }
+              },
+              "required": [ "lessOrEquals" ]
+            }
+          ]
+        }
+      ]
+    },
+    "countExpression": {
+      "oneOf": [
+        {
+          "properties": {
+            "field": {
+              "type": "string"
+            },
+            "where": {
+              "oneOf": [
+                { "$ref": "#/definitions/condition" },
+                { "$ref": "#/definitions/operatorNot" },
+                { "$ref": "#/definitions/operatorAnyOf" },
+                { "$ref": "#/definitions/operatorAllOf" }
+              ]
+            }
+          },
+          "required": [ "field" ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "value": {
+              "oneOf": [
+                { "type": "array" },
+                { "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression" }
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "where": {
+              "oneOf": [
+                { "$ref": "#/definitions/condition" },
+                { "$ref": "#/definitions/operatorNot" },
+                { "$ref": "#/definitions/operatorAnyOf" },
+                { "$ref": "#/definitions/operatorAllOf" }
+              ]
+            }
+          },
+          "required": [ "value" ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "operatorNot": {
+      "properties": {
+        "not": {
+          "oneOf": [
+            { "$ref": "#/definitions/condition" },
+            { "$ref": "#/definitions/operatorNot" },
+            { "$ref": "#/definitions/operatorAnyOf" },
+            { "$ref": "#/definitions/operatorAllOf" }
+          ]
+        }
+      },
+      "required": [ "not" ],
+      "additionalProperties": false
+    },
+    "operatorAnyOf": {
+      "properties": {
+        "anyOf": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              { "$ref": "#/definitions/condition" },
+              { "$ref": "#/definitions/operatorNot" },
+              { "$ref": "#/definitions/operatorAnyOf" },
+              { "$ref": "#/definitions/operatorAllOf" }
+            ]
+          }
+        }
+      },
+      "required": [ "anyOf" ],
+      "additionalProperties": false
+    },
+    "operatorAllOf": {
+      "properties": {
+        "allOf": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              { "$ref": "#/definitions/condition" },
+              { "$ref": "#/definitions/operatorNot" },
+              { "$ref": "#/definitions/operatorAnyOf" },
+              { "$ref": "#/definitions/operatorAllOf" }
+            ]
+          }
+        }
+      },
+      "required": [ "allOf" ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/tests/2020-10-01/policyDefinition.tests.json
+++ b/tests/2020-10-01/policyDefinition.tests.json
@@ -1,0 +1,958 @@
+{
+  "tests": [
+    {
+      "name": "PolicyDefinition tests - valid minimal rule",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "location",
+          "equals": "westus"
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - valid complex rule",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "not": {
+            "anyOf": [
+              {
+                "field": "type",
+                "equals": "Microsoft.SQL/servers"
+              },
+              {
+                "source": "action",
+                "equals": "asdkfjkladsf"
+              },
+              {
+                "value": "string literal",
+                "notLike": "string*"
+              },
+              {
+                "count": {
+                  "field": "Microsoft.Compute/virtualMachines/networkInterfaces[*]"
+                },
+                "greater": 10
+              },
+              {
+                "not": {
+                  "allOf": [
+                    {
+                      "field": "foo",
+                      "notIn": [ "foo12", "asdf", "asdf" ]
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "then": {
+          "effect": "[parameters('effect')]"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - valid complex field count condition",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+            "allOf": [
+              {
+                "field": "type",
+                "equals": "Microsoft.Compute/virtualMachines"
+              },
+              {
+                "count": {
+                  "field": "Microsoft.Compute/virtualMachines/ipConfigurations[*]",
+                  "where": {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/virtualMachines/ipConfigurations[*].networkInterface.id",
+                        "contains": "[concat('/resourcegroups/', parameters('myRG'))]"
+                      },
+                      {
+                        "count": {
+                          "field": "Microsoft.Compute/virtualMachines/ipConfigurations[*].networkInterface.ports[*]"
+                        },
+                        "equals": 0
+                      }
+                    ]
+                  }
+                },
+                "greater": 10
+              }
+            ]
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - valid value count conditions",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "allOf": [
+            {
+              "count": {
+                "value": []
+              },
+              "greater": 0
+            },
+            {
+              "count": {
+                "value": [],
+                "name": "currentValue"
+              },
+              "greater": 0
+            },
+            {
+              "count": {
+                "value": [],
+                "name": "currentValue",
+                "where": {
+                  "value": "[current('currentValue')]",
+                  "equals": 1
+                }
+              },
+              "greater": 0
+            },
+            {
+              "count": {
+                "value": "[parameters('arrayParam')]"
+              },
+              "greater": 0
+            },
+            {
+              "count": {
+                "value": "[parameters('arrayParam')]",
+                "name": "currentValue"
+              },
+              "greater": 0
+            },
+            {
+              "count": {
+                "value": "[parameters('arrayParam')]",
+                "name": "currentValue",
+                "where": {
+                  "value": "[current('currentValue')]",
+                  "equals": 1
+                }
+              },
+              "greater": 0
+            }
+          ]
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - valid append details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "append",
+          "details": [
+            {
+              "field": "tags.location",
+              "value": "westus"
+            },
+            {
+              "field": "tags.foo",
+              "value": "bar"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - minimal ifNotExists details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "auditIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions"
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - complex ifNotExists details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "auditIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "resourceGroupName": "myRG",
+            "name": "myResource",
+            "existenceCondition": {
+              "not": {
+                "field": "location",
+                "in": [ "eastus", "westeurope" ]
+              }
+            },
+            "existenceScope": "subscription",
+            "roleDefinitionIds": [ "/providers/microsoft.authorization/roleDefinitions/d0610b27-9663-4c05-89f8-5b4be01e86a5" ],
+            "deployment": {
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "resources": [
+                    {
+                      "type": "Microsoft.Compute/virtualMachines",
+                      "name": "MyVirtualMachine",
+                      "apiVersion": "2018-06-01"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid deployIfNotExists deployment template",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "type",
+          "equals": "Microsoft.Compute/virtualMachines"
+        },
+        "then": {
+          "effect": "deployIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "existenceCondition": {
+              "field": "Microsoft.Compute/virtualMachines/extensions/type",
+              "equals": "OmsAgentForLinux"
+            },
+            "roleDefinitionIds": [
+              "/providers/microsoft.authorization/roleDefinitions/d0610b27-9663-4c05-89f8-5b4be01e86a5"
+            ],
+            "deployment": {
+              "properties": {
+                "template": {
+                  "resources": [
+                    {
+                      "type": "Microsoft.Compute/virtualMachines",
+                      "name": "MyVirtualMachine",
+                      "apiVersion": "2018-06-01"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - complex deployIfNotExists deployment",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.Compute/virtualMachines"
+            },
+            {
+              "anyOf": [
+                {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "RedHat"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "in": [
+                        "RHEL",
+                        "RHEL-SAP-HANA"
+                      ]
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "6.*"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "7*"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "SUSE"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "in": [
+                        "SLES",
+                        "SLES-SAP",
+                        "SLES-SAP-BYOS",
+                        "SLES-Priority",
+                        "SLES-BYOS",
+                        "SLES-SAPCAL",
+                        "sles-byos"
+                      ]
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "12*"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "Canonical"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "equals": "UbuntuServer"
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "14.04*LTS"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "16.04*LTS"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "18.04*LTS"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "Oracle"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "equals": "Oracle-Linux"
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "6.*"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "7.*"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "OpenLogic"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "in": [
+                        "CentOS",
+                        "Centos-LVM"
+                      ]
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "6.*"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "like": "7*"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "then": {
+          "effect": "deployIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "roleDefinitionIds": [
+              "/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293"
+            ],
+            "existenceCondition": {
+              "allOf": [
+                {
+                  "field": "Microsoft.Compute/virtualMachines/extensions/type",
+                  "equals": "OmsAgentForLinux"
+                },
+                {
+                  "field": "Microsoft.Compute/virtualMachines/extensions/publisher",
+                  "equals": "Microsoft.EnterpriseCloud.Monitoring"
+                },
+                {
+                  "field": "Microsoft.Compute/virtualMachines/extensions/provisioningState",
+                  "equals": "Succeeded"
+                }
+              ]
+            },
+            "deploymentScope": "subscription",
+            "deployment": {
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {
+                    "vmName": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "logAnalytics": {
+                      "type": "string"
+                    }
+                  },
+                  "variables": {
+                    "vmExtensionName": "MMAExtension",
+                    "vmExtensionPublisher": "Microsoft.EnterpriseCloud.Monitoring",
+                    "vmExtensionType": "OmsAgentForLinux",
+                    "vmExtensionTypeHandlerVersion": "1.7"
+                  },
+                  "resources": [
+                    {
+                      "name": "[concat(parameters('vmName'), '/', variables('vmExtensionName'))]",
+                      "type": "Microsoft.Compute/virtualMachines/extensions",
+                      "location": "[parameters('location')]",
+                      "apiVersion": "2018-06-01",
+                      "properties": {
+                        "publisher": "[variables('vmExtensionPublisher')]",
+                        "type": "[variables('vmExtensionType')]",
+                        "typeHandlerVersion": "[variables('vmExtensionTypeHandlerVersion')]",
+                        "autoUpgradeMinorVersion": true,
+                        "settings": {
+                          "workspaceId": "[reference(parameters('logAnalytics'), '2015-03-20').customerId]",
+                          "stopOnMultipleConnections": "true"
+                        },
+                        "protectedSettings": {
+                          "workspaceKey": "[listKeys(parameters('logAnalytics'), '2015-03-20').primarySharedKey]"
+                        }
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "policy": {
+                      "type": "string",
+                      "value": "[concat('Enabled extension for VM', ': ', parameters('vmName'))]"
+                    }
+                  }
+                },
+                "parameters": {
+                  "vmName": {
+                    "value": "[field('name')]"
+                  },
+                  "location": {
+                    "value": "[field('location')]"
+                  },
+                  "logAnalytics": {
+                    "value": "[parameters('logAnalytics')]"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid ifNotExists existenceCondition",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "auditIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "existenceCondition": {
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid ifNotExists existenceScope",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "auditIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "existenceScope": "foo"
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid ifNotExists deploymentScope",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "auditIfNotExists",
+          "details": {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "deploymentScope": "foo"
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - missing append details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "tags",
+          "containsKey": "westus"
+        },
+        "then": {
+          "effect": "append",
+          "details": []
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid effect",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/effect",
+          "schemaPath": "/properties/then/properties/effect/oneOf",
+          "subErrors": [
+            {
+              "message": "No enum match for: \"foo\"",
+              "dataPath": "/then/effect",
+              "schemaPath": "/properties/then/properties/effect/oneOf/0/type",
+              "subErrors": []
+            },
+            {
+              "message": "String does not match pattern: ^\\[([^\\[].*)?\\]$",
+              "dataPath": "/then/effect",
+              "schemaPath": "/properties/then/properties/effect/oneOf/1/pattern",
+              "subErrors": []
+            }
+          ]
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "location",
+          "equals": "westus"
+        },
+        "then": {
+          "effect": "foo"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid field property",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/if"
+        }
+      ],
+      "json": {
+        "if": {
+          "field2": "location",
+          "equals": "westus"
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid operator",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/if"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "location",
+          "notEqualTo": "westus"
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - array for non-array operator",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/if"
+        }
+      ],
+      "json": {
+        "if": {
+          "field": "location",
+          "equals": [ "foo" ]
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - string for array operator",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "location",
+          "notIn": "[parameters('foo')]"
+        },
+        "then": {
+          "effect": "deny"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - minimal modify details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "notContainsKey": "westus"
+        },
+        "then": {
+          "effect": "modify",
+          "details": {
+            "roleDefinitionIds": [
+              "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+            ],
+            "operations": [
+              { "field": "tags.westus", "value": "present", "operation": "add" }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid modify details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "notContainsKey": "westus"
+        },
+        "then": {
+          "effect": "modify",
+          "details": {
+            "operations": [ 
+              { "field": "tags.westus", "value": "present", "operation": "foo" } 
+            ]
+          }
+        }
+      },
+      "expectedErrors": [
+        {
+          "dataPath": "/then/details",
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "schemaPath": "/properties/then/properties/details/oneOf",
+          "subErrors": [
+            {
+              "dataPath": "/then/details",
+              "message": "Missing required property: type",
+              "schemaPath": "/properties/then/properties/details/oneOf/0/required/0",
+              "subErrors": []
+            },
+            {
+              "dataPath": "/then/details/operations",
+              "message": "Additional properties not allowed",
+              "schemaPath": "/properties/then/properties/details/oneOf/0/additionalProperties",
+              "subErrors": []
+            },
+            {
+              "dataPath": "/then/details",
+              "message": "Invalid type: object (expected array)",
+              "schemaPath": "/properties/then/properties/details/oneOf/1/type",
+              "subErrors": []
+            },
+            {
+              "dataPath": "/then/details",
+              "message": "Missing required property: roleDefinitionIds",
+              "schemaPath": "/properties/then/properties/details/oneOf/2/required/0",
+              "subErrors": []
+            },
+            {
+              "dataPath": "/then/details/operations/0/operation",
+              "message": "No enum match for: \"foo\"",
+              "schemaPath": "/properties/then/properties/details/oneOf/2/properties/operations/items/properties/operation/type",
+              "subErrors": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "PolicyDefinition tests - complex modify details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "tags",
+          "notContainsKey": "westus"
+        },
+        "then": {
+          "effect": "modify",
+          "details": {
+            "conflictEffect": "audit",
+            "roleDefinitionIds": [
+              "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+              "/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+            ],
+            "operations": [
+              { "field": "tags.westus", "value": "present", "operation": "add" },
+              { "field": "tags.tagOne", "value": "present", "operation": "add", "condition": "[greater(requestContext().apiVersion, '2019-01-01')]" },
+              { "field": "tags.tagTwo", "operation": "remove" },
+              { "field": "[concat('tags.', parameters('tagName'))]", "value": "[parameters('tagValue')]", "operation": "addOrReplace" }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - valid manual details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "type",
+          "equals": "Microsoft.Resources/subscriptions"
+        },
+        "then": {
+          "effect": "manual",
+          "details": {
+            "defaultState": "NonCompliant"
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - no manual details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "type",
+          "equals": "Microsoft.Resources/subscriptions"
+        },
+        "then": {
+          "effect": "manual"
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - empty manual details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "type",
+          "equals": "Microsoft.Resources/subscriptions"
+        },
+        "then": {
+          "effect": "manual",
+          "details": {}
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - parameterized manual details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "type",
+          "equals": "Microsoft.Resources/subscriptions"
+        },
+        "then": {
+          "effect": "manual",
+          "details": {
+            "defaultState": "[parameters('defaultState')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "PolicyDefinition tests - invalid manual details",
+      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "json": {
+        "if": {
+          "field": "type",
+          "equals": "Microsoft.Resources/subscriptions"
+        },
+        "then": {
+          "effect": "manual",
+          "details": {
+            "defaultState": "Conflict"
+          }
+        }
+      },
+      "expectedErrors": [
+        {
+          "message": "Data does not match any schemas from \"oneOf\"",
+          "dataPath": "/then/details",
+          "schemaPath": "/properties/then/properties/details/oneOf",
+          "subErrors": [
+            {
+              "message": "Missing required property: type",
+              "dataPath": "/then/details",
+              "schemaPath": "/properties/then/properties/details/oneOf/0/required/0",
+              "subErrors": []
+            },
+            {
+              "message": "Additional properties not allowed",
+              "dataPath": "/then/details/defaultState",
+              "schemaPath": "/properties/then/properties/details/oneOf/0/additionalProperties",
+              "subErrors": []
+            },
+            {
+              "message": "Invalid type: object (expected array)",
+              "dataPath": "/then/details",
+              "schemaPath": "/properties/then/properties/details/oneOf/1/type",
+              "subErrors": []
+            },
+            {
+              "message": "Missing required property: roleDefinitionIds",
+              "dataPath": "/then/details",
+              "schemaPath": "/properties/then/properties/details/oneOf/2/required/0",
+              "subErrors": []
+            },
+            {
+              "message": "Missing required property: operations",
+              "dataPath": "/then/details",
+              "schemaPath": "/properties/then/properties/details/oneOf/2/required/1",
+              "subErrors": []
+            },
+            {
+              "message": "Additional properties not allowed",
+              "dataPath": "/then/details/defaultState",
+              "schemaPath": "/properties/then/properties/details/oneOf/2/additionalProperties",
+              "subErrors": []
+            },
+            {
+              "message": "Data does not match any schemas from \"oneOf\"",
+              "dataPath": "/then/details/defaultState",
+              "schemaPath": "/properties/then/properties/details/oneOf/3/properties/defaultState/oneOf",
+              "subErrors": [
+                {
+                  "message": "No enum match for: \"Conflict\"",
+                  "dataPath": "/then/details/defaultState",
+                  "schemaPath": "/properties/then/properties/details/oneOf/3/properties/defaultState/oneOf/0/type",
+                  "subErrors": []
+                },
+                {
+                  "message": "String does not match pattern: ^\\[([^\\[].*)?\\]$",
+                  "dataPath": "/then/details/defaultState",
+                  "schemaPath": "/properties/then/properties/details/oneOf/3/properties/defaultState/oneOf/1/pattern",
+                  "subErrors": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/2020-10-01/policyDefinition.tests.json
+++ b/tests/2020-10-01/policyDefinition.tests.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "name": "PolicyDefinition tests - valid minimal rule",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "location",
@@ -15,7 +15,7 @@
     },
     {
       "name": "PolicyDefinition tests - valid complex rule",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "json": {
         "if": {
           "not": {
@@ -58,7 +58,7 @@
     },
     {
       "name": "PolicyDefinition tests - valid complex field count condition",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "json": {
         "if": {
             "allOf": [
@@ -95,7 +95,7 @@
     },
     {
       "name": "PolicyDefinition tests - valid value count conditions",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "json": {
         "if": {
           "allOf": [
@@ -156,7 +156,7 @@
     },
     {
       "name": "PolicyDefinition tests - valid append details",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "tags",
@@ -179,7 +179,7 @@
     },
     {
       "name": "PolicyDefinition tests - minimal ifNotExists details",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "tags",
@@ -195,7 +195,7 @@
     },
     {
       "name": "PolicyDefinition tests - complex ifNotExists details",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "tags",
@@ -207,6 +207,7 @@
             "type": "Microsoft.Compute/virtualMachines/extensions",
             "resourceGroupName": "myRG",
             "name": "myResource",
+            "evaluationDelay": "AfterProvisioning",
             "existenceCondition": {
               "not": {
                 "field": "location",
@@ -235,7 +236,7 @@
     },
     {
       "name": "PolicyDefinition tests - invalid deployIfNotExists deployment template",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "expectedErrors": [
         {
           "message": "Data does not match any schemas from \"oneOf\"",
@@ -277,7 +278,7 @@
     },
     {
       "name": "PolicyDefinition tests - complex deployIfNotExists deployment",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "json": {
         "if": {
           "allOf": [
@@ -519,7 +520,7 @@
     },
     {
       "name": "PolicyDefinition tests - invalid ifNotExists existenceCondition",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "expectedErrors": [
         {
           "message": "Data does not match any schemas from \"oneOf\"",
@@ -543,7 +544,7 @@
     },
     {
       "name": "PolicyDefinition tests - invalid ifNotExists existenceScope",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "expectedErrors": [
         {
           "message": "Data does not match any schemas from \"oneOf\"",
@@ -566,7 +567,7 @@
     },
     {
       "name": "PolicyDefinition tests - invalid ifNotExists deploymentScope",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "expectedErrors": [
         {
           "message": "Data does not match any schemas from \"oneOf\"",
@@ -589,7 +590,7 @@
     },
     {
       "name": "PolicyDefinition tests - missing append details",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "expectedErrors": [
         {
           "message": "Data does not match any schemas from \"oneOf\"",
@@ -609,7 +610,7 @@
     },
     {
       "name": "PolicyDefinition tests - invalid effect",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "expectedErrors": [
         {
           "message": "Data does not match any schemas from \"oneOf\"",
@@ -643,7 +644,7 @@
     },
     {
       "name": "PolicyDefinition tests - invalid field property",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "expectedErrors": [
         {
           "message": "Data does not match any schemas from \"oneOf\"",
@@ -662,7 +663,7 @@
     },
     {
       "name": "PolicyDefinition tests - invalid operator",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "expectedErrors": [
         {
           "message": "Data does not match any schemas from \"oneOf\"",
@@ -681,7 +682,7 @@
     },
     {
       "name": "PolicyDefinition tests - array for non-array operator",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "expectedErrors": [
         {
           "message": "Data does not match any schemas from \"oneOf\"",
@@ -700,7 +701,7 @@
     },
     {
       "name": "PolicyDefinition tests - string for array operator",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "location",
@@ -713,7 +714,7 @@
     },
     {
       "name": "PolicyDefinition tests - minimal modify details",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "tags",
@@ -734,7 +735,7 @@
     },
     {
       "name": "PolicyDefinition tests - invalid modify details",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "tags",
@@ -791,7 +792,7 @@
     },
     {
       "name": "PolicyDefinition tests - complex modify details",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "tags",
@@ -817,7 +818,7 @@
     },
     {
       "name": "PolicyDefinition tests - valid manual details",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "type",
@@ -833,7 +834,7 @@
     },
     {
       "name": "PolicyDefinition tests - no manual details",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "type",
@@ -846,7 +847,7 @@
     },
     {
       "name": "PolicyDefinition tests - empty manual details",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "type",
@@ -860,7 +861,7 @@
     },
     {
       "name": "PolicyDefinition tests - parameterized manual details",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "type",
@@ -876,7 +877,7 @@
     },
     {
       "name": "PolicyDefinition tests - invalid manual details",
-      "definition": "https://schema.management.azure.com/schemas/2020-09-01/policyDefinition.json#",
+      "definition": "https://schema.management.azure.com/schemas/2020-10-01/policyDefinition.json#",
       "json": {
         "if": {
           "field": "type",

--- a/tools/tests.ts
+++ b/tools/tests.ts
@@ -122,6 +122,7 @@ const schemasToSkip = [
   '2019-06-01/policyDefinition.json',
   '2019-09-01/policyDefinition.json',
   '2020-09-01/policyDefinition.json',
+  '2020-10-01/policyDefinition.json',
   '2018-05-01/subscriptionDeploymentParameters.json',
   '2018-05-01/subscriptionDeploymentTemplate.json',
   '2019-04-01/deploymentParameters.json',


### PR DESCRIPTION
ifNotExists policy rules now support a configurable evaluation delay. It can't be a string enum (without a bunch of crazy logic) because it can either be a few set values ("AfterProvisioning[Success|Failure]") or an ISO duration (i.e. "PT2H").

1st iteration copied existing versions to new paths, 2nd+ iterations have changes.