### PR TITLE
Temporarily disable Authorization/Resource-Manager from autogen

### DIFF
--- a/generator/autogenlist.ts
+++ b/generator/autogenlist.ts
@@ -89,6 +89,7 @@ const disabledProviders: AutoGenConfig[] = [
         namespace: 'Microsoft.Media',
         disabledForAutogen: true,
     },
+    // Disabled because the swagger spec contains duplicate API paths and results in schema generation failures, see here for more info: https://github.com/Azure/azure-resource-manager-schemas/issues/2462
     {
         basePath: 'authorization/resource-manager',
         namespace: 'Microsoft.Authorization',

--- a/generator/autogenlist.ts
+++ b/generator/autogenlist.ts
@@ -89,6 +89,11 @@ const disabledProviders: AutoGenConfig[] = [
         namespace: 'Microsoft.Media',
         disabledForAutogen: true,
     },
+    {
+        basePath: 'authorization/resource-manager',
+        namespace: 'Microsoft.Authorization',
+        disabledForAutogen: true,
+    }
 ];
 
 // Run "npm run list-basepaths" to discover all the valid readme files to add to this list
@@ -649,37 +654,6 @@ const autoGenList: AutoGenConfig[] = [
         ],
         suffix: 'Resources',
         postProcessor: policyProcessor
-    },
-    {
-        basePath: 'authorization/resource-manager',
-        namespace: 'Microsoft.Authorization',
-        resourceConfig: [
-            {
-                type: 'roleAssignments',
-                scopes: ScopeType.Extension | ScopeType.ManagementGroup | ScopeType.ResourceGroup | ScopeType.Subcription | ScopeType.Tenant
-            },
-            {
-                type: 'roleDefinitions',
-                scopes: ScopeType.Extension | ScopeType.ManagementGroup | ScopeType.ResourceGroup | ScopeType.Subcription | ScopeType.Tenant
-            },
-            {
-                type: 'roleAssignmentScheduleRequests',
-                scopes: ScopeType.Extension | ScopeType.ManagementGroup | ScopeType.ResourceGroup | ScopeType.Subcription | ScopeType.Tenant
-            },
-            {
-                type: 'roleEligibilityScheduleRequests',
-                scopes: ScopeType.Extension | ScopeType.ManagementGroup | ScopeType.ResourceGroup | ScopeType.Subcription | ScopeType.Tenant
-            },
-            {
-                type: 'roleManagementPolicyAssignments',
-                scopes: ScopeType.Extension | ScopeType.ManagementGroup | ScopeType.ResourceGroup | ScopeType.Subcription | ScopeType.Tenant
-            },
-            {
-                type: 'roleAssignmentApprovals/stages',
-                scopes: ScopeType.Tenant
-            }
-        ],
-        suffix: 'Authz'
     },
     {
         basePath: 'relay/resource-manager',


### PR DESCRIPTION
Workaround to handle: https://github.com/Azure/azure-resource-manager-schemas/issues/2462

The following swagger spec PR introduced duplicate paths: https://github.com/Azure/azure-rest-api-specs/pull/16919 and as a result the schema generation failed, since the schema generation process first removes all existing schemas (to simplify handling deltas between specs) and proceeds to re-generate them, failing to re-generate schemas means that an RP will end up with existing schemas getting deleted.