### PR TITLE
[Microsoft.Insights] Remove cyclic reference

### DIFF
--- a/generator/processors/Microsoft.SecurityInsights.ts
+++ b/generator/processors/Microsoft.SecurityInsights.ts
@@ -5,4 +5,5 @@ import { replaceCyclicRef } from './helpers';
 
 export const postProcessor: SchemaPostProcessor = async (namespace, apiVersion, schema) => {
   replaceCyclicRef(schema.definitions?.MetadataDependencies?.properties?.criteria?.oneOf[0]?.items);
+  replaceCyclicRef(schema.definitions?.AutomationRuleCondition?.oneOf[0]);
 }


### PR DESCRIPTION
This PR fixes the following failure:

1) Validate individual resource schemas
       /home/runner/work/azure-resource-manager-schemas/azure-resource-manager-schemas/schemas/2022-09-01-preview/Microsoft.SecurityInsights.json
         does not contain any cycles:
     AssertionError: Found cycle #/definitions/AutomationRuleCondition -> #/definitions/BooleanConditionProperties -> #/definitions/AutomationRuleBooleanCondition -> #/definitions/AutomationRuleCondition: expected [ Array(4) ] to be undefined
      at Context.<anonymous> (tests.ts:192:68)