### PR TITLE
Onboarding Dynatrace.Observability (dynatrace/resource-manager) for autogeneration

### DIFF
--- a/generator/autogenlist.ts
+++ b/generator/autogenlist.ts
@@ -928,6 +928,10 @@ const autoGenList: AutoGenConfig[] = [
         namespace: 'Microsoft.Logz',
     },
     {
+        basePath: 'dynatrace/resource-manager',
+        namespace: 'Dynatrace.Observability',
+    },
+    {
         basePath: 'healthbot/resource-manager',
         namespace: 'Microsoft.HealthBot',
     },

--- a/generator/constants.ts
+++ b/generator/constants.ts
@@ -9,7 +9,7 @@ export const specsRepoPath = path.join(os.tmpdir(), 'schm_azspc');
 export const specsRepoUri = 'https://github.com/azure/azure-rest-api-specs';
 export const specsRepoCommitHash = 'origin/main';
 // eslint-disable-next-line no-useless-escape
-export const pathRegex = /(microsoft\.\w+|NGINX.NGINXPLUS)[\\\/]\S*[\\\/](\d{4}-\d{2}-\d{2}(|-preview))[\\\/]/i;
+export const pathRegex = /(microsoft\.\w+|NGINX.NGINXPLUS|DYNATRACE.OBSERVABILITY)[\\\/]\S*[\\\/](\d{4}-\d{2}-\d{2}(|-preview))[\\\/]/i;
 
 export const autoRestVerboseOutput = false;
 

--- a/schemas/2021-09-01-preview/Dynatrace.Observability.json
+++ b/schemas/2021-09-01-preview/Dynatrace.Observability.json
@@ -1,0 +1,705 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2021-09-01-preview/Dynatrace.Observability.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Dynatrace.Observability",
+  "description": "Dynatrace Observability Resource Types",
+  "resourceDefinitions": {
+    "monitors": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-09-01-preview"
+          ]
+        },
+        "identity": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/IdentityProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of the managed service identities assigned to this resource."
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives"
+        },
+        "name": {
+          "type": "string",
+          "description": "Monitor resource name"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitorProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties specific to the monitor resource."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/monitors_tagRules_childResource"
+              },
+              {
+                "$ref": "#/definitions/monitors_singleSignOnConfigurations_childResource"
+              }
+            ]
+          }
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Dynatrace.Observability/monitors"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Dynatrace.Observability/monitors"
+    },
+    "monitors_singleSignOnConfigurations": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-09-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Single Sign On Configuration Name"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DynatraceSingleSignOnProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The details of a Dynatrace single sign-on."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Dynatrace.Observability/monitors/singleSignOnConfigurations"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Dynatrace.Observability/monitors/singleSignOnConfigurations"
+    },
+    "monitors_tagRules": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-09-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Monitor resource name"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitoringTagRulesProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for the Tag rules resource of a Monitor account."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Dynatrace.Observability/monitors/tagRules"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Dynatrace.Observability/monitors/tagRules"
+    }
+  },
+  "definitions": {
+    "AccountInfo": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string",
+          "description": "Account Id of the account this environment is linked to"
+        },
+        "regionId": {
+          "type": "string",
+          "description": "Region in which the account is created"
+        }
+      },
+      "description": "Dynatrace Account Information"
+    },
+    "DynatraceEnvironmentProperties": {
+      "type": "object",
+      "properties": {
+        "accountInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccountInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Dynatrace Account Information"
+        },
+        "environmentInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/EnvironmentInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Dynatrace Environment Information"
+        },
+        "singleSignOnProperties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DynatraceSingleSignOnProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The details of a Dynatrace single sign-on."
+        },
+        "userId": {
+          "type": "string",
+          "description": "User id"
+        }
+      },
+      "description": "Properties of the Dynatrace environment."
+    },
+    "DynatraceSingleSignOnProperties": {
+      "type": "object",
+      "properties": {
+        "aadDomains": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "array of Aad(azure active directory) domains"
+        },
+        "enterpriseAppId": {
+          "type": "string",
+          "description": "Version of the Dynatrace agent installed on the VM."
+        },
+        "singleSignOnState": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Initial",
+                "Enable",
+                "Disable",
+                "Existing"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "State of Single Sign On."
+        },
+        "singleSignOnUrl": {
+          "type": "string",
+          "description": "The login URL specific to this Dynatrace Environment"
+        }
+      },
+      "description": "The details of a Dynatrace single sign-on."
+    },
+    "EnvironmentInfo": {
+      "type": "object",
+      "properties": {
+        "environmentId": {
+          "type": "string",
+          "description": "Id of the environment created"
+        },
+        "ingestionKey": {
+          "type": "string",
+          "description": "Ingestion key of the environment"
+        },
+        "landingURL": {
+          "type": "string",
+          "description": "Landing URL for Dynatrace environment"
+        },
+        "logsIngestionEndpoint": {
+          "type": "string",
+          "description": "Ingestion endpoint used for sending logs"
+        }
+      },
+      "description": "Dynatrace Environment Information"
+    },
+    "FilteringTag": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Include",
+                "Exclude"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Valid actions for a filtering tag. Exclusion takes priority over inclusion."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name (also known as the key) of the tag."
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the tag."
+        }
+      },
+      "description": "The definition of a filtering tag. Filtering tags are used for capturing resources and include/exclude them from being monitored."
+    },
+    "IdentityProperties": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "SystemAssigned",
+                "UserAssigned",
+                "SystemAndUserAssigned"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of managed identity assigned to this resource."
+        },
+        "userAssignedIdentities": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/UserAssignedIdentity"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The identities assigned to this resource by the user."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "description": "The properties of the managed service identities assigned to this resource."
+    },
+    "LogRules": {
+      "type": "object",
+      "properties": {
+        "filteringTags": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FilteringTag"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of filtering tags to be used for capturing logs. This only takes effect if SendActivityLogs flag is enabled. If empty, all resources will be captured.\nIf only Exclude action is specified, the rules will apply to the list of all available resources. If Include actions are specified, the rules will only include resources with the associated tags."
+        },
+        "sendAadLogs": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag specifying if AAD logs should be sent for the Monitor resource."
+        },
+        "sendActivityLogs": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag specifying if activity logs from Azure resources should be sent for the Monitor resource."
+        },
+        "sendSubscriptionLogs": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag specifying if subscription logs should be sent for the Monitor resource."
+        }
+      },
+      "description": "Set of rules for sending logs for the Monitor resource."
+    },
+    "MetricRules": {
+      "type": "object",
+      "properties": {
+        "filteringTags": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FilteringTag"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of filtering tags to be used for capturing metrics. If empty, all resources will be captured. If only Exclude action is specified, the rules will apply to the list of all available resources. If Include actions are specified, the rules will only include resources with the associated tags."
+        }
+      },
+      "description": "Set of rules for sending metrics for the Monitor resource."
+    },
+    "MonitoringTagRulesProperties": {
+      "type": "object",
+      "properties": {
+        "logRules": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/LogRules"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Set of rules for sending logs for the Monitor resource."
+        },
+        "metricRules": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MetricRules"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Set of rules for sending metrics for the Monitor resource."
+        }
+      },
+      "description": "Properties for the Tag rules resource of a Monitor account."
+    },
+    "MonitorProperties": {
+      "type": "object",
+      "properties": {
+        "dynatraceEnvironmentProperties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DynatraceEnvironmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of the Dynatrace environment."
+        },
+        "marketplaceSubscriptionStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Active",
+                "Suspended"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Marketplace subscription status."
+        },
+        "monitoringStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Status of the monitor."
+        },
+        "planData": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PlanData"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Billing plan information."
+        },
+        "userInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UserInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "User info."
+        }
+      },
+      "description": "Properties specific to the monitor resource."
+    },
+    "monitors_singleSignOnConfigurations_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-09-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Single Sign On Configuration Name"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DynatraceSingleSignOnProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The details of a Dynatrace single sign-on."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "singleSignOnConfigurations"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Dynatrace.Observability/monitors/singleSignOnConfigurations"
+    },
+    "monitors_tagRules_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-09-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Monitor resource name"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitoringTagRulesProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for the Tag rules resource of a Monitor account."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "tagRules"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Dynatrace.Observability/monitors/tagRules"
+    },
+    "PlanData": {
+      "type": "object",
+      "properties": {
+        "billingCycle": {
+          "type": "string",
+          "maxLength": 50,
+          "description": "Shorthand for setting length limit."
+        },
+        "effectiveDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "date when plan was applied"
+        },
+        "planDetails": {
+          "type": "string",
+          "maxLength": 50,
+          "description": "Shorthand for setting length limit."
+        },
+        "usageType": {
+          "type": "string",
+          "maxLength": 50,
+          "description": "Shorthand for setting length limit."
+        }
+      },
+      "description": "Billing plan information."
+    },
+    "UserAssignedIdentity": {
+      "type": "object",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The active directory client identifier for this principal."
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The active directory identifier for this principal."
+        }
+      },
+      "required": [
+        "clientId",
+        "principalId"
+      ],
+      "description": "A managed identity assigned by the user."
+    },
+    "UserInfo": {
+      "type": "object",
+      "properties": {
+        "country": {
+          "type": "string",
+          "description": "Country of the user"
+        },
+        "emailAddress": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9._%+-]+@(?:[A-Za-z0-9-]+\\.)+[A-Za-z]{2,}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Reusable representation of an email address"
+        },
+        "firstName": {
+          "type": "string",
+          "maxLength": 50,
+          "description": "Shorthand for setting length limit."
+        },
+        "lastName": {
+          "type": "string",
+          "maxLength": 50,
+          "description": "Shorthand for setting length limit."
+        },
+        "phoneNumber": {
+          "type": "string",
+          "maxLength": 40,
+          "description": "Phone number of the user used by Dynatrace for contacting them if needed"
+        }
+      },
+      "description": "User info."
+    }
+  }
+}

--- a/schemas/2021-09-01/Dynatrace.Observability.json
+++ b/schemas/2021-09-01/Dynatrace.Observability.json
@@ -1,0 +1,700 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2021-09-01/Dynatrace.Observability.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Dynatrace.Observability",
+  "description": "Dynatrace Observability Resource Types",
+  "resourceDefinitions": {
+    "monitors": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-09-01"
+          ]
+        },
+        "identity": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/IdentityProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The properties of the managed service identities assigned to this resource."
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives"
+        },
+        "name": {
+          "type": "string",
+          "description": "Monitor resource name"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitorProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties specific to the monitor resource."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/monitors_tagRules_childResource"
+              },
+              {
+                "$ref": "#/definitions/monitors_singleSignOnConfigurations_childResource"
+              }
+            ]
+          }
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Dynatrace.Observability/monitors"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Dynatrace.Observability/monitors"
+    },
+    "monitors_singleSignOnConfigurations": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-09-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Single Sign On Configuration Name"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DynatraceSingleSignOnProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The details of a Dynatrace single sign-on."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Dynatrace.Observability/monitors/singleSignOnConfigurations"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Dynatrace.Observability/monitors/singleSignOnConfigurations"
+    },
+    "monitors_tagRules": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-09-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Monitor resource name"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitoringTagRulesProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for the Tag rules resource of a Monitor account."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Dynatrace.Observability/monitors/tagRules"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Dynatrace.Observability/monitors/tagRules"
+    }
+  },
+  "definitions": {
+    "AccountInfo": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string",
+          "description": "Account Id of the account this environment is linked to"
+        },
+        "regionId": {
+          "type": "string",
+          "description": "Region in which the account is created"
+        }
+      },
+      "description": "Dynatrace Account Information"
+    },
+    "DynatraceEnvironmentProperties": {
+      "type": "object",
+      "properties": {
+        "accountInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccountInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Dynatrace Account Information"
+        },
+        "environmentInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/EnvironmentInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Dynatrace Environment Information"
+        },
+        "singleSignOnProperties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DynatraceSingleSignOnProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The details of a Dynatrace single sign-on."
+        },
+        "userId": {
+          "type": "string",
+          "description": "User id"
+        }
+      },
+      "description": "Properties of the Dynatrace environment."
+    },
+    "DynatraceSingleSignOnProperties": {
+      "type": "object",
+      "properties": {
+        "aadDomains": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "array of Aad(azure active directory) domains"
+        },
+        "enterpriseAppId": {
+          "type": "string",
+          "description": "Version of the Dynatrace agent installed on the VM."
+        },
+        "singleSignOnState": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Initial",
+                "Enable",
+                "Disable",
+                "Existing"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "State of Single Sign On."
+        },
+        "singleSignOnUrl": {
+          "type": "string",
+          "description": "The login URL specific to this Dynatrace Environment"
+        }
+      },
+      "description": "The details of a Dynatrace single sign-on."
+    },
+    "EnvironmentInfo": {
+      "type": "object",
+      "properties": {
+        "environmentId": {
+          "type": "string",
+          "description": "Id of the environment created"
+        },
+        "ingestionKey": {
+          "type": "string",
+          "description": "Ingestion key of the environment"
+        },
+        "landingURL": {
+          "type": "string",
+          "description": "Landing URL for Dynatrace environment"
+        },
+        "logsIngestionEndpoint": {
+          "type": "string",
+          "description": "Ingestion endpoint used for sending logs"
+        }
+      },
+      "description": "Dynatrace Environment Information"
+    },
+    "FilteringTag": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Include",
+                "Exclude"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Valid actions for a filtering tag. Exclusion takes priority over inclusion."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name (also known as the key) of the tag."
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the tag."
+        }
+      },
+      "description": "The definition of a filtering tag. Filtering tags are used for capturing resources and include/exclude them from being monitored."
+    },
+    "IdentityProperties": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "SystemAssigned",
+                "UserAssigned",
+                "SystemAndUserAssigned"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of managed identity assigned to this resource."
+        },
+        "userAssignedIdentities": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/UserAssignedIdentity"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The identities assigned to this resource by the user."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "description": "The properties of the managed service identities assigned to this resource."
+    },
+    "LogRules": {
+      "type": "object",
+      "properties": {
+        "filteringTags": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FilteringTag"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of filtering tags to be used for capturing logs. This only takes effect if SendActivityLogs flag is enabled. If empty, all resources will be captured.\nIf only Exclude action is specified, the rules will apply to the list of all available resources. If Include actions are specified, the rules will only include resources with the associated tags."
+        },
+        "sendAadLogs": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag specifying if AAD logs should be sent for the Monitor resource."
+        },
+        "sendActivityLogs": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag specifying if activity logs from Azure resources should be sent for the Monitor resource."
+        },
+        "sendSubscriptionLogs": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag specifying if subscription logs should be sent for the Monitor resource."
+        }
+      },
+      "description": "Set of rules for sending logs for the Monitor resource."
+    },
+    "MetricRules": {
+      "type": "object",
+      "properties": {
+        "filteringTags": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FilteringTag"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of filtering tags to be used for capturing metrics. If empty, all resources will be captured. If only Exclude action is specified, the rules will apply to the list of all available resources. If Include actions are specified, the rules will only include resources with the associated tags."
+        }
+      },
+      "description": "Set of rules for sending metrics for the Monitor resource."
+    },
+    "MonitoringTagRulesProperties": {
+      "type": "object",
+      "properties": {
+        "logRules": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/LogRules"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Set of rules for sending logs for the Monitor resource."
+        },
+        "metricRules": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MetricRules"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Set of rules for sending metrics for the Monitor resource."
+        }
+      },
+      "description": "Properties for the Tag rules resource of a Monitor account."
+    },
+    "MonitorProperties": {
+      "type": "object",
+      "properties": {
+        "dynatraceEnvironmentProperties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DynatraceEnvironmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of the Dynatrace environment."
+        },
+        "marketplaceSubscriptionStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Active",
+                "Suspended"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Marketplace subscription status."
+        },
+        "monitoringStatus": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Status of the monitor."
+        },
+        "planData": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PlanData"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Billing plan information."
+        },
+        "userInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UserInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "User info."
+        }
+      },
+      "description": "Properties specific to the monitor resource."
+    },
+    "monitors_singleSignOnConfigurations_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-09-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Single Sign On Configuration Name"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DynatraceSingleSignOnProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The details of a Dynatrace single sign-on."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "singleSignOnConfigurations"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Dynatrace.Observability/monitors/singleSignOnConfigurations"
+    },
+    "monitors_tagRules_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-09-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Monitor resource name"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MonitoringTagRulesProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for the Tag rules resource of a Monitor account."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "tagRules"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Dynatrace.Observability/monitors/tagRules"
+    },
+    "PlanData": {
+      "type": "object",
+      "properties": {
+        "billingCycle": {
+          "type": "string",
+          "description": "different billing cycles like MONTHLY/WEEKLY. this could be enum"
+        },
+        "effectiveDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "date when plan was applied"
+        },
+        "planDetails": {
+          "type": "string",
+          "description": "plan id as published by Dynatrace"
+        },
+        "usageType": {
+          "type": "string",
+          "description": "different usage type like PAYG/COMMITTED. this could be enum"
+        }
+      },
+      "description": "Billing plan information."
+    },
+    "UserAssignedIdentity": {
+      "type": "object",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The active directory client identifier for this principal."
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The active directory identifier for this principal."
+        }
+      },
+      "required": [
+        "clientId",
+        "principalId"
+      ],
+      "description": "A managed identity assigned by the user."
+    },
+    "UserInfo": {
+      "type": "object",
+      "properties": {
+        "country": {
+          "type": "string",
+          "description": "Country of the user"
+        },
+        "emailAddress": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9._%+-]+@(?:[A-Za-z0-9-]+\\.)+[A-Za-z]{2,}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Reusable representation of an email address"
+        },
+        "firstName": {
+          "type": "string",
+          "description": "First Name of the user"
+        },
+        "lastName": {
+          "type": "string",
+          "description": "Last Name of the user"
+        },
+        "phoneNumber": {
+          "type": "string",
+          "maxLength": 40,
+          "description": "Phone number of the user used by Dynatrace for contacting them if needed"
+        }
+      },
+      "description": "User info."
+    }
+  }
+}

--- a/schemas/common/autogeneratedResources.json
+++ b/schemas/common/autogeneratedResources.json
@@ -11,6 +11,24 @@
     {
       "oneOf": [
         {
+          "$ref": "https://schema.management.azure.com/schemas/2021-09-01/Dynatrace.Observability.json#/resourceDefinitions/monitors"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2021-09-01/Dynatrace.Observability.json#/resourceDefinitions/monitors_singleSignOnConfigurations"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2021-09-01/Dynatrace.Observability.json#/resourceDefinitions/monitors_tagRules"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2021-09-01-preview/Dynatrace.Observability.json#/resourceDefinitions/monitors"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2021-09-01-preview/Dynatrace.Observability.json#/resourceDefinitions/monitors_singleSignOnConfigurations"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2021-09-01-preview/Dynatrace.Observability.json#/resourceDefinitions/monitors_tagRules"
+        },
+        {
           "$ref": "https://schema.management.azure.com/schemas/2017-01-01/Microsoft.AAD.json#/resourceDefinitions/domainServices"
         },
         {


### PR DESCRIPTION
**The output of npm run generate-single dynatrace/resource-manager:**
```
C:\tmp\azure-resource-manager-schemas\generator>npm run generate-single -- --base-path dynatrace/resource-manager

> template-schema-generator@1.0.0 generate-single
> ts-node cmd/generatesingle "--base-path" "dynatrace/resource-manager"

[C:\Users\SVEERA~1\AppData\Local\Temp\schm_azspc] executing: git fsck
[C:\Users\SVEERA~1\AppData\Local\Temp\schm_azspc] executing: git reset -q .
[C:\Users\SVEERA~1\AppData\Local\Temp\schm_azspc] executing: git checkout -q -- .
[C:\Users\SVEERA~1\AppData\Local\Temp\schm_azspc] executing: git clean -q -fd
[C:\Users\SVEERA~1\AppData\Local\Temp\schm_azspc] executing: git gc
[C:\Users\SVEERA~1\AppData\Local\Temp\schm_azspc] executing: git fetch -q
[C:\Users\SVEERA~1\AppData\Local\Temp\schm_azspc] executing: git checkout -q origin/main
Using autogenlist config:
{
  "basePath": "dynatrace/resource-manager",
  "namespace": "Dynatrace.Observability"
}
[C:\tmp\azure-resource-manager-schemas\generator] executing: C:\tmp\azure-resource-manager-schemas\generator/node_modules/.bin/autorest.cmd --version=3.0.6374 --use=@autorest/azureresourceschema@3.0.92 --azureresourceschema --output-folder=C:\Users\SVEERA~1\AppData\Local\Temp\j3ykjh70eu --multiapi --pass-thru:subset-reducer --pass-thru:schema-validator-swagger C:\Users\SVEERA~1\AppData\Local\Temp\schm_azspc\specification\dynatrace\resource-manager\readme.md
AutoRest code generation utility [cli version: 3.3.2; node: v14.17.0]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest
NOTE: AutoRest core version selected from configuration: 3.0.6374.

There is a new version of AutoRest available (3.6.2).
 > You can install the newer version with with npm install -g autorest@latest

   Loading AutoRest core      'C:\Users\sveeravalli\.autorest\@autorest_core@3.0.6374\node_modules\@autorest\core\dist' (3.0.6374)
   Loading AutoRest extension '@autorest/azureresourceschema' (3.0.92->3.0.92)
Processing batch task - {"tag":"schema-2021-09-01-preview"} .
Processing batch task - {"tag":"schema-2021-09-01"} .
[11.46 s] Generation Complete
================================================================================================================================
Filename: C:\tmp\azure-resource-manager-schemas\schemas\2021-09-01\Dynatrace.Observability.json
Provider Namespace: Dynatrace.Observability
API Version: 2021-09-01
Resource Types (Resource Group Scope):
- monitors
- monitors/singleSignOnConfigurations
- monitors/tagRules
================================================================================================================================
================================================================================================================================
Filename: C:\tmp\azure-resource-manager-schemas\schemas\2021-09-01-preview\Dynatrace.Observability.json
Provider Namespace: Dynatrace.Observability
API Version: 2021-09-01-preview
Resource Types (Resource Group Scope):
- monitors
- monitors/singleSignOnConfigurations
- monitors/tagRules
================================================================================================================================
```

**Test suite output:**

![Screenshot 2022-07-28 034258](https://user-images.githubusercontent.com/89127295/182046963-7e976e63-2884-4f54-9f07-4808a478f2ed.jpg)

*Also the Dynatrace.Observability RP won't auto generate schemas. Dynatrace.Observability RP is the Microsoft first party RP. So we want to add it in constants file.*
