### PR TITLE
[CI] Edit bot username (GH action)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
     needs: schema-tests
     env:
       PR_PREFIX: sdkAuto/
-    if: ${{ github.event.pull_request.user.login == 'azure-sdk[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'azure-sdk' }}
     steps:
       - uses: actions/checkout@v2.3.5
 


### PR DESCRIPTION
Edit bot username, noticed that our CI was skipping the task where username is: 'azure-sdk[bot]' removed [bot] from username to enable task check.