### PR TITLE
Added missing arg in npm command

### DIFF
--- a/generator/package-lock.json
+++ b/generator/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-schema-generator",
+  "name": "template-schema-generator",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
GH action failed because output-path was not recognized, this is because '--' was missing as part of the command.