### PR TITLE
Add NGINX.NGINXPLUS in the file path Regex

### DIFF
--- a/generator/constants.ts
+++ b/generator/constants.ts
@@ -9,7 +9,7 @@ export const specsRepoPath = path.join(os.tmpdir(), 'schm_azspc');
 export const specsRepoUri = 'https://github.com/azure/azure-rest-api-specs';
 export const specsRepoCommitHash = 'origin/main';
 // eslint-disable-next-line no-useless-escape
-export const pathRegex = /(microsoft\.\w+)[\\\/]\S*[\\\/](\d{4}-\d{2}-\d{2}(|-preview))[\\\/]/i;
+export const pathRegex = /(microsoft\.\w+|NGINX.NGINXPLUS)[\\\/]\S*[\\\/](\d{4}-\d{2}-\d{2}(|-preview))[\\\/]/i;
 
 export const autoRestVerboseOutput = false;
 


### PR DESCRIPTION
Because of the issue: https://github.com/Azure/azure-resource-manager-schemas/issues/2388, the NGINX.NGINXPLUS RP won't auto generate schemas. NGINX.NGINXPLUS RP is the Microsoft first party RP. So we want to add it.