### PR TITLE
Onboard any providers matching format <provider>.<name>

### DIFF
--- a/generator/constants.ts
+++ b/generator/constants.ts
@@ -9,7 +9,7 @@ export const specsRepoPath = path.join(os.tmpdir(), 'schm_azspc');
 export const specsRepoUri = 'https://github.com/azure/azure-rest-api-specs';
 export const specsRepoCommitHash = 'origin/main';
 // eslint-disable-next-line no-useless-escape
-export const pathRegex = /(microsoft\.\w+|NGINX.NGINXPLUS|DYNATRACE.OBSERVABILITY)[\\\/]\S*[\\\/](\d{4}-\d{2}-\d{2}(|-preview))[\\\/]/i;
+export const pathRegex = /(\w+\.\w+)[\\\/]\S*[\\\/](\d{4}-\d{2}-\d{2}(|-preview))[\\\/]/i;
 
 export const autoRestVerboseOutput = false;
 


### PR DESCRIPTION
Currently we look for `Microsoft.*` with the exception of a few 3rd party RPs. This PR just changes the logic to look for `*.*` so that 3rd party RPs do not need to manually onboard.