### PR TITLE
bypass swagger schema validation

### DIFF
--- a/generator/generate.ts
+++ b/generator/generate.ts
@@ -118,6 +118,7 @@ async function generateSchema(readme: string, tmpFolder: string) {
         `--output-folder=${tmpFolder}`,
         '--multiapi',
         '--pass-thru:subset-reducer',
+        '--pass-thru:schema-validator-swagger',
         readme,
     ];
 


### PR DESCRIPTION
The autorest version used in schema generation doesn't allow unknown swagger extension, while upgrading autorest version introduces many issues. So creating the pr to bypass swagger validation in autorest as a workaround.