### PR TITLE
TitleDataSet onboarding for new version 2022-04-12-preview

### DIFF
--- a/schemas/2019-04-01/deploymentTemplate.json
+++ b/schemas/2019-04-01/deploymentTemplate.json
@@ -1861,7 +1861,12 @@
                 { "$ref": "https://schema.management.azure.com/schemas/2022-03-02-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles" },
                 { "$ref": "https://schema.management.azure.com/schemas/2022-03-02-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles_segments" },
                 { "$ref": "https://schema.management.azure.com/schemas/2022-03-02-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles_titledatakeyvalues" },
-                { "$ref": "https://schema.management.azure.com/schemas/2022-03-02-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles_titleinternaldatakeyvalues" }
+                { "$ref": "https://schema.management.azure.com/schemas/2022-03-02-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles_titleinternaldatakeyvalues" },
+                { "$ref": "https://schema.management.azure.com/schemas/2022-04-12-preview/Microsoft.PlayFab.json#/resourceDefinitions/playerAccountPools" },
+                { "$ref": "https://schema.management.azure.com/schemas/2022-04-12-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles" },
+                { "$ref": "https://schema.management.azure.com/schemas/2022-04-12-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles_segments" },
+                { "$ref": "https://schema.management.azure.com/schemas/2022-04-12-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles_titledatasets" },
+                { "$ref": "https://schema.management.azure.com/schemas/2022-04-12-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles_titleinternaldatasets" }
               ]
             }
           ]

--- a/schemas/2022-04-12-preview/Microsoft.PlayFab.json
+++ b/schemas/2022-04-12-preview/Microsoft.PlayFab.json
@@ -1,0 +1,1073 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2022-04-12-preview/Microsoft.PlayFab.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.PlayFab",
+  "description": "Microsoft PlayFab Resource Types",
+  "resourceDefinitions": {
+    "playerAccountPools": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2022-04-12-preview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives"
+        },
+        "name": {
+          "type": "string",
+          "description": "PlayerAccountPool resource name"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PlayerAccountPoolProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of PlayAccountPool"
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.PlayFab/playerAccountPools"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.PlayFab/playerAccountPools"
+    },
+    "titles": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2022-04-12-preview"
+          ]
+        },
+        "identity": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AzureARMManagedSystemIdentityProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of the service-assigned identity associated with this resource/"
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the Title Parameter."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TitleProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of Title Resource"
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/titles_segments_childResource"
+              },
+              {
+                "$ref": "#/definitions/titles_titledatasets_childResource"
+              },
+              {
+                "$ref": "#/definitions/titles_titleinternaldatasets_childResource"
+              }
+            ]
+          }
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.PlayFab/titles"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.PlayFab/titles"
+    },
+    "titles_segments": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2022-04-12-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the Segment Parameter."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SegmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of Segment Resource"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.PlayFab/titles/segments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.PlayFab/titles/segments"
+    },
+    "titles_titledatasets": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2022-04-12-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the TitleDataSet Parameter."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TitleDataSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of TitleDataSet Resource"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.PlayFab/titles/titledatasets"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.PlayFab/titles/titledatasets"
+    },
+    "titles_titleinternaldatasets": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2022-04-12-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the TitleInternalDataSet Parameter."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TitleInternalDataSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of TitleInternalDataSet Resource"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.PlayFab/titles/titleinternaldatasets"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.PlayFab/titles/titleinternaldatasets"
+    }
+  },
+  "definitions": {
+    "ApiSettings": {
+      "type": "object",
+      "properties": {
+        "allowClientsToUpdatePlayerStatistics": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Setting to enable API allowing client to update user statistics."
+        }
+      },
+      "description": "Title API Settings"
+    },
+    "AzureARMManagedSystemIdentityProperties": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "None",
+                "SystemAssigned"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of managed identity assigned to this resource."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "description": "The properties of the service-assigned identity associated with this resource/"
+    },
+    "GeneralSettings": {
+      "type": "object",
+      "properties": {
+        "allowNonUniquePlayerDisplayNames": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Setting to allow non unique player display name."
+        },
+        "displayNameRandomSuffixLength": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Setting to enable addition of random suffix to player display name and specify it's length"
+        }
+      },
+      "description": "General Title Settings"
+    },
+    "KeyValuePair": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "Key of KeyValuePair."
+        },
+        "value": {
+          "type": "string",
+          "description": "Value of KeyValuePair."
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ],
+      "description": "KeyValuePair object"
+    },
+    "PlayerAccountPoolProperties": {
+      "type": "object",
+      "properties": {},
+      "description": "Properties of PlayAccountPool"
+    },
+    "SegmentAllPlayersFilter": {
+      "type": "object",
+      "properties": {
+        "filterName": {
+          "type": "string",
+          "enum": [
+            "AllPlayers"
+          ]
+        }
+      },
+      "required": [
+        "filterName"
+      ],
+      "description": "Details about Segment AllPlayers Filter"
+    },
+    "SegmentFilter": {
+      "type": "object",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/SegmentAllPlayersFilter"
+        },
+        {
+          "$ref": "#/definitions/SegmentFirstLoginDateFilter"
+        },
+        {
+          "$ref": "#/definitions/SegmentFirstLoginFilter"
+        },
+        {
+          "$ref": "#/definitions/SegmentLastLoginDateFilter"
+        },
+        {
+          "$ref": "#/definitions/SegmentLastLoginFilter"
+        },
+        {
+          "$ref": "#/definitions/SegmentLocationFilter"
+        },
+        {
+          "$ref": "#/definitions/SegmentStatisticFilter"
+        },
+        {
+          "$ref": "#/definitions/SegmentTagFilter"
+        },
+        {
+          "$ref": "#/definitions/SegmentUserOriginationFilter"
+        }
+      ],
+      "properties": {},
+      "description": "Details about Segment Filter"
+    },
+    "SegmentFirstLoginDateFilter": {
+      "type": "object",
+      "properties": {
+        "comparison": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Greater",
+                "Less",
+                "Equals",
+                "NotEquals",
+                "GreaterOrEquals",
+                "LessOrEquals",
+                "Contains",
+                "NotContains",
+                "Ignore",
+                "Exists"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Comparator used for the filter."
+        },
+        "filterName": {
+          "type": "string",
+          "enum": [
+            "FirstLoginDate"
+          ]
+        },
+        "value": {
+          "type": "string",
+          "description": "Value to be compared"
+        }
+      },
+      "required": [
+        "comparison",
+        "filterName",
+        "value"
+      ],
+      "description": "Details about Segment FirstLoginDate Filter"
+    },
+    "SegmentFirstLoginFilter": {
+      "type": "object",
+      "properties": {
+        "comparison": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Greater",
+                "Less",
+                "Equals",
+                "NotEquals",
+                "GreaterOrEquals",
+                "LessOrEquals",
+                "Contains",
+                "NotContains",
+                "Ignore",
+                "Exists"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Comparator used for the filter."
+        },
+        "filterName": {
+          "type": "string",
+          "enum": [
+            "FirstLogin"
+          ]
+        },
+        "value": {
+          "type": "string",
+          "description": "Value to be compared"
+        }
+      },
+      "required": [
+        "comparison",
+        "filterName",
+        "value"
+      ],
+      "description": "Details about Segment FirstLogin Filter"
+    },
+    "SegmentGroup": {
+      "type": "object",
+      "properties": {
+        "filters": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SegmentFilter"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of Filters for defining groups"
+        }
+      },
+      "required": [
+        "filters"
+      ],
+      "description": "Details about Segment Group"
+    },
+    "SegmentLastLoginDateFilter": {
+      "type": "object",
+      "properties": {
+        "comparison": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Greater",
+                "Less",
+                "Equals",
+                "NotEquals",
+                "GreaterOrEquals",
+                "LessOrEquals",
+                "Contains",
+                "NotContains",
+                "Ignore",
+                "Exists"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Comparator used for the filter."
+        },
+        "filterName": {
+          "type": "string",
+          "enum": [
+            "LastLoginDate"
+          ]
+        },
+        "value": {
+          "type": "string",
+          "description": "Value to be compared"
+        }
+      },
+      "required": [
+        "comparison",
+        "filterName",
+        "value"
+      ],
+      "description": "Details about Segment LastLoginDate Filter"
+    },
+    "SegmentLastLoginFilter": {
+      "type": "object",
+      "properties": {
+        "comparison": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Greater",
+                "Less",
+                "Equals",
+                "NotEquals",
+                "GreaterOrEquals",
+                "LessOrEquals",
+                "Contains",
+                "NotContains",
+                "Ignore",
+                "Exists"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Comparator used for the filter."
+        },
+        "filterName": {
+          "type": "string",
+          "enum": [
+            "LastLogin"
+          ]
+        },
+        "value": {
+          "type": "string",
+          "description": "Value to be compared"
+        }
+      },
+      "required": [
+        "comparison",
+        "filterName",
+        "value"
+      ],
+      "description": "Details about Segment LastLogin Filter"
+    },
+    "SegmentLocationFilter": {
+      "type": "object",
+      "properties": {
+        "comparison": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Greater",
+                "Less",
+                "Equals",
+                "NotEquals",
+                "GreaterOrEquals",
+                "LessOrEquals",
+                "Contains",
+                "NotContains",
+                "Ignore",
+                "Exists"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Comparator used for the filter."
+        },
+        "filterName": {
+          "type": "string",
+          "enum": [
+            "Location"
+          ]
+        },
+        "value": {
+          "type": "string",
+          "description": "Value to be compared"
+        }
+      },
+      "required": [
+        "comparison",
+        "filterName",
+        "value"
+      ],
+      "description": "Details about Segment Location Filter"
+    },
+    "SegmentProperties": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SegmentQuery"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Details about Segment Query"
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "description": "Properties of Segment Resource"
+    },
+    "SegmentQuery": {
+      "type": "object",
+      "properties": {
+        "groups": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SegmentGroup"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Groups in Query for Segment definition"
+        }
+      },
+      "required": [
+        "groups"
+      ],
+      "description": "Details about Segment Query"
+    },
+    "SegmentStatisticFilter": {
+      "type": "object",
+      "properties": {
+        "comparison": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Greater",
+                "Less",
+                "Equals",
+                "NotEquals",
+                "GreaterOrEquals",
+                "LessOrEquals",
+                "Contains",
+                "NotContains",
+                "Ignore",
+                "Exists"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Comparator used for the filter."
+        },
+        "filterName": {
+          "type": "string",
+          "enum": [
+            "Statistic"
+          ]
+        },
+        "statisticName": {
+          "type": "string",
+          "description": "Statistic Filter name"
+        },
+        "useCurrentVersion": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Use current version of Statistic filter"
+        },
+        "value": {
+          "type": "string",
+          "description": "Value to be compared"
+        },
+        "version": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Version of Statistic to be used"
+        }
+      },
+      "required": [
+        "comparison",
+        "filterName",
+        "statisticName",
+        "value"
+      ],
+      "description": "Details about Segment Statistics Filter"
+    },
+    "SegmentTagFilter": {
+      "type": "object",
+      "properties": {
+        "comparison": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Greater",
+                "Less",
+                "Equals",
+                "NotEquals",
+                "GreaterOrEquals",
+                "LessOrEquals",
+                "Contains",
+                "NotContains",
+                "Ignore",
+                "Exists"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Comparator used for the filter."
+        },
+        "filterName": {
+          "type": "string",
+          "enum": [
+            "Tag"
+          ]
+        },
+        "value": {
+          "type": "string",
+          "description": "Value to be compared"
+        }
+      },
+      "required": [
+        "comparison",
+        "filterName",
+        "value"
+      ],
+      "description": "Details about Segment TagFilter"
+    },
+    "SegmentUserOriginationFilter": {
+      "type": "object",
+      "properties": {
+        "comparison": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Greater",
+                "Less",
+                "Equals",
+                "NotEquals",
+                "GreaterOrEquals",
+                "LessOrEquals",
+                "Contains",
+                "NotContains",
+                "Ignore",
+                "Exists"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Comparator used for the filter."
+        },
+        "filterName": {
+          "type": "string",
+          "enum": [
+            "UserOrigination"
+          ]
+        },
+        "value": {
+          "type": "string",
+          "description": "Value to be compared"
+        }
+      },
+      "required": [
+        "comparison",
+        "filterName",
+        "value"
+      ],
+      "description": "Details about Segment UserOrigination Filter"
+    },
+    "TitleDataSetProperties": {
+      "type": "object",
+      "properties": {
+        "keyValuePairs": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/KeyValuePair"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of KeyValuePairs"
+        }
+      },
+      "required": [
+        "keyValuePairs"
+      ],
+      "description": "Properties of TitleDataSet Resource"
+    },
+    "TitleInternalDataSetProperties": {
+      "type": "object",
+      "properties": {
+        "keyValuePairs": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/KeyValuePair"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of KeyValuePairs"
+        }
+      },
+      "required": [
+        "keyValuePairs"
+      ],
+      "description": "Properties of TitleInternalDataSet Resource"
+    },
+    "TitleProperties": {
+      "type": "object",
+      "properties": {
+        "playerAccountPoolId": {
+          "type": "string",
+          "description": "Azure resource Id of the PlayerAccountPool resource."
+        },
+        "settings": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TitleSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Title Settings model"
+        }
+      },
+      "required": [
+        "playerAccountPoolId"
+      ],
+      "description": "Properties of Title Resource"
+    },
+    "TitleSettings": {
+      "type": "object",
+      "properties": {
+        "api": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ApiSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Title API Settings"
+        },
+        "general": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/GeneralSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "General Title Settings"
+        }
+      },
+      "description": "Title Settings model"
+    },
+    "titles_segments_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2022-04-12-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the Segment Parameter."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SegmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of Segment Resource"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "segments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.PlayFab/titles/segments"
+    },
+    "titles_titledatasets_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2022-04-12-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the TitleDataSet Parameter."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TitleDataSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of TitleDataSet Resource"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "titledatasets"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.PlayFab/titles/titledatasets"
+    },
+    "titles_titleinternaldatasets_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2022-04-12-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the TitleInternalDataSet Parameter."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TitleInternalDataSetProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of TitleInternalDataSet Resource"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "titleinternaldatasets"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.PlayFab/titles/titleinternaldatasets"
+    }
+  }
+}

--- a/tests/2022-04-12-preview/Microsoft.PlayFab.tests.json
+++ b/tests/2022-04-12-preview/Microsoft.PlayFab.tests.json
@@ -1,0 +1,99 @@
+{
+  "tests": [
+    {
+      "name": "PlayFab tests - minimal title resource",
+      "definition": "https://schema.management.azure.com/schemas/2022-04-12-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles",
+      "json": {
+        "name": "title1",
+        "type": "Microsoft.PlayFab/titles",
+        "apiVersion": "2022-04-12-preview",
+        "location": "westus2",
+        "properties": {
+            "playerAccountPoolId": "/subscriptions/3f753bd1-b08e-4473-965c-0397c16d9789/resourceGroups/testrg/providers/Microsoft.PlayFab/playerAccountPools/playerAccountName"
+        }
+      }
+    },
+    {
+        "name": "PlayFab tests - minimal playerAccountPool resource",
+        "definition": "https://schema.management.azure.com/schemas/2022-04-12-preview/Microsoft.PlayFab.json#/resourceDefinitions/playerAccountPools",
+        "json": {
+          "name": "playerAccountPool1",
+          "type": "Microsoft.PlayFab/playerAccountPools",
+          "apiVersion": "2022-04-12-preview",
+          "location": "westus2",
+          "properties": {}
+        }
+    },
+    {
+        "name": "PlayFab tests - minimal Segments resource",
+        "definition": "https://schema.management.azure.com/schemas/2022-04-12-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles_segments",
+        "json": {
+          "name": "segments1",
+          "type": "Microsoft.PlayFab/titles/segments",
+          "apiVersion": "2022-04-12-preview",
+          "location": "westus2",
+          "properties": {
+            "query":{
+                "groups":[
+                    {
+                       "filters":[
+                           {
+                             "filterName":"UserOrigination",
+                             "comparison":"Equals",
+                             "value":"WindowsHello"
+                          }
+                       ]
+                    }
+                 ]
+            }
+          }
+        }
+     },
+     {
+      "name": "PlayFab tests - minimal TitleDataSet resource",
+      "definition": "https://schema.management.azure.com/schemas/2022-04-12-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles_titledatasets",
+      "json": {
+        "name": "testKey",
+        "type": "Microsoft.PlayFab/titles/titledatasets",
+        "apiVersion": "2022-04-12-preview",
+        "location": "westus2",
+        "properties": {
+          "keyValuePairs": [
+            {
+              "key": "key01",
+              "value": "value01"
+            },
+            {
+              "key": "key02",
+              "value": "value02"
+            }
+          ],
+          "provisioningState": "NotSpecified"
+        }
+      }
+    },
+    {
+      "name": "PlayFab tests - minimal TitleInternalDataSet resource",
+      "definition": "https://schema.management.azure.com/schemas/2022-04-12-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles_titleinternaldatasets",
+      "json": {
+        "name": "testKey",
+        "type": "Microsoft.PlayFab/titles/titleinternaldatasets",
+        "apiVersion": "2022-04-12-preview",
+        "location": "westus2",
+        "properties": {
+          "keyValuePairs": [
+            {
+              "key": "key01",
+              "value": "value01"
+            },
+            {
+              "key": "key02",
+              "value": "value02"
+            }
+          ],
+          "provisioningState": "NotSpecified"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
We are also introducing new resources
1)TitleDataSet
2)TitleInternalDataSet


Related Swagger: https://github.com/Azure/azure-rest-api-specs-pr/pull/7044
In reality these are renames of existing Resources TitleDataKeyValue and TitleInternalDataKeyValue but we made a concious decision of registering new resources and then delete these old resources (TitleDataKeyValue and TitleInternalDataKeyValue ) and for that reason the scripts are not updated to add new version ie; 2022-04-12-preview for TitleDataKeyValue and TitleInternalDataKeyValue