### PR TITLE
new schema version for Microsoft.Logz (logz/resource-manager)

### DIFF
--- a/schemas/2020-10-01/Microsoft.Logz.json
+++ b/schemas/2020-10-01/Microsoft.Logz.json
@@ -1,0 +1,915 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Logz.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Logz",
+  "description": "Microsoft Logz Resource Types",
+  "resourceDefinitions": {
+    "monitors": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-10-01"
+          ]
+        },
+        "identity": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/IdentityProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "location": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "description": "Monitor resource name"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitorProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties specific to the monitor resource."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/monitors_tagRules_childResource"
+              },
+              {
+                "$ref": "#/definitions/monitors_singleSignOnConfigurations_childResource"
+              },
+              {
+                "$ref": "#/definitions/monitors_accounts_childResource"
+              }
+            ]
+          }
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Logz/monitors"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Logz/monitors"
+    },
+    "monitors_accounts": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-10-01"
+          ]
+        },
+        "identity": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/IdentityProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "location": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "description": "Sub Account resource name"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitorProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties specific to the monitor resource."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/monitors_accounts_tagRules_childResource"
+              }
+            ]
+          }
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Logz/monitors/accounts"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Logz/monitors/accounts"
+    },
+    "monitors_accounts_tagRules": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-10-01"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitoringTagRulesProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Definition of the properties for a TagRules resource."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Logz/monitors/accounts/tagRules"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Logz/monitors/accounts/tagRules"
+    },
+    "monitors_singleSignOnConfigurations": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-10-01"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/LogzSingleSignOnProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "systemData": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SystemData"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Metadata pertaining to creation and last modification of the resource."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Logz/monitors/singleSignOnConfigurations"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Logz/monitors/singleSignOnConfigurations"
+    },
+    "monitors_tagRules": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-10-01"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitoringTagRulesProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Definition of the properties for a TagRules resource."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Logz/monitors/tagRules"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Logz/monitors/tagRules"
+    }
+  },
+  "definitions": {
+    "FilteringTag": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Include",
+                "Exclude"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name (also known as the key) of the tag."
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the tag."
+        }
+      },
+      "description": "The definition of a filtering tag. Filtering tags are used for capturing resources and include/exclude them from being monitored."
+    },
+    "IdentityProperties": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "SystemAssigned",
+                "UserAssigned"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      }
+    },
+    "LogRules": {
+      "type": "object",
+      "properties": {
+        "filteringTags": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FilteringTag"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of filtering tags to be used for capturing logs. This only takes effect if SendActivityLogs flag is enabled. If empty, all resources will be captured. If only Exclude action is specified, the rules will apply to the list of all available resources. If Include actions are specified, the rules will only include resources with the associated tags."
+        },
+        "sendAadLogs": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag specifying if AAD logs should be sent for the Monitor resource."
+        },
+        "sendActivityLogs": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag specifying if activity logs from Azure resources should be sent for the Monitor resource."
+        },
+        "sendSubscriptionLogs": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag specifying if subscription logs should be sent for the Monitor resource."
+        }
+      },
+      "description": "Set of rules for sending logs for the Monitor resource."
+    },
+    "LogzOrganizationProperties": {
+      "type": "object",
+      "properties": {
+        "companyName": {
+          "type": "string",
+          "description": "Name of the Logz organization."
+        },
+        "enterpriseAppId": {
+          "type": "string",
+          "description": "The Id of the Enterprise App used for Single sign on."
+        },
+        "singleSignOnUrl": {
+          "type": "string",
+          "description": "The login URL specific to this Logz Organization."
+        }
+      }
+    },
+    "LogzSingleSignOnProperties": {
+      "type": "object",
+      "properties": {
+        "enterpriseAppId": {
+          "type": "string",
+          "description": "The Id of the Enterprise App used for Single sign-on."
+        },
+        "provisioningState": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Accepted",
+                "Creating",
+                "Updating",
+                "Deleting",
+                "Succeeded",
+                "Failed",
+                "Canceled",
+                "Deleted",
+                "NotSpecified"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "singleSignOnState": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Initial",
+                "Enable",
+                "Disable",
+                "Existing"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "singleSignOnUrl": {
+          "type": "string",
+          "description": "The login URL specific to this Logz Organization."
+        }
+      }
+    },
+    "MonitoringTagRulesProperties": {
+      "type": "object",
+      "properties": {
+        "logRules": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/LogRules"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Set of rules for sending logs for the Monitor resource."
+        },
+        "provisioningState": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Accepted",
+                "Creating",
+                "Updating",
+                "Deleting",
+                "Succeeded",
+                "Failed",
+                "Canceled",
+                "Deleted",
+                "NotSpecified"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "systemData": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SystemData"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Metadata pertaining to creation and last modification of the resource."
+        }
+      },
+      "description": "Definition of the properties for a TagRules resource."
+    },
+    "MonitorProperties": {
+      "type": "object",
+      "properties": {
+        "liftrResourceCategory": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Unknown",
+                "MonitorLogs"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "logzOrganizationProperties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/LogzOrganizationProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "marketplaceSubscriptionStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Active",
+                "Suspended"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "monitoringStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "planData": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PlanData"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "provisioningState": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Accepted",
+                "Creating",
+                "Updating",
+                "Deleting",
+                "Succeeded",
+                "Failed",
+                "Canceled",
+                "Deleted",
+                "NotSpecified"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "userInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UserInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "description": "Properties specific to the monitor resource."
+    },
+    "monitors_accounts_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-10-01"
+          ]
+        },
+        "identity": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/IdentityProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "location": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "description": "Sub Account resource name"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitorProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties specific to the monitor resource."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "accounts"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Logz/monitors/accounts"
+    },
+    "monitors_accounts_tagRules_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-10-01"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitoringTagRulesProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Definition of the properties for a TagRules resource."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "tagRules"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Logz/monitors/accounts/tagRules"
+    },
+    "monitors_singleSignOnConfigurations_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-10-01"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/LogzSingleSignOnProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "systemData": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SystemData"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Metadata pertaining to creation and last modification of the resource."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "singleSignOnConfigurations"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Logz/monitors/singleSignOnConfigurations"
+    },
+    "monitors_tagRules_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-10-01"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitoringTagRulesProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Definition of the properties for a TagRules resource."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "tagRules"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Logz/monitors/tagRules"
+    },
+    "PlanData": {
+      "type": "object",
+      "properties": {
+        "billingCycle": {
+          "type": "string",
+          "maxLength": 50,
+          "description": "different billing cycles like MONTHLY/WEEKLY. this could be enum"
+        },
+        "effectiveDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "date when plan was applied"
+        },
+        "planDetails": {
+          "type": "string",
+          "maxLength": 50,
+          "description": "plan id as published by Logz"
+        },
+        "usageType": {
+          "type": "string",
+          "maxLength": 50,
+          "description": "different usage type like PAYG/COMMITTED. this could be enum"
+        }
+      }
+    },
+    "SystemData": {
+      "type": "object",
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp of resource creation (UTC)."
+        },
+        "createdBy": {
+          "type": "string",
+          "description": "The identity that created the resource."
+        },
+        "createdByType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "User",
+                "Application",
+                "ManagedIdentity",
+                "Key"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of identity that created the resource."
+        },
+        "lastModifiedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp of resource last modification (UTC)"
+        },
+        "lastModifiedBy": {
+          "type": "string",
+          "description": "The identity that last modified the resource."
+        },
+        "lastModifiedByType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "User",
+                "Application",
+                "ManagedIdentity",
+                "Key"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of identity that last modified the resource."
+        }
+      },
+      "description": "Metadata pertaining to creation and last modification of the resource."
+    },
+    "UserInfo": {
+      "type": "object",
+      "properties": {
+        "emailAddress": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9._%+-]+@(?:[A-Za-z0-9-]+\\.)+[A-Za-z]{2,}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Email of the user used by Logz for contacting them if needed"
+        },
+        "firstName": {
+          "type": "string",
+          "maxLength": 50,
+          "description": "First Name of the user"
+        },
+        "lastName": {
+          "type": "string",
+          "maxLength": 50,
+          "description": "Last Name of the user"
+        },
+        "phoneNumber": {
+          "type": "string",
+          "maxLength": 40,
+          "description": "Phone number of the user used by Logz for contacting them if needed"
+        }
+      }
+    }
+  }
+}

--- a/schemas/common/autogeneratedResources.json
+++ b/schemas/common/autogeneratedResources.json
@@ -6560,6 +6560,21 @@
           "$ref": "https://schema.management.azure.com/schemas/2018-10-15/Microsoft.LabServices.json#/resourceDefinitions/labaccounts_labs_users"
         },
         {
+          "$ref": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Logz.json#/resourceDefinitions/monitors"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Logz.json#/resourceDefinitions/monitors_accounts"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Logz.json#/resourceDefinitions/monitors_accounts_tagRules"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Logz.json#/resourceDefinitions/monitors_singleSignOnConfigurations"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Logz.json#/resourceDefinitions/monitors_tagRules"
+        },
+        {
           "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Logz.json#/resourceDefinitions/monitors"
         },
         {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/82204807/130017079-40d596da-8ad6-40b0-9e65-064cf14bd17b.png)

The output of npm run generate-single logz/resource-manager

```
npm WARN lifecycle The node binary used for scripts is C:\Program Files (x86)\Nodist\bin\node.exe but npm is using C:\Program Files (x86)\Nodist\v-x64\11.13.0\node.exe itself. Use the --scripts-prepend-node-path option to include the path for the node binary npm was executed with.

> azure-schema-generator@1.0.0 generate-single D:\VSO\azure-resource-manager-schemas\generator
> ts-node cmd/generatesingle "logz/resource-manager"

[C:\Users\SAURGU~1\AppData\Local\Temp\schm_azspc] executing: git fsck
[C:\Users\SAURGU~1\AppData\Local\Temp\schm_azspc] executing: git reset -q .
[C:\Users\SAURGU~1\AppData\Local\Temp\schm_azspc] executing: git checkout -q -- .
[C:\Users\SAURGU~1\AppData\Local\Temp\schm_azspc] executing: git clean -q -fd
[C:\Users\SAURGU~1\AppData\Local\Temp\schm_azspc] executing: git gc
[C:\Users\SAURGU~1\AppData\Local\Temp\schm_azspc] executing: git fetch -q
[C:\Users\SAURGU~1\AppData\Local\Temp\schm_azspc] executing: git checkout -q origin/main
Using autogenlist config:
{
  "basePath": "logz/resource-manager",
  "namespace": "Microsoft.Logz"
}
[D:\VSO\azure-resource-manager-schemas\generator] executing: D:\VSO\azure-resource-manager-schemas\generator/node_modules/.bin/autorest.cmd --version=3.0.6374 --use=@autorest/azureresourceschema@3.0.92 --azureresourceschema --output-folder=C:\Users\SAURGU~1\AppData\Local\Temp\4hp6mimha4l --multiapi --pass-thru:
```