### PR TITLE
GH actions single schema gen fix

### DIFF
--- a/.github/workflows/generate-types.yml
+++ b/.github/workflows/generate-types.yml
@@ -37,7 +37,7 @@ jobs:
           then
             npm run generate-all -- --local-path "$GITHUB_WORKSPACE/workflow-temp/azure-rest-api-specs"
           else
-            npm run generate-single -- --base-path '${{ github.event.inputs.single_path }}/resource-manager' --output-path '$GITHUB_WORKSPACE/workflow-temp/azure-rest-api-specs'
+            npm run generate-single -- --base-path '${{ github.event.inputs.single_path }}/resource-manager' -- --output-path '$GITHUB_WORKSPACE/workflow-temp/azure-rest-api-specs'
           fi
         working-directory: generator
 


### PR DESCRIPTION
GH actions complained about 'output-path' not being recognized, it was due a missing '--' as part of the npm cmd.