### PR TITLE
Revert "[ReleasePR authorization/resource-manager] Exposing membershipType property from Access review APIs"

### DIFF
--- a/schemas/2015-07-01/Microsoft.Authorization.Authz.json
+++ b/schemas/2015-07-01/Microsoft.Authorization.Authz.json
@@ -1,0 +1,187 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2015-07-01/Microsoft.Authorization.Authz.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Authorization",
+  "description": "Microsoft Authorization Resource Types",
+  "resourceDefinitions": {},
+  "unknown_resourceDefinitions": {
+    "roleAssignments": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-07-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "A GUID for the role assignment to create. The name must be unique and different for each role assignment."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role assignment properties."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleAssignments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleAssignments"
+    },
+    "roleDefinitions": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2015-07-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The ID of the role definition."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role definition properties."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleDefinitions"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleDefinitions"
+    }
+  },
+  "definitions": {
+    "Permission": {
+      "type": "object",
+      "properties": {
+        "actions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Allowed actions."
+        },
+        "notActions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Denied actions."
+        }
+      },
+      "description": "Role definition permissions."
+    },
+    "RoleAssignmentProperties": {
+      "type": "object",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID assigned to the role. This maps to the ID inside the Active Directory. It can point to a user, service principal, or security group."
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The role definition ID used in the role assignment."
+        }
+      },
+      "required": [
+        "principalId",
+        "roleDefinitionId"
+      ],
+      "description": "Role assignment properties."
+    },
+    "RoleDefinitionProperties": {
+      "type": "object",
+      "properties": {
+        "assignableScopes": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role definition assignable scopes."
+        },
+        "description": {
+          "type": "string",
+          "description": "The role definition description."
+        },
+        "permissions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Permission"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role definition permissions."
+        },
+        "roleName": {
+          "type": "string",
+          "description": "The role name."
+        },
+        "type": {
+          "type": "string",
+          "description": "The role type."
+        }
+      },
+      "description": "Role definition properties."
+    }
+  }
+}

--- a/schemas/2017-10-01-preview/Microsoft.Authorization.Authz.json
+++ b/schemas/2017-10-01-preview/Microsoft.Authorization.Authz.json
@@ -1,0 +1,75 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2017-10-01-preview/Microsoft.Authorization.Authz.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Authorization",
+  "description": "Microsoft Authorization Resource Types",
+  "resourceDefinitions": {},
+  "unknown_resourceDefinitions": {
+    "roleAssignments": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2017-10-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "A GUID for the role assignment to create. The name must be unique and different for each role assignment."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role assignment properties."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleAssignments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleAssignments"
+    }
+  },
+  "definitions": {
+    "RoleAssignmentProperties": {
+      "type": "object",
+      "properties": {
+        "canDelegate": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The delegation flag used for creating a role assignment"
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID assigned to the role. This maps to the ID inside the Active Directory. It can point to a user, service principal, or security group."
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The role definition ID used in the role assignment."
+        }
+      },
+      "description": "Role assignment properties."
+    }
+  }
+}

--- a/schemas/2018-01-01-preview/Microsoft.Authorization.Authz.json
+++ b/schemas/2018-01-01-preview/Microsoft.Authorization.Authz.json
@@ -1,0 +1,226 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2018-01-01-preview/Microsoft.Authorization.Authz.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Authorization",
+  "description": "Microsoft Authorization Resource Types",
+  "resourceDefinitions": {},
+  "unknown_resourceDefinitions": {
+    "roleAssignments": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-01-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "A GUID for the role assignment to create. The name must be unique and different for each role assignment."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role assignment properties."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleAssignments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleAssignments"
+    },
+    "roleDefinitions": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-01-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The ID of the role definition."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role definition properties."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleDefinitions"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleDefinitions"
+    }
+  },
+  "definitions": {
+    "Permission": {
+      "type": "object",
+      "properties": {
+        "actions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Allowed actions."
+        },
+        "dataActions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Allowed Data actions."
+        },
+        "notActions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Denied actions."
+        },
+        "notDataActions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Denied Data actions."
+        }
+      },
+      "description": "Role definition permissions."
+    },
+    "RoleAssignmentProperties": {
+      "type": "object",
+      "properties": {
+        "canDelegate": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The delegation flag used for creating a role assignment"
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID assigned to the role. This maps to the ID inside the Active Directory. It can point to a user, service principal, or security group."
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The role definition ID used in the role assignment."
+        }
+      },
+      "required": [
+        "principalId",
+        "roleDefinitionId"
+      ],
+      "description": "Role assignment properties."
+    },
+    "RoleDefinitionProperties": {
+      "type": "object",
+      "properties": {
+        "assignableScopes": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role definition assignable scopes."
+        },
+        "description": {
+          "type": "string",
+          "description": "The role definition description."
+        },
+        "permissions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Permission"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role definition permissions."
+        },
+        "roleName": {
+          "type": "string",
+          "description": "The role name."
+        },
+        "type": {
+          "type": "string",
+          "description": "The role type."
+        }
+      },
+      "description": "Role definition properties."
+    }
+  }
+}

--- a/schemas/2018-05-01-preview/Microsoft.Authorization.Authz.json
+++ b/schemas/2018-05-01-preview/Microsoft.Authorization.Authz.json
@@ -1,0 +1,478 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2018-05-01-preview/Microsoft.Authorization.Authz.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Authorization",
+  "description": "Microsoft Authorization Resource Types",
+  "resourceDefinitions": {},
+  "subscription_resourceDefinitions": {
+    "accessReviewScheduleDefinitions": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-05-01-preview"
+          ]
+        },
+        "descriptionForAdmins": {
+          "type": "string",
+          "description": "The description provided by the access review creator and visible to admins."
+        },
+        "descriptionForReviewers": {
+          "type": "string",
+          "description": "The description provided by the access review creator to be shown to reviewers."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name for the schedule definition."
+        },
+        "instances": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewInstance"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of instances returned when one does an expand on it."
+        },
+        "name": {
+          "type": "string",
+          "description": "The id of the access review schedule definition."
+        },
+        "reviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of reviewers."
+        },
+        "settings": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewScheduleSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Settings of an Access Review."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/accessReviewScheduleDefinitions"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/accessReviewScheduleDefinitions"
+    },
+    "accessReviewScheduleSettings": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-05-01-preview"
+          ]
+        },
+        "autoApplyDecisionsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether auto-apply capability, to automatically change the target object access resource, is enabled. If not enabled, a user must, after the review completes, apply the access review."
+        },
+        "defaultDecision": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Approve",
+                "Deny",
+                "Recommendation"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This specifies the behavior for the autoReview feature when an access review completes."
+        },
+        "defaultDecisionEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether reviewers are required to provide a justification when reviewing access."
+        },
+        "instanceDurationInDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The duration in days for an instance."
+        },
+        "justificationRequiredOnApproval": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether the reviewer is required to pass justification when recording a decision."
+        },
+        "mailNotificationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether sending mails to reviewers and the review creator is enabled."
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "default"
+          ]
+        },
+        "recommendationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether showing recommendations to reviewers is enabled."
+        },
+        "recurrence": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrenceSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Settings of an Access Review Schedule Definition."
+        },
+        "reminderNotificationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether sending reminder emails to reviewers are enabled."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/accessReviewScheduleSettings"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/accessReviewScheduleSettings"
+    }
+  },
+  "definitions": {
+    "AccessReviewInstance": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewInstanceProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Access Review Instance properties."
+        }
+      },
+      "description": "Access Review Instance."
+    },
+    "AccessReviewInstanceProperties": {
+      "type": "object",
+      "properties": {
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review instance is scheduled to end."
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review instance is scheduled to be start."
+        }
+      },
+      "description": "Access Review Instance properties."
+    },
+    "AccessReviewRecurrencePattern": {
+      "type": "object",
+      "properties": {
+        "interval": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The interval for recurrence. For a quarterly review, the interval is 3 for type : absoluteMonthly."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "weekly",
+                "absoluteMonthly"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The recurrence type : weekly, monthly, etc."
+        }
+      },
+      "description": "Recurrence Pattern of an Access Review Schedule Definition."
+    },
+    "AccessReviewRecurrenceRange": {
+      "type": "object",
+      "properties": {
+        "endDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review is scheduled to end. Required if type is endDate"
+        },
+        "numberOfOccurrences": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The number of times to repeat the access review. Required and must be positive if type is numbered."
+        },
+        "startDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review is scheduled to be start. This could be a date in the future. Required on create."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "endDate",
+                "noEnd",
+                "numbered"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The recurrence range type. The possible values are: endDate, noEnd, numbered."
+        }
+      },
+      "description": "Recurrence Range of an Access Review Schedule Definition."
+    },
+    "AccessReviewRecurrenceSettings": {
+      "type": "object",
+      "properties": {
+        "pattern": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrencePattern"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Pattern of an Access Review Schedule Definition."
+        },
+        "range": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrenceRange"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Range of an Access Review Schedule Definition."
+        }
+      },
+      "description": "Recurrence Settings of an Access Review Schedule Definition."
+    },
+    "AccessReviewReviewer": {
+      "type": "object",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "The id of the reviewer(user/servicePrincipal)"
+        }
+      },
+      "description": "Descriptor for what needs to be reviewed"
+    },
+    "AccessReviewScheduleSettings": {
+      "type": "object",
+      "properties": {
+        "autoApplyDecisionsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether auto-apply capability, to automatically change the target object access resource, is enabled. If not enabled, a user must, after the review completes, apply the access review."
+        },
+        "defaultDecision": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Approve",
+                "Deny",
+                "Recommendation"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This specifies the behavior for the autoReview feature when an access review completes."
+        },
+        "defaultDecisionEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether reviewers are required to provide a justification when reviewing access."
+        },
+        "instanceDurationInDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The duration in days for an instance."
+        },
+        "justificationRequiredOnApproval": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether the reviewer is required to pass justification when recording a decision."
+        },
+        "mailNotificationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether sending mails to reviewers and the review creator is enabled."
+        },
+        "recommendationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether showing recommendations to reviewers is enabled."
+        },
+        "recurrence": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrenceSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Settings of an Access Review Schedule Definition."
+        },
+        "reminderNotificationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether sending reminder emails to reviewers are enabled."
+        }
+      },
+      "description": "Settings of an Access Review."
+    }
+  }
+}

--- a/schemas/2018-05-01/subscriptionDeploymentTemplate.json
+++ b/schemas/2018-05-01/subscriptionDeploymentTemplate.json
@@ -513,6 +513,93 @@
               "$ref": "https://schema.management.azure.com/schemas/2020-01-01/Microsoft.Advisor.json#/subscription_resourceDefinitions/configurations"
             },
             {
+              "$ref": "https://schema.management.azure.com/schemas/2015-07-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2015-07-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleDefinitions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2017-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2018-01-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2018-01-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleDefinitions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2018-05-01-preview/Microsoft.Authorization.Authz.json#/subscription_resourceDefinitions/accessReviewScheduleDefinitions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2018-05-01-preview/Microsoft.Authorization.Authz.json#/subscription_resourceDefinitions/accessReviewScheduleSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2018-09-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-03-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-04-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-08-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignmentScheduleRequests"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleEligibilityScheduleRequests"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleManagementPolicyAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignmentScheduleRequests"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleEligibilityScheduleRequests"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleManagementPolicyAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2021-03-01-preview/Microsoft.Authorization.Authz.json#/subscription_resourceDefinitions/accessReviewScheduleDefinitions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2021-03-01-preview/Microsoft.Authorization.Authz.json#/subscription_resourceDefinitions/accessReviewScheduleSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2021-07-01-preview/Microsoft.Authorization.Authz.json#/subscription_resourceDefinitions/accessReviewScheduleDefinitions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2021-07-01-preview/Microsoft.Authorization.Authz.json#/subscription_resourceDefinitions/accessReviewScheduleDefinitions_instances"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2021-07-01-preview/Microsoft.Authorization.Authz.json#/subscription_resourceDefinitions/accessReviewScheduleSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2021-11-16-preview/Microsoft.Authorization.Authz.json#/subscription_resourceDefinitions/accessReviewHistoryDefinitions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2021-11-16-preview/Microsoft.Authorization.Authz.json#/subscription_resourceDefinitions/accessReviewScheduleDefinitions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2021-11-16-preview/Microsoft.Authorization.Authz.json#/subscription_resourceDefinitions/accessReviewScheduleDefinitions_instances"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2021-11-16-preview/Microsoft.Authorization.Authz.json#/subscription_resourceDefinitions/accessReviewScheduleSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2022-04-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignmentScheduleRequests"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2022-04-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleEligibilityScheduleRequests"
+            },
+            {
               "$ref": "https://schema.management.azure.com/schemas/2017-09-01/Microsoft.Authorization.json#/resourceDefinitions/roleAssignments"
             },
             {

--- a/schemas/2018-09-01-preview/Microsoft.Authorization.Authz.json
+++ b/schemas/2018-09-01-preview/Microsoft.Authorization.Authz.json
@@ -1,0 +1,96 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2018-09-01-preview/Microsoft.Authorization.Authz.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Authorization",
+  "description": "Microsoft Authorization Resource Types",
+  "resourceDefinitions": {},
+  "unknown_resourceDefinitions": {
+    "roleAssignments": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2018-09-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "A GUID for the role assignment to create. The name must be unique and different for each role assignment."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role assignment properties."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleAssignments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleAssignments"
+    }
+  },
+  "definitions": {
+    "RoleAssignmentProperties": {
+      "type": "object",
+      "properties": {
+        "canDelegate": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The delegation flag used for creating a role assignment"
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID assigned to the role. This maps to the ID inside the Active Directory. It can point to a user, service principal, or security group."
+        },
+        "principalType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "User",
+                "Group",
+                "ServicePrincipal",
+                "ForeignGroup"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The principal type of the assigned principal ID."
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The role definition ID used in the role assignment."
+        }
+      },
+      "required": [
+        "principalId",
+        "roleDefinitionId"
+      ],
+      "description": "Role assignment properties."
+    }
+  }
+}

--- a/schemas/2019-08-01/managementGroupDeploymentTemplate.json
+++ b/schemas/2019-08-01/managementGroupDeploymentTemplate.json
@@ -501,6 +501,60 @@
         {
           "oneOf": [
             {
+              "$ref": "https://schema.management.azure.com/schemas/2015-07-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2015-07-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleDefinitions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2017-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2018-01-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2018-01-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleDefinitions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2018-09-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-03-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-04-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-08-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignmentScheduleRequests"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleEligibilityScheduleRequests"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleManagementPolicyAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignmentScheduleRequests"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleEligibilityScheduleRequests"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleManagementPolicyAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2022-04-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignmentScheduleRequests"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2022-04-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleEligibilityScheduleRequests"
+            },
+            {
               "$ref": "https://schema.management.azure.com/schemas/2017-09-01/Microsoft.Authorization.json#/resourceDefinitions/roleAssignments"
             },
             {

--- a/schemas/2019-08-01/tenantDeploymentTemplate.json
+++ b/schemas/2019-08-01/tenantDeploymentTemplate.json
@@ -509,6 +509,63 @@
                   "$ref": "https://schema.management.azure.com/schemas/2017-04-01-preview/Microsoft.Aadiam.json#/tenant_resourceDefinitions/diagnosticSettings"
                 },
                 {
+                  "$ref": "https://schema.management.azure.com/schemas/2015-07-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2015-07-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleDefinitions"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2017-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2018-01-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2018-01-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleDefinitions"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2018-09-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2020-03-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2020-04-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2020-08-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignmentScheduleRequests"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleEligibilityScheduleRequests"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleManagementPolicyAssignments"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignmentScheduleRequests"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleEligibilityScheduleRequests"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleManagementPolicyAssignments"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2021-01-01-preview/Microsoft.Authorization.Authz.json#/tenant_resourceDefinitions/roleAssignmentApprovals_stages"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2022-04-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignmentScheduleRequests"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2022-04-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleEligibilityScheduleRequests"
+                },
+                {
                   "$ref": "https://schema.management.azure.com/schemas/2017-09-01/Microsoft.Authorization.json#/resourceDefinitions/roleAssignments"
                 },
                 {

--- a/schemas/2020-03-01-preview/Microsoft.Authorization.Authz.json
+++ b/schemas/2020-03-01-preview/Microsoft.Authorization.Authz.json
@@ -1,0 +1,112 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2020-03-01-preview/Microsoft.Authorization.Authz.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Authorization",
+  "description": "Microsoft Authorization Resource Types",
+  "resourceDefinitions": {},
+  "unknown_resourceDefinitions": {
+    "roleAssignments": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-03-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the role assignment. It can be any valid GUID."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role assignment properties."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleAssignments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleAssignments"
+    }
+  },
+  "definitions": {
+    "RoleAssignmentProperties": {
+      "type": "object",
+      "properties": {
+        "canDelegate": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The delegation flag used for creating a role assignment"
+        },
+        "condition": {
+          "type": "string",
+          "description": "The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase 'foo_storage_container'"
+        },
+        "conditionVersion": {
+          "type": "string",
+          "description": "Version of the condition. Currently accepted value is '2.0'"
+        },
+        "delegatedManagedIdentityResourceId": {
+          "type": "string",
+          "description": "Id of the delegated managed identity resource"
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID."
+        },
+        "principalType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "User",
+                "Group",
+                "ServicePrincipal",
+                "ForeignGroup"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The principal type of the assigned principal ID."
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The role definition ID."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The role assignment scope."
+        }
+      },
+      "required": [
+        "principalId",
+        "roleDefinitionId"
+      ],
+      "description": "Role assignment properties."
+    }
+  }
+}

--- a/schemas/2020-04-01-preview/Microsoft.Authorization.Authz.json
+++ b/schemas/2020-04-01-preview/Microsoft.Authorization.Authz.json
@@ -1,0 +1,112 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2020-04-01-preview/Microsoft.Authorization.Authz.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Authorization",
+  "description": "Microsoft Authorization Resource Types",
+  "resourceDefinitions": {},
+  "unknown_resourceDefinitions": {
+    "roleAssignments": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-04-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "A GUID for the role assignment to create. The name must be unique and different for each role assignment."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role assignment properties."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleAssignments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleAssignments"
+    }
+  },
+  "definitions": {
+    "RoleAssignmentProperties": {
+      "type": "object",
+      "properties": {
+        "canDelegate": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The delegation flag used for creating a role assignment"
+        },
+        "condition": {
+          "type": "string",
+          "description": "The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase 'foo_storage_container'"
+        },
+        "conditionVersion": {
+          "type": "string",
+          "description": "Version of the condition. Currently accepted value is '2.0'"
+        },
+        "delegatedManagedIdentityResourceId": {
+          "type": "string",
+          "description": "Id of the delegated managed identity resource"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of role assignment"
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID assigned to the role. This maps to the ID inside the Active Directory. It can point to a user, service principal, or security group."
+        },
+        "principalType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "User",
+                "Group",
+                "ServicePrincipal",
+                "ForeignGroup"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The principal type of the assigned principal ID."
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The role definition ID used in the role assignment."
+        }
+      },
+      "required": [
+        "principalId",
+        "roleDefinitionId"
+      ],
+      "description": "Role assignment properties."
+    }
+  }
+}

--- a/schemas/2020-08-01-preview/Microsoft.Authorization.Authz.json
+++ b/schemas/2020-08-01-preview/Microsoft.Authorization.Authz.json
@@ -1,0 +1,101 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2020-08-01-preview/Microsoft.Authorization.Authz.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Authorization",
+  "description": "Microsoft Authorization Resource Types",
+  "resourceDefinitions": {},
+  "unknown_resourceDefinitions": {
+    "roleAssignments": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-08-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the role assignment. It can be any valid GUID."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role assignment properties."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleAssignments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleAssignments"
+    }
+  },
+  "definitions": {
+    "RoleAssignmentProperties": {
+      "type": "object",
+      "properties": {
+        "condition": {
+          "type": "string",
+          "description": "The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase 'foo_storage_container'"
+        },
+        "conditionVersion": {
+          "type": "string",
+          "description": "Version of the condition. Currently accepted value is '2.0'"
+        },
+        "delegatedManagedIdentityResourceId": {
+          "type": "string",
+          "description": "Id of the delegated managed identity resource"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of role assignment"
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID."
+        },
+        "principalType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "User",
+                "Group",
+                "ServicePrincipal",
+                "ForeignGroup"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The principal type of the assigned principal ID."
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The role definition ID."
+        }
+      },
+      "required": [
+        "principalId",
+        "roleDefinitionId"
+      ],
+      "description": "Role assignment properties."
+    }
+  }
+}

--- a/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json
+++ b/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json
@@ -1,0 +1,541 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Authorization",
+  "description": "Microsoft Authorization Resource Types",
+  "resourceDefinitions": {},
+  "unknown_resourceDefinitions": {
+    "roleAssignments": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-10-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the role assignment. It can be any valid GUID."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role assignment properties."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleAssignments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleAssignments"
+    },
+    "roleAssignmentScheduleRequests": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-10-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "A GUID for the role assignment to create. The name must be unique and different for each role assignment."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentScheduleRequestProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role assignment schedule request properties with scope."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleAssignmentScheduleRequests"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleAssignmentScheduleRequests"
+    },
+    "roleEligibilityScheduleRequests": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-10-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the role eligibility to create. It can be any valid GUID."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleEligibilityScheduleRequestProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role eligibility schedule request properties with scope."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleEligibilityScheduleRequests"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleEligibilityScheduleRequests"
+    },
+    "roleManagementPolicyAssignments": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-10-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of format {guid_guid} the role management policy assignment to upsert."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleManagementPolicyAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role management policy assignment properties with scope."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleManagementPolicyAssignments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleManagementPolicyAssignments"
+    }
+  },
+  "definitions": {
+    "RoleAssignmentProperties": {
+      "type": "object",
+      "properties": {
+        "condition": {
+          "type": "string",
+          "description": "The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase 'foo_storage_container'"
+        },
+        "conditionVersion": {
+          "type": "string",
+          "description": "Version of the condition. Currently accepted value is '2.0'"
+        },
+        "delegatedManagedIdentityResourceId": {
+          "type": "string",
+          "description": "Id of the delegated managed identity resource"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of role assignment"
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID."
+        },
+        "principalType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "User",
+                "Group",
+                "ServicePrincipal",
+                "ForeignGroup",
+                "Device"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The principal type of the assigned principal ID."
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The role definition ID."
+        }
+      },
+      "required": [
+        "principalId",
+        "roleDefinitionId"
+      ],
+      "description": "Role assignment properties."
+    },
+    "RoleAssignmentScheduleRequestProperties": {
+      "type": "object",
+      "properties": {
+        "condition": {
+          "type": "string",
+          "description": "The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase 'foo_storage_container'"
+        },
+        "conditionVersion": {
+          "type": "string",
+          "description": "Version of the condition. Currently accepted value is '2.0'"
+        },
+        "justification": {
+          "type": "string",
+          "description": "Justification for the role assignment"
+        },
+        "linkedRoleEligibilityScheduleId": {
+          "type": "string",
+          "description": "The linked role eligibility schedule id - to activate an eligibility."
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID."
+        },
+        "requestType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "AdminAssign",
+                "AdminRemove",
+                "AdminUpdate",
+                "AdminExtend",
+                "AdminRenew",
+                "SelfActivate",
+                "SelfDeactivate",
+                "SelfExtend",
+                "SelfRenew"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of the role assignment schedule request. Eg: SelfActivate, AdminAssign etc."
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The role definition ID."
+        },
+        "scheduleInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentScheduleRequestPropertiesScheduleInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Schedule info of the role assignment schedule"
+        },
+        "targetRoleAssignmentScheduleId": {
+          "type": "string",
+          "description": "The resultant role assignment schedule id or the role assignment schedule id being updated"
+        },
+        "targetRoleAssignmentScheduleInstanceId": {
+          "type": "string",
+          "description": "The role assignment schedule instance id being updated"
+        },
+        "ticketInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentScheduleRequestPropertiesTicketInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Ticket Info of the role assignment"
+        }
+      },
+      "required": [
+        "principalId",
+        "requestType",
+        "roleDefinitionId"
+      ],
+      "description": "Role assignment schedule request properties with scope."
+    },
+    "RoleAssignmentScheduleRequestPropertiesScheduleInfo": {
+      "type": "object",
+      "properties": {
+        "expiration": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentScheduleRequestPropertiesScheduleInfoExpiration"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Expiration of the role assignment schedule"
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Start DateTime of the role assignment schedule."
+        }
+      },
+      "description": "Schedule info of the role assignment schedule"
+    },
+    "RoleAssignmentScheduleRequestPropertiesScheduleInfoExpiration": {
+      "type": "object",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "description": "Duration of the role assignment schedule in TimeSpan."
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "End DateTime of the role assignment schedule."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "AfterDuration",
+                "AfterDateTime",
+                "NoExpiration"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Type of the role assignment schedule expiration."
+        }
+      },
+      "description": "Expiration of the role assignment schedule"
+    },
+    "RoleAssignmentScheduleRequestPropertiesTicketInfo": {
+      "type": "object",
+      "properties": {
+        "ticketNumber": {
+          "type": "string",
+          "description": "Ticket number for the role assignment"
+        },
+        "ticketSystem": {
+          "type": "string",
+          "description": "Ticket system name for the role assignment"
+        }
+      },
+      "description": "Ticket Info of the role assignment"
+    },
+    "RoleEligibilityScheduleRequestProperties": {
+      "type": "object",
+      "properties": {
+        "condition": {
+          "type": "string",
+          "description": "The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase 'foo_storage_container'"
+        },
+        "conditionVersion": {
+          "type": "string",
+          "description": "Version of the condition. Currently accepted value is '2.0'"
+        },
+        "justification": {
+          "type": "string",
+          "description": "Justification for the role eligibility"
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID."
+        },
+        "requestType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "AdminAssign",
+                "AdminRemove",
+                "AdminUpdate",
+                "AdminExtend",
+                "AdminRenew",
+                "SelfActivate",
+                "SelfDeactivate",
+                "SelfExtend",
+                "SelfRenew"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of the role assignment schedule request. Eg: SelfActivate, AdminAssign etc."
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The role definition ID."
+        },
+        "scheduleInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleEligibilityScheduleRequestPropertiesScheduleInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Schedule info of the role eligibility schedule"
+        },
+        "targetRoleEligibilityScheduleId": {
+          "type": "string",
+          "description": "The resultant role eligibility schedule id or the role eligibility schedule id being updated"
+        },
+        "targetRoleEligibilityScheduleInstanceId": {
+          "type": "string",
+          "description": "The role eligibility schedule instance id being updated"
+        },
+        "ticketInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleEligibilityScheduleRequestPropertiesTicketInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Ticket Info of the role eligibility"
+        }
+      },
+      "required": [
+        "principalId",
+        "requestType",
+        "roleDefinitionId"
+      ],
+      "description": "Role eligibility schedule request properties with scope."
+    },
+    "RoleEligibilityScheduleRequestPropertiesScheduleInfo": {
+      "type": "object",
+      "properties": {
+        "expiration": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleEligibilityScheduleRequestPropertiesScheduleInfoExpiration"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Expiration of the role eligibility schedule"
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Start DateTime of the role eligibility schedule."
+        }
+      },
+      "description": "Schedule info of the role eligibility schedule"
+    },
+    "RoleEligibilityScheduleRequestPropertiesScheduleInfoExpiration": {
+      "type": "object",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "description": "Duration of the role eligibility schedule in TimeSpan."
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "End DateTime of the role eligibility schedule."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "AfterDuration",
+                "AfterDateTime",
+                "NoExpiration"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Type of the role eligibility schedule expiration."
+        }
+      },
+      "description": "Expiration of the role eligibility schedule"
+    },
+    "RoleEligibilityScheduleRequestPropertiesTicketInfo": {
+      "type": "object",
+      "properties": {
+        "ticketNumber": {
+          "type": "string",
+          "description": "Ticket number for the role eligibility"
+        },
+        "ticketSystem": {
+          "type": "string",
+          "description": "Ticket system name for the role eligibility"
+        }
+      },
+      "description": "Ticket Info of the role eligibility"
+    },
+    "RoleManagementPolicyAssignmentProperties": {
+      "type": "object",
+      "properties": {
+        "policyId": {
+          "type": "string",
+          "description": "The policy id role management policy assignment."
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The role definition of management policy assignment."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The role management policy scope."
+        }
+      },
+      "description": "Role management policy assignment properties with scope."
+    }
+  }
+}

--- a/schemas/2020-10-01/Microsoft.Authorization.Authz.json
+++ b/schemas/2020-10-01/Microsoft.Authorization.Authz.json
@@ -1,0 +1,450 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Authorization.Authz.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Authorization",
+  "description": "Microsoft Authorization Resource Types",
+  "resourceDefinitions": {},
+  "unknown_resourceDefinitions": {
+    "roleAssignmentScheduleRequests": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-10-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "A GUID for the role assignment to create. The name must be unique and different for each role assignment."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentScheduleRequestProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role assignment schedule request properties with scope."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleAssignmentScheduleRequests"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleAssignmentScheduleRequests"
+    },
+    "roleEligibilityScheduleRequests": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-10-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the role eligibility to create. It can be any valid GUID."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleEligibilityScheduleRequestProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role eligibility schedule request properties with scope."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleEligibilityScheduleRequests"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleEligibilityScheduleRequests"
+    },
+    "roleManagementPolicyAssignments": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2020-10-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of format {guid_guid} the role management policy assignment to upsert."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleManagementPolicyAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role management policy assignment properties with scope."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleManagementPolicyAssignments"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleManagementPolicyAssignments"
+    }
+  },
+  "definitions": {
+    "RoleAssignmentScheduleRequestProperties": {
+      "type": "object",
+      "properties": {
+        "condition": {
+          "type": "string",
+          "description": "The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase 'foo_storage_container'"
+        },
+        "conditionVersion": {
+          "type": "string",
+          "description": "Version of the condition. Currently accepted value is '2.0'"
+        },
+        "justification": {
+          "type": "string",
+          "description": "Justification for the role assignment"
+        },
+        "linkedRoleEligibilityScheduleId": {
+          "type": "string",
+          "description": "The linked role eligibility schedule id - to activate an eligibility."
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID."
+        },
+        "requestType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "AdminAssign",
+                "AdminRemove",
+                "AdminUpdate",
+                "AdminExtend",
+                "AdminRenew",
+                "SelfActivate",
+                "SelfDeactivate",
+                "SelfExtend",
+                "SelfRenew"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of the role assignment schedule request. Eg: SelfActivate, AdminAssign etc."
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The role definition ID."
+        },
+        "scheduleInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentScheduleRequestPropertiesScheduleInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Schedule info of the role assignment schedule"
+        },
+        "targetRoleAssignmentScheduleId": {
+          "type": "string",
+          "description": "The resultant role assignment schedule id or the role assignment schedule id being updated"
+        },
+        "targetRoleAssignmentScheduleInstanceId": {
+          "type": "string",
+          "description": "The role assignment schedule instance id being updated"
+        },
+        "ticketInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentScheduleRequestPropertiesTicketInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Ticket Info of the role assignment"
+        }
+      },
+      "required": [
+        "principalId",
+        "requestType",
+        "roleDefinitionId"
+      ],
+      "description": "Role assignment schedule request properties with scope."
+    },
+    "RoleAssignmentScheduleRequestPropertiesScheduleInfo": {
+      "type": "object",
+      "properties": {
+        "expiration": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentScheduleRequestPropertiesScheduleInfoExpiration"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Expiration of the role assignment schedule"
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Start DateTime of the role assignment schedule."
+        }
+      },
+      "description": "Schedule info of the role assignment schedule"
+    },
+    "RoleAssignmentScheduleRequestPropertiesScheduleInfoExpiration": {
+      "type": "object",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "description": "Duration of the role assignment schedule in TimeSpan."
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "End DateTime of the role assignment schedule."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "AfterDuration",
+                "AfterDateTime",
+                "NoExpiration"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Type of the role assignment schedule expiration."
+        }
+      },
+      "description": "Expiration of the role assignment schedule"
+    },
+    "RoleAssignmentScheduleRequestPropertiesTicketInfo": {
+      "type": "object",
+      "properties": {
+        "ticketNumber": {
+          "type": "string",
+          "description": "Ticket number for the role assignment"
+        },
+        "ticketSystem": {
+          "type": "string",
+          "description": "Ticket system name for the role assignment"
+        }
+      },
+      "description": "Ticket Info of the role assignment"
+    },
+    "RoleEligibilityScheduleRequestProperties": {
+      "type": "object",
+      "properties": {
+        "condition": {
+          "type": "string",
+          "description": "The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase 'foo_storage_container'"
+        },
+        "conditionVersion": {
+          "type": "string",
+          "description": "Version of the condition. Currently accepted value is '2.0'"
+        },
+        "justification": {
+          "type": "string",
+          "description": "Justification for the role eligibility"
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID."
+        },
+        "requestType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "AdminAssign",
+                "AdminRemove",
+                "AdminUpdate",
+                "AdminExtend",
+                "AdminRenew",
+                "SelfActivate",
+                "SelfDeactivate",
+                "SelfExtend",
+                "SelfRenew"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of the role assignment schedule request. Eg: SelfActivate, AdminAssign etc."
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The role definition ID."
+        },
+        "scheduleInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleEligibilityScheduleRequestPropertiesScheduleInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Schedule info of the role eligibility schedule"
+        },
+        "targetRoleEligibilityScheduleId": {
+          "type": "string",
+          "description": "The resultant role eligibility schedule id or the role eligibility schedule id being updated"
+        },
+        "targetRoleEligibilityScheduleInstanceId": {
+          "type": "string",
+          "description": "The role eligibility schedule instance id being updated"
+        },
+        "ticketInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleEligibilityScheduleRequestPropertiesTicketInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Ticket Info of the role eligibility"
+        }
+      },
+      "required": [
+        "principalId",
+        "requestType",
+        "roleDefinitionId"
+      ],
+      "description": "Role eligibility schedule request properties with scope."
+    },
+    "RoleEligibilityScheduleRequestPropertiesScheduleInfo": {
+      "type": "object",
+      "properties": {
+        "expiration": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleEligibilityScheduleRequestPropertiesScheduleInfoExpiration"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Expiration of the role eligibility schedule"
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Start DateTime of the role eligibility schedule."
+        }
+      },
+      "description": "Schedule info of the role eligibility schedule"
+    },
+    "RoleEligibilityScheduleRequestPropertiesScheduleInfoExpiration": {
+      "type": "object",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "description": "Duration of the role eligibility schedule in TimeSpan."
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "End DateTime of the role eligibility schedule."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "AfterDuration",
+                "AfterDateTime",
+                "NoExpiration"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Type of the role eligibility schedule expiration."
+        }
+      },
+      "description": "Expiration of the role eligibility schedule"
+    },
+    "RoleEligibilityScheduleRequestPropertiesTicketInfo": {
+      "type": "object",
+      "properties": {
+        "ticketNumber": {
+          "type": "string",
+          "description": "Ticket number for the role eligibility"
+        },
+        "ticketSystem": {
+          "type": "string",
+          "description": "Ticket system name for the role eligibility"
+        }
+      },
+      "description": "Ticket Info of the role eligibility"
+    },
+    "RoleManagementPolicyAssignmentProperties": {
+      "type": "object",
+      "properties": {
+        "policyId": {
+          "type": "string",
+          "description": "The policy id role management policy assignment."
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The role definition of management policy assignment."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The role management policy scope."
+        }
+      },
+      "description": "Role management policy assignment properties with scope."
+    }
+  }
+}

--- a/schemas/2021-01-01-preview/Microsoft.Authorization.Authz.json
+++ b/schemas/2021-01-01-preview/Microsoft.Authorization.Authz.json
@@ -1,0 +1,114 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2021-01-01-preview/Microsoft.Authorization.Authz.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Authorization",
+  "description": "Microsoft Authorization Resource Types",
+  "resourceDefinitions": {},
+  "tenant_resourceDefinitions": {
+    "roleAssignmentApprovals_stages": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-01-01-preview"
+          ]
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name for the approval stage."
+        },
+        "justification": {
+          "type": "string",
+          "description": "Justification provided by approvers for their action"
+        },
+        "name": {
+          "type": "string",
+          "description": "The id of the role assignment approval stage."
+        },
+        "reviewResult": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Approve",
+                "Deny",
+                "NotReviewed"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The decision on the approval stage. This value is initially set to NotReviewed. Approvers can take action of Approve/Deny."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleAssignmentApprovals/stages"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleAssignmentApprovals/stages"
+    }
+  },
+  "unknown_resourceDefinitions": {
+    "roleAssignmentApprovals_stages": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-01-01-preview"
+          ]
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name for the approval stage."
+        },
+        "justification": {
+          "type": "string",
+          "description": "Justification provided by approvers for their action"
+        },
+        "name": {
+          "type": "string",
+          "description": "The id of the role assignment approval stage."
+        },
+        "reviewResult": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Approve",
+                "Deny",
+                "NotReviewed"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The decision on the approval stage. This value is initially set to NotReviewed. Approvers can take action of Approve/Deny."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleAssignmentApprovals/stages"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleAssignmentApprovals/stages"
+    }
+  },
+  "definitions": {}
+}

--- a/schemas/2021-03-01-preview/Microsoft.Authorization.Authz.json
+++ b/schemas/2021-03-01-preview/Microsoft.Authorization.Authz.json
@@ -1,0 +1,492 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2021-03-01-preview/Microsoft.Authorization.Authz.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Authorization",
+  "description": "Microsoft Authorization Resource Types",
+  "resourceDefinitions": {},
+  "subscription_resourceDefinitions": {
+    "accessReviewScheduleDefinitions": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-03-01-preview"
+          ]
+        },
+        "backupReviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of backup reviewers."
+        },
+        "descriptionForAdmins": {
+          "type": "string",
+          "description": "The description provided by the access review creator and visible to admins."
+        },
+        "descriptionForReviewers": {
+          "type": "string",
+          "description": "The description provided by the access review creator to be shown to reviewers."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name for the schedule definition."
+        },
+        "instances": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewInstance"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of instances returned when one does an expand on it."
+        },
+        "name": {
+          "type": "string",
+          "description": "The id of the access review schedule definition."
+        },
+        "reviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of reviewers."
+        },
+        "settings": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewScheduleSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Settings of an Access Review."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/accessReviewScheduleDefinitions"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/accessReviewScheduleDefinitions"
+    },
+    "accessReviewScheduleSettings": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-03-01-preview"
+          ]
+        },
+        "autoApplyDecisionsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether auto-apply capability, to automatically change the target object access resource, is enabled. If not enabled, a user must, after the review completes, apply the access review."
+        },
+        "defaultDecision": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Approve",
+                "Deny",
+                "Recommendation"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This specifies the behavior for the autoReview feature when an access review completes."
+        },
+        "defaultDecisionEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether reviewers are required to provide a justification when reviewing access."
+        },
+        "instanceDurationInDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The duration in days for an instance."
+        },
+        "justificationRequiredOnApproval": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether the reviewer is required to pass justification when recording a decision."
+        },
+        "mailNotificationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether sending mails to reviewers and the review creator is enabled."
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "default"
+          ]
+        },
+        "recommendationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether showing recommendations to reviewers is enabled."
+        },
+        "recurrence": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrenceSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Settings of an Access Review Schedule Definition."
+        },
+        "reminderNotificationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether sending reminder emails to reviewers are enabled."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/accessReviewScheduleSettings"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/accessReviewScheduleSettings"
+    }
+  },
+  "definitions": {
+    "AccessReviewInstance": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewInstanceProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Access Review Instance properties."
+        }
+      },
+      "description": "Access Review Instance."
+    },
+    "AccessReviewInstanceProperties": {
+      "type": "object",
+      "properties": {
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review instance is scheduled to end."
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review instance is scheduled to be start."
+        }
+      },
+      "description": "Access Review Instance properties."
+    },
+    "AccessReviewRecurrencePattern": {
+      "type": "object",
+      "properties": {
+        "interval": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The interval for recurrence. For a quarterly review, the interval is 3 for type : absoluteMonthly."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "weekly",
+                "absoluteMonthly"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The recurrence type : weekly, monthly, etc."
+        }
+      },
+      "description": "Recurrence Pattern of an Access Review Schedule Definition."
+    },
+    "AccessReviewRecurrenceRange": {
+      "type": "object",
+      "properties": {
+        "endDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review is scheduled to end. Required if type is endDate"
+        },
+        "numberOfOccurrences": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The number of times to repeat the access review. Required and must be positive if type is numbered."
+        },
+        "startDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review is scheduled to be start. This could be a date in the future. Required on create."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "endDate",
+                "noEnd",
+                "numbered"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The recurrence range type. The possible values are: endDate, noEnd, numbered."
+        }
+      },
+      "description": "Recurrence Range of an Access Review Schedule Definition."
+    },
+    "AccessReviewRecurrenceSettings": {
+      "type": "object",
+      "properties": {
+        "pattern": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrencePattern"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Pattern of an Access Review Schedule Definition."
+        },
+        "range": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrenceRange"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Range of an Access Review Schedule Definition."
+        }
+      },
+      "description": "Recurrence Settings of an Access Review Schedule Definition."
+    },
+    "AccessReviewReviewer": {
+      "type": "object",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "The id of the reviewer(user/servicePrincipal)"
+        }
+      },
+      "description": "Descriptor for what needs to be reviewed"
+    },
+    "AccessReviewScheduleSettings": {
+      "type": "object",
+      "properties": {
+        "autoApplyDecisionsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether auto-apply capability, to automatically change the target object access resource, is enabled. If not enabled, a user must, after the review completes, apply the access review."
+        },
+        "defaultDecision": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Approve",
+                "Deny",
+                "Recommendation"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This specifies the behavior for the autoReview feature when an access review completes."
+        },
+        "defaultDecisionEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether reviewers are required to provide a justification when reviewing access."
+        },
+        "instanceDurationInDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The duration in days for an instance."
+        },
+        "justificationRequiredOnApproval": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether the reviewer is required to pass justification when recording a decision."
+        },
+        "mailNotificationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether sending mails to reviewers and the review creator is enabled."
+        },
+        "recommendationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether showing recommendations to reviewers is enabled."
+        },
+        "recurrence": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrenceSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Settings of an Access Review Schedule Definition."
+        },
+        "reminderNotificationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether sending reminder emails to reviewers are enabled."
+        }
+      },
+      "description": "Settings of an Access Review."
+    }
+  }
+}

--- a/schemas/2021-07-01-preview/Microsoft.Authorization.Authz.json
+++ b/schemas/2021-07-01-preview/Microsoft.Authorization.Authz.json
@@ -1,0 +1,665 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2021-07-01-preview/Microsoft.Authorization.Authz.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Authorization",
+  "description": "Microsoft Authorization Resource Types",
+  "resourceDefinitions": {},
+  "subscription_resourceDefinitions": {
+    "accessReviewScheduleDefinitions": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-07-01-preview"
+          ]
+        },
+        "backupReviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of backup reviewers."
+        },
+        "descriptionForAdmins": {
+          "type": "string",
+          "description": "The description provided by the access review creator and visible to admins."
+        },
+        "descriptionForReviewers": {
+          "type": "string",
+          "description": "The description provided by the access review creator to be shown to reviewers."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name for the schedule definition."
+        },
+        "instances": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewInstance"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of instances returned when one does an expand on it."
+        },
+        "name": {
+          "type": "string",
+          "description": "The id of the access review schedule definition."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/accessReviewScheduleDefinitions_instances_childResource"
+              }
+            ]
+          }
+        },
+        "reviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of reviewers."
+        },
+        "settings": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewScheduleSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Settings of an Access Review."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/accessReviewScheduleDefinitions"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/accessReviewScheduleDefinitions"
+    },
+    "accessReviewScheduleDefinitions_instances": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-07-01-preview"
+          ]
+        },
+        "backupReviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of backup reviewers."
+        },
+        "endDateTime": {
+          "type": "string",
+          "description": "The DateTime when the review instance is scheduled to end."
+        },
+        "name": {
+          "type": "string",
+          "description": "The id of the access review instance."
+        },
+        "reviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of reviewers."
+        },
+        "startDateTime": {
+          "type": "string",
+          "description": "The DateTime when the review instance is scheduled to be start."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/accessReviewScheduleDefinitions/instances"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/accessReviewScheduleDefinitions/instances"
+    },
+    "accessReviewScheduleSettings": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-07-01-preview"
+          ]
+        },
+        "autoApplyDecisionsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether auto-apply capability, to automatically change the target object access resource, is enabled. If not enabled, a user must, after the review completes, apply the access review."
+        },
+        "defaultDecision": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Approve",
+                "Deny",
+                "Recommendation"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This specifies the behavior for the autoReview feature when an access review completes."
+        },
+        "defaultDecisionEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether reviewers are required to provide a justification when reviewing access."
+        },
+        "instanceDurationInDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The duration in days for an instance."
+        },
+        "justificationRequiredOnApproval": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether the reviewer is required to pass justification when recording a decision."
+        },
+        "mailNotificationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether sending mails to reviewers and the review creator is enabled."
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "default"
+          ]
+        },
+        "recommendationLookBackDuration": {
+          "type": "string",
+          "description": "Recommendations for access reviews are calculated by looking back at 30 days of data(w.r.t the start date of the review) by default. However, in some scenarios, customers want to change how far back to look at and want to configure 60 days, 90 days, etc. instead. This setting allows customers to configure this duration. The value should be in ISO  8601 format (http://en.wikipedia.org/wiki/ISO_8601#Durations).This code can be used to convert TimeSpan to a valid interval string: XmlConvert.ToString(new TimeSpan(hours, minutes, seconds))"
+        },
+        "recommendationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether showing recommendations to reviewers is enabled."
+        },
+        "recurrence": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrenceSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Settings of an Access Review Schedule Definition."
+        },
+        "reminderNotificationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether sending reminder emails to reviewers are enabled."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/accessReviewScheduleSettings"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/accessReviewScheduleSettings"
+    }
+  },
+  "definitions": {
+    "AccessReviewInstance": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewInstanceProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Access Review Instance properties."
+        }
+      },
+      "description": "Access Review Instance."
+    },
+    "AccessReviewInstanceProperties": {
+      "type": "object",
+      "properties": {
+        "backupReviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of backup reviewers."
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review instance is scheduled to end."
+        },
+        "reviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of reviewers."
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review instance is scheduled to be start."
+        }
+      },
+      "description": "Access Review Instance properties."
+    },
+    "AccessReviewRecurrencePattern": {
+      "type": "object",
+      "properties": {
+        "interval": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The interval for recurrence. For a quarterly review, the interval is 3 for type : absoluteMonthly."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "weekly",
+                "absoluteMonthly"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The recurrence type : weekly, monthly, etc."
+        }
+      },
+      "description": "Recurrence Pattern of an Access Review Schedule Definition."
+    },
+    "AccessReviewRecurrenceRange": {
+      "type": "object",
+      "properties": {
+        "endDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review is scheduled to end. Required if type is endDate"
+        },
+        "numberOfOccurrences": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The number of times to repeat the access review. Required and must be positive if type is numbered."
+        },
+        "startDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review is scheduled to be start. This could be a date in the future. Required on create."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "endDate",
+                "noEnd",
+                "numbered"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The recurrence range type. The possible values are: endDate, noEnd, numbered."
+        }
+      },
+      "description": "Recurrence Range of an Access Review Schedule Definition."
+    },
+    "AccessReviewRecurrenceSettings": {
+      "type": "object",
+      "properties": {
+        "pattern": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrencePattern"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Pattern of an Access Review Schedule Definition."
+        },
+        "range": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrenceRange"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Range of an Access Review Schedule Definition."
+        }
+      },
+      "description": "Recurrence Settings of an Access Review Schedule Definition."
+    },
+    "AccessReviewReviewer": {
+      "type": "object",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "The id of the reviewer(user/servicePrincipal)"
+        }
+      },
+      "description": "Descriptor for what needs to be reviewed"
+    },
+    "accessReviewScheduleDefinitions_instances_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-07-01-preview"
+          ]
+        },
+        "backupReviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of backup reviewers."
+        },
+        "endDateTime": {
+          "type": "string",
+          "description": "The DateTime when the review instance is scheduled to end."
+        },
+        "name": {
+          "type": "string",
+          "description": "The id of the access review instance."
+        },
+        "reviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of reviewers."
+        },
+        "startDateTime": {
+          "type": "string",
+          "description": "The DateTime when the review instance is scheduled to be start."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "instances"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/accessReviewScheduleDefinitions/instances"
+    },
+    "AccessReviewScheduleSettings": {
+      "type": "object",
+      "properties": {
+        "autoApplyDecisionsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether auto-apply capability, to automatically change the target object access resource, is enabled. If not enabled, a user must, after the review completes, apply the access review."
+        },
+        "defaultDecision": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Approve",
+                "Deny",
+                "Recommendation"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This specifies the behavior for the autoReview feature when an access review completes."
+        },
+        "defaultDecisionEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether reviewers are required to provide a justification when reviewing access."
+        },
+        "instanceDurationInDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The duration in days for an instance."
+        },
+        "justificationRequiredOnApproval": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether the reviewer is required to pass justification when recording a decision."
+        },
+        "mailNotificationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether sending mails to reviewers and the review creator is enabled."
+        },
+        "recommendationLookBackDuration": {
+          "type": "string",
+          "format": "duration",
+          "description": "Recommendations for access reviews are calculated by looking back at 30 days of data(w.r.t the start date of the review) by default. However, in some scenarios, customers want to change how far back to look at and want to configure 60 days, 90 days, etc. instead. This setting allows customers to configure this duration. The value should be in ISO  8601 format (http://en.wikipedia.org/wiki/ISO_8601#Durations).This code can be used to convert TimeSpan to a valid interval string: XmlConvert.ToString(new TimeSpan(hours, minutes, seconds))"
+        },
+        "recommendationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether showing recommendations to reviewers is enabled."
+        },
+        "recurrence": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrenceSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Settings of an Access Review Schedule Definition."
+        },
+        "reminderNotificationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether sending reminder emails to reviewers are enabled."
+        }
+      },
+      "description": "Settings of an Access Review."
+    }
+  }
+}

--- a/schemas/2021-11-16-preview/Microsoft.Authorization.Authz.json
+++ b/schemas/2021-11-16-preview/Microsoft.Authorization.Authz.json
@@ -1,0 +1,858 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2021-11-16-preview/Microsoft.Authorization.Authz.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Authorization",
+  "description": "Microsoft Authorization Resource Types",
+  "resourceDefinitions": {},
+  "subscription_resourceDefinitions": {
+    "accessReviewHistoryDefinitions": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-11-16-preview"
+          ]
+        },
+        "decisions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "Approve",
+                  "Deny",
+                  "NotReviewed",
+                  "DontKnow",
+                  "NotNotified"
+                ]
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Collection of review decisions which the history data should be filtered on. For example if Approve and Deny are supplied the data will only contain review results in which the decision maker approved or denied a review request."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name for the history definition."
+        },
+        "instances": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewHistoryInstance"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Set of access review history instances for this history definition."
+        },
+        "name": {
+          "type": "string",
+          "description": "The id of the access review history definition."
+        },
+        "scopes": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewScope"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "A collection of scopes used when selecting review history data"
+        },
+        "settings": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewHistoryScheduleSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence settings of an Access Review History Definition."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/accessReviewHistoryDefinitions"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/accessReviewHistoryDefinitions"
+    },
+    "accessReviewScheduleDefinitions": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-11-16-preview"
+          ]
+        },
+        "backupReviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of backup reviewers."
+        },
+        "descriptionForAdmins": {
+          "type": "string",
+          "description": "The description provided by the access review creator and visible to admins."
+        },
+        "descriptionForReviewers": {
+          "type": "string",
+          "description": "The description provided by the access review creator to be shown to reviewers."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name for the schedule definition."
+        },
+        "instances": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewInstance"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of instances returned when one does an expand on it."
+        },
+        "name": {
+          "type": "string",
+          "description": "The id of the access review schedule definition."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/accessReviewScheduleDefinitions_instances_childResource"
+              }
+            ]
+          }
+        },
+        "reviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of reviewers."
+        },
+        "settings": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewScheduleSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Settings of an Access Review."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/accessReviewScheduleDefinitions"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/accessReviewScheduleDefinitions"
+    },
+    "accessReviewScheduleDefinitions_instances": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-11-16-preview"
+          ]
+        },
+        "backupReviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of backup reviewers."
+        },
+        "endDateTime": {
+          "type": "string",
+          "description": "The DateTime when the review instance is scheduled to end."
+        },
+        "name": {
+          "type": "string",
+          "description": "The id of the access review instance."
+        },
+        "reviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of reviewers."
+        },
+        "startDateTime": {
+          "type": "string",
+          "description": "The DateTime when the review instance is scheduled to be start."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/accessReviewScheduleDefinitions/instances"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/accessReviewScheduleDefinitions/instances"
+    },
+    "accessReviewScheduleSettings": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-11-16-preview"
+          ]
+        },
+        "autoApplyDecisionsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether auto-apply capability, to automatically change the target object access resource, is enabled. If not enabled, a user must, after the review completes, apply the access review."
+        },
+        "defaultDecision": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Approve",
+                "Deny",
+                "Recommendation"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This specifies the behavior for the autoReview feature when an access review completes."
+        },
+        "defaultDecisionEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether reviewers are required to provide a justification when reviewing access."
+        },
+        "instanceDurationInDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The duration in days for an instance."
+        },
+        "justificationRequiredOnApproval": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether the reviewer is required to pass justification when recording a decision."
+        },
+        "mailNotificationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether sending mails to reviewers and the review creator is enabled."
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "default"
+          ]
+        },
+        "recommendationLookBackDuration": {
+          "type": "string",
+          "description": "Recommendations for access reviews are calculated by looking back at 30 days of data(w.r.t the start date of the review) by default. However, in some scenarios, customers want to change how far back to look at and want to configure 60 days, 90 days, etc. instead. This setting allows customers to configure this duration. The value should be in ISO  8601 format (http://en.wikipedia.org/wiki/ISO_8601#Durations).This code can be used to convert TimeSpan to a valid interval string: XmlConvert.ToString(new TimeSpan(hours, minutes, seconds))"
+        },
+        "recommendationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether showing recommendations to reviewers is enabled."
+        },
+        "recurrence": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrenceSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Settings of an Access Review Schedule Definition."
+        },
+        "reminderNotificationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether sending reminder emails to reviewers are enabled."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/accessReviewScheduleSettings"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/accessReviewScheduleSettings"
+    }
+  },
+  "definitions": {
+    "AccessReviewHistoryInstance": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewHistoryInstanceProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Access Review History Definition Instance properties."
+        }
+      },
+      "description": "Access Review History Definition Instance."
+    },
+    "AccessReviewHistoryInstanceProperties": {
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "The display name for the parent history definition."
+        },
+        "expiration": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date time when history data report expires and the associated data is deleted."
+        },
+        "fulfilledDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date time when the history data report is scheduled to be generated."
+        },
+        "reviewHistoryPeriodEndDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date time used when selecting review data, all reviews included in data end on or before this date. For use only with one-time/non-recurring reports."
+        },
+        "reviewHistoryPeriodStartDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date time used when selecting review data, all reviews included in data start on or after this date. For use only with one-time/non-recurring reports."
+        },
+        "runDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date time when the history data report is scheduled to be generated."
+        }
+      },
+      "description": "Access Review History Definition Instance properties."
+    },
+    "AccessReviewHistoryScheduleSettings": {
+      "type": "object",
+      "properties": {
+        "pattern": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrencePattern"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Pattern of an Access Review Schedule Definition."
+        },
+        "range": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrenceRange"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Range of an Access Review Schedule Definition."
+        }
+      },
+      "description": "Recurrence settings of an Access Review History Definition."
+    },
+    "AccessReviewInstance": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewInstanceProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Access Review Instance properties."
+        }
+      },
+      "description": "Access Review Instance."
+    },
+    "AccessReviewInstanceProperties": {
+      "type": "object",
+      "properties": {
+        "backupReviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of backup reviewers."
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review instance is scheduled to end."
+        },
+        "reviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of reviewers."
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review instance is scheduled to be start."
+        }
+      },
+      "description": "Access Review Instance properties."
+    },
+    "AccessReviewRecurrencePattern": {
+      "type": "object",
+      "properties": {
+        "interval": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The interval for recurrence. For a quarterly review, the interval is 3 for type : absoluteMonthly."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "weekly",
+                "absoluteMonthly"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The recurrence type : weekly, monthly, etc."
+        }
+      },
+      "description": "Recurrence Pattern of an Access Review Schedule Definition."
+    },
+    "AccessReviewRecurrenceRange": {
+      "type": "object",
+      "properties": {
+        "endDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review is scheduled to end. Required if type is endDate"
+        },
+        "numberOfOccurrences": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The number of times to repeat the access review. Required and must be positive if type is numbered."
+        },
+        "startDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The DateTime when the review is scheduled to be start. This could be a date in the future. Required on create."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "endDate",
+                "noEnd",
+                "numbered"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The recurrence range type. The possible values are: endDate, noEnd, numbered."
+        }
+      },
+      "description": "Recurrence Range of an Access Review Schedule Definition."
+    },
+    "AccessReviewRecurrenceSettings": {
+      "type": "object",
+      "properties": {
+        "pattern": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrencePattern"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Pattern of an Access Review Schedule Definition."
+        },
+        "range": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrenceRange"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Range of an Access Review Schedule Definition."
+        }
+      },
+      "description": "Recurrence Settings of an Access Review Schedule Definition."
+    },
+    "AccessReviewReviewer": {
+      "type": "object",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "The id of the reviewer(user/servicePrincipal)"
+        }
+      },
+      "description": "Descriptor for what needs to be reviewed"
+    },
+    "accessReviewScheduleDefinitions_instances_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2021-11-16-preview"
+          ]
+        },
+        "backupReviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of backup reviewers."
+        },
+        "endDateTime": {
+          "type": "string",
+          "description": "The DateTime when the review instance is scheduled to end."
+        },
+        "name": {
+          "type": "string",
+          "description": "The id of the access review instance."
+        },
+        "reviewers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessReviewReviewer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the collection of reviewers."
+        },
+        "startDateTime": {
+          "type": "string",
+          "description": "The DateTime when the review instance is scheduled to be start."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "instances"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/accessReviewScheduleDefinitions/instances"
+    },
+    "AccessReviewScheduleSettings": {
+      "type": "object",
+      "properties": {
+        "autoApplyDecisionsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether auto-apply capability, to automatically change the target object access resource, is enabled. If not enabled, a user must, after the review completes, apply the access review."
+        },
+        "defaultDecision": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Approve",
+                "Deny",
+                "Recommendation"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This specifies the behavior for the autoReview feature when an access review completes."
+        },
+        "defaultDecisionEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether reviewers are required to provide a justification when reviewing access."
+        },
+        "instanceDurationInDays": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The duration in days for an instance."
+        },
+        "justificationRequiredOnApproval": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether the reviewer is required to pass justification when recording a decision."
+        },
+        "mailNotificationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether sending mails to reviewers and the review creator is enabled."
+        },
+        "recommendationLookBackDuration": {
+          "type": "string",
+          "format": "duration",
+          "description": "Recommendations for access reviews are calculated by looking back at 30 days of data(w.r.t the start date of the review) by default. However, in some scenarios, customers want to change how far back to look at and want to configure 60 days, 90 days, etc. instead. This setting allows customers to configure this duration. The value should be in ISO  8601 format (http://en.wikipedia.org/wiki/ISO_8601#Durations).This code can be used to convert TimeSpan to a valid interval string: XmlConvert.ToString(new TimeSpan(hours, minutes, seconds))"
+        },
+        "recommendationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether showing recommendations to reviewers is enabled."
+        },
+        "recurrence": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AccessReviewRecurrenceSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Recurrence Settings of an Access Review Schedule Definition."
+        },
+        "reminderNotificationsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether sending reminder emails to reviewers are enabled."
+        }
+      },
+      "description": "Settings of an Access Review."
+    },
+    "AccessReviewScope": {
+      "type": "object",
+      "properties": {
+        "expandNestedMemberships": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flag to indicate whether to expand nested memberships or not."
+        },
+        "inactiveDuration": {
+          "type": "string",
+          "format": "duration",
+          "description": "Duration users are inactive for. The value should be in ISO  8601 format (http://en.wikipedia.org/wiki/ISO_8601#Durations).This code can be used to convert TimeSpan to a valid interval string: XmlConvert.ToString(new TimeSpan(hours, minutes, seconds))"
+        }
+      },
+      "description": "Descriptor for what needs to be reviewed"
+    }
+  }
+}

--- a/schemas/2022-04-01-preview/Microsoft.Authorization.Authz.json
+++ b/schemas/2022-04-01-preview/Microsoft.Authorization.Authz.json
@@ -1,0 +1,393 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2022-04-01-preview/Microsoft.Authorization.Authz.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.Authorization",
+  "description": "Microsoft Authorization Resource Types",
+  "resourceDefinitions": {},
+  "unknown_resourceDefinitions": {
+    "roleAssignmentScheduleRequests": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2022-04-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "A GUID for the role assignment to create. The name must be unique and different for each role assignment."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentScheduleRequestProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role assignment schedule request properties with scope."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleAssignmentScheduleRequests"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleAssignmentScheduleRequests"
+    },
+    "roleEligibilityScheduleRequests": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2022-04-01-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the role eligibility to create. It can be any valid GUID."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleEligibilityScheduleRequestProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Role eligibility schedule request properties with scope."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.Authorization/roleEligibilityScheduleRequests"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.Authorization/roleEligibilityScheduleRequests"
+    }
+  },
+  "definitions": {
+    "RoleAssignmentScheduleRequestProperties": {
+      "type": "object",
+      "properties": {
+        "condition": {
+          "type": "string",
+          "description": "The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase 'foo_storage_container'"
+        },
+        "conditionVersion": {
+          "type": "string",
+          "description": "Version of the condition. Currently accepted value is '2.0'"
+        },
+        "justification": {
+          "type": "string",
+          "description": "Justification for the role assignment"
+        },
+        "linkedRoleEligibilityScheduleId": {
+          "type": "string",
+          "description": "The linked role eligibility schedule id - to activate an eligibility."
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID."
+        },
+        "requestType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "AdminAssign",
+                "AdminRemove",
+                "AdminUpdate",
+                "AdminExtend",
+                "AdminRenew",
+                "SelfActivate",
+                "SelfDeactivate",
+                "SelfExtend",
+                "SelfRenew"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of the role assignment schedule request. Eg: SelfActivate, AdminAssign etc."
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The role definition ID."
+        },
+        "scheduleInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentScheduleRequestPropertiesScheduleInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Schedule info of the role assignment schedule"
+        },
+        "targetRoleAssignmentScheduleId": {
+          "type": "string",
+          "description": "The resultant role assignment schedule id or the role assignment schedule id being updated"
+        },
+        "targetRoleAssignmentScheduleInstanceId": {
+          "type": "string",
+          "description": "The role assignment schedule instance id being updated"
+        },
+        "ticketInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentScheduleRequestPropertiesTicketInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Ticket Info of the role assignment"
+        }
+      },
+      "required": [
+        "principalId",
+        "requestType",
+        "roleDefinitionId"
+      ],
+      "description": "Role assignment schedule request properties with scope."
+    },
+    "RoleAssignmentScheduleRequestPropertiesScheduleInfo": {
+      "type": "object",
+      "properties": {
+        "expiration": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleAssignmentScheduleRequestPropertiesScheduleInfoExpiration"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Expiration of the role assignment schedule"
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Start DateTime of the role assignment schedule."
+        }
+      },
+      "description": "Schedule info of the role assignment schedule"
+    },
+    "RoleAssignmentScheduleRequestPropertiesScheduleInfoExpiration": {
+      "type": "object",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "description": "Duration of the role assignment schedule in TimeSpan."
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "End DateTime of the role assignment schedule."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "AfterDuration",
+                "AfterDateTime",
+                "NoExpiration"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Type of the role assignment schedule expiration."
+        }
+      },
+      "description": "Expiration of the role assignment schedule"
+    },
+    "RoleAssignmentScheduleRequestPropertiesTicketInfo": {
+      "type": "object",
+      "properties": {
+        "ticketNumber": {
+          "type": "string",
+          "description": "Ticket number for the role assignment"
+        },
+        "ticketSystem": {
+          "type": "string",
+          "description": "Ticket system name for the role assignment"
+        }
+      },
+      "description": "Ticket Info of the role assignment"
+    },
+    "RoleEligibilityScheduleRequestProperties": {
+      "type": "object",
+      "properties": {
+        "condition": {
+          "type": "string",
+          "description": "The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase 'foo_storage_container'"
+        },
+        "conditionVersion": {
+          "type": "string",
+          "description": "Version of the condition. Currently accepted value is '2.0'"
+        },
+        "justification": {
+          "type": "string",
+          "description": "Justification for the role eligibility"
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID."
+        },
+        "requestType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "AdminAssign",
+                "AdminRemove",
+                "AdminUpdate",
+                "AdminExtend",
+                "AdminRenew",
+                "SelfActivate",
+                "SelfDeactivate",
+                "SelfExtend",
+                "SelfRenew"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of the role assignment schedule request. Eg: SelfActivate, AdminAssign etc."
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The role definition ID."
+        },
+        "scheduleInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleEligibilityScheduleRequestPropertiesScheduleInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Schedule info of the role eligibility schedule"
+        },
+        "targetRoleEligibilityScheduleId": {
+          "type": "string",
+          "description": "The resultant role eligibility schedule id or the role eligibility schedule id being updated"
+        },
+        "targetRoleEligibilityScheduleInstanceId": {
+          "type": "string",
+          "description": "The role eligibility schedule instance id being updated"
+        },
+        "ticketInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleEligibilityScheduleRequestPropertiesTicketInfo"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Ticket Info of the role eligibility"
+        }
+      },
+      "required": [
+        "principalId",
+        "requestType",
+        "roleDefinitionId"
+      ],
+      "description": "Role eligibility schedule request properties with scope."
+    },
+    "RoleEligibilityScheduleRequestPropertiesScheduleInfo": {
+      "type": "object",
+      "properties": {
+        "expiration": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RoleEligibilityScheduleRequestPropertiesScheduleInfoExpiration"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Expiration of the role eligibility schedule"
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Start DateTime of the role eligibility schedule."
+        }
+      },
+      "description": "Schedule info of the role eligibility schedule"
+    },
+    "RoleEligibilityScheduleRequestPropertiesScheduleInfoExpiration": {
+      "type": "object",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "description": "Duration of the role eligibility schedule in TimeSpan."
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "End DateTime of the role eligibility schedule."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "AfterDuration",
+                "AfterDateTime",
+                "NoExpiration"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Type of the role eligibility schedule expiration."
+        }
+      },
+      "description": "Expiration of the role eligibility schedule"
+    },
+    "RoleEligibilityScheduleRequestPropertiesTicketInfo": {
+      "type": "object",
+      "properties": {
+        "ticketNumber": {
+          "type": "string",
+          "description": "Ticket number for the role eligibility"
+        },
+        "ticketSystem": {
+          "type": "string",
+          "description": "Ticket system name for the role eligibility"
+        }
+      },
+      "description": "Ticket Info of the role eligibility"
+    }
+  }
+}

--- a/schemas/common/autogeneratedResources.json
+++ b/schemas/common/autogeneratedResources.json
@@ -2297,6 +2297,60 @@
           "$ref": "https://schema.management.azure.com/schemas/2021-06-01-preview/Microsoft.Attestation.json#/resourceDefinitions/attestationProviders_privateEndpointConnections"
         },
         {
+          "$ref": "https://schema.management.azure.com/schemas/2015-07-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2015-07-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleDefinitions"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2017-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-01-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-01-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleDefinitions"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-09-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-03-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-04-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-08-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignmentScheduleRequests"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleEligibilityScheduleRequests"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-10-01/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleManagementPolicyAssignments"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignments"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignmentScheduleRequests"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleEligibilityScheduleRequests"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleManagementPolicyAssignments"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2022-04-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleAssignmentScheduleRequests"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2022-04-01-preview/Microsoft.Authorization.Authz.json#/unknown_resourceDefinitions/roleEligibilityScheduleRequests"
+        },
+        {
           "$ref": "https://schema.management.azure.com/schemas/2015-01-01/Microsoft.Authorization.Resources.json#/resourceDefinitions/locks"
         },
         {


### PR DESCRIPTION
Reverts Azure/azure-resource-manager-schemas#2447

This is a temporary workaround to overcome the schemas deleted mentioned in this issue https://github.com/Azure/azure-resource-manager-schemas/issues/2462