### PR TITLE
Fixes https://github.com/Azure/azure-sdk-for-net/issues/23429

### DIFF
--- a/schemas/2021-11-01/Microsoft.Compute.json
+++ b/schemas/2021-11-01/Microsoft.Compute.json
@@ -2674,7 +2674,7 @@
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
             }
           ],
-          "description": "Specifies the mode of VM Guest Patch Assessment for the IaaS virtual machine.<br /><br /> Possible values are:<br /><br /> **ImageDefault** - You control the timing of patch assessments on a virtual machine. <br /><br /> **AutomaticByPlatform** - The platform will trigger periodic patch assessments. The property provisionVMAgent must be true."
+          "description": "Specifies the mode of VM Guest Patch Assessment for the IaaS virtual machine.<br><br> Possible values are:<br><br> **ImageDefault** - You control the timing of patch assessments on a virtual machine. <br><br> **AutomaticByPlatform** - The platform will trigger periodic patch assessments. The property provisionVMAgent must be true."
         },
         "patchMode": {
           "oneOf": [
@@ -2689,7 +2689,7 @@
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
             }
           ],
-          "description": "Specifies the mode of VM Guest Patching to IaaS virtual machine or virtual machines associated to virtual machine scale set with OrchestrationMode as Flexible.<br /><br /> Possible values are:<br /><br /> **ImageDefault** - The virtual machine's default patching configuration is used. <br /><br /> **AutomaticByPlatform** - The virtual machine will be automatically updated by the platform. The property provisionVMAgent must be true."
+          "description": "Specifies the mode of VM Guest Patching to IaaS virtual machine or virtual machines associated to virtual machine scale set with OrchestrationMode as Flexible.<br><br> Possible values are:<br><br> **ImageDefault** - The virtual machine's default patching configuration is used. <br><br> **AutomaticByPlatform** - The virtual machine will be automatically updated by the platform. The property provisionVMAgent must be true."
         }
       },
       "description": "Specifies settings related to VM Guest Patching on Linux."
@@ -3094,7 +3094,7 @@
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
             }
           ],
-          "description": "Specifies the mode of VM Guest patch assessment for the IaaS virtual machine.<br /><br /> Possible values are:<br /><br /> **ImageDefault** - You control the timing of patch assessments on a virtual machine.<br /><br /> **AutomaticByPlatform** - The platform will trigger periodic patch assessments. The property provisionVMAgent must be true."
+          "description": "Specifies the mode of VM Guest patch assessment for the IaaS virtual machine.<br><br> Possible values are:<br><br> **ImageDefault** - You control the timing of patch assessments on a virtual machine.<br><br> **AutomaticByPlatform** - The platform will trigger periodic patch assessments. The property provisionVMAgent must be true."
         },
         "enableHotpatching": {
           "oneOf": [
@@ -3121,7 +3121,7 @@
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
             }
           ],
-          "description": "Specifies the mode of VM Guest Patching to IaaS virtual machine or virtual machines associated to virtual machine scale set with OrchestrationMode as Flexible.<br /><br /> Possible values are:<br /><br /> **Manual** - You  control the application of patches to a virtual machine. You do this by applying patches manually inside the VM. In this mode, automatic updates are disabled; the property WindowsConfiguration.enableAutomaticUpdates must be false<br /><br /> **AutomaticByOS** - The virtual machine will automatically be updated by the OS. The property WindowsConfiguration.enableAutomaticUpdates must be true. <br /><br /> **AutomaticByPlatform** - the virtual machine will automatically updated by the platform. The properties provisionVMAgent and WindowsConfiguration.enableAutomaticUpdates must be true."
+          "description": "Specifies the mode of VM Guest Patching to IaaS virtual machine or virtual machines associated to virtual machine scale set with OrchestrationMode as Flexible.<br><br> Possible values are:<br><br> **Manual** - You  control the application of patches to a virtual machine. You do this by applying patches manually inside the VM. In this mode, automatic updates are disabled; the property WindowsConfiguration.enableAutomaticUpdates must be false<br><br> **AutomaticByOS** - The virtual machine will automatically be updated by the OS. The property WindowsConfiguration.enableAutomaticUpdates must be true. <br><br> **AutomaticByPlatform** - the virtual machine will automatically updated by the platform. The properties provisionVMAgent and WindowsConfiguration.enableAutomaticUpdates must be true."
         }
       },
       "description": "Specifies settings related to VM Guest Patching on Windows."
@@ -3521,7 +3521,7 @@
         },
         "tier": {
           "type": "string",
-          "description": "Specifies the tier of virtual machines in a scale set.<br /><br /> Possible Values:<br /><br /> **Standard**<br /><br /> **Basic**"
+          "description": "Specifies the tier of virtual machines in a scale set.<br><br> Possible Values:<br><br> **Standard**<br><br> **Basic**"
         }
       },
       "description": "Describes a virtual machine scale set sku. NOTE: If the new VM SKU is not supported on the hardware the scale set is currently on, you need to deallocate the VMs in the scale set before you modify the SKU name."
@@ -3718,7 +3718,7 @@
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
             }
           ],
-          "description": "Specifies the mode of an upgrade to virtual machines in the scale set.<br /><br /> Possible values are:<br /><br /> **Manual** - You  control the application of updates to virtual machines in the scale set. You do this by using the manualUpgrade action.<br /><br /> **Automatic** - All virtual machines in the scale set are  automatically updated at the same time."
+          "description": "Specifies the mode of an upgrade to virtual machines in the scale set.<br><br> Possible values are:<br><br> **Manual** - You  control the application of updates to virtual machines in the scale set. You do this by using the manualUpgrade action.<br><br> **Automatic** - All virtual machines in the scale set are  automatically updated at the same time."
         },
         "rollingUpgradePolicy": {
           "oneOf": [


### PR DESCRIPTION
`<br />` is causing unintelligent texts 
Gets or sets specifies the mode of VM Guest Patch Assessment for the IaaS virtual machine**.&lt;br /&gt;&lt;br /&gt;** 
eg., https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.compute.models.linuxpatchsettings?view=azure-dotnet