### PR TITLE
Add HDInsightOnAKS 2023 schemas

### DIFF
--- a/schemas/2019-04-01/deploymentTemplate.json
+++ b/schemas/2019-04-01/deploymentTemplate.json
@@ -661,7 +661,9 @@
                 { "$ref": "https://schema.management.azure.com/schemas/2022-05-05-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles" },
                 { "$ref": "https://schema.management.azure.com/schemas/2022-05-05-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles_segments" },
                 { "$ref": "https://schema.management.azure.com/schemas/2022-05-05-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles_titledatasets" },
-                { "$ref": "https://schema.management.azure.com/schemas/2022-05-05-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles_titleinternaldatasets" }
+                { "$ref": "https://schema.management.azure.com/schemas/2022-05-05-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles_titleinternaldatasets" },
+                { "$ref": "https://schema.management.azure.com/schemas/2023-06-01-preview/Microsoft.HDInsight.json#/resourceDefinitions/clusterpools" },
+                { "$ref": "https://schema.management.azure.com/schemas/2023-06-01-preview/Microsoft.HDInsight.json#/resourceDefinitions/clusterpools_clusters" }
               ]
             }
           ]

--- a/schemas/2023-06-01-preview/Microsoft.HDInsight.json
+++ b/schemas/2023-06-01-preview/Microsoft.HDInsight.json
@@ -1,0 +1,2143 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2023-06-01-preview/Microsoft.HDInsight.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.HDInsight",
+  "description": "Microsoft HDInsight Resource Types",
+  "resourceDefinitions": {
+    "clusterpools": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-06-01-preview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the cluster pool."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ClusterPoolResourceProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Cluster pool resource properties."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/clusterpools_clusters_childResource"
+              }
+            ]
+          }
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.HDInsight/clusterpools"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.HDInsight/clusterpools"
+    },
+    "clusterpools_clusters": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-06-01-preview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the HDInsight cluster."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ClusterResourceProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Cluster resource properties."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.HDInsight/clusterpools/clusters"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.HDInsight/clusterpools/clusters"
+    }
+  },
+  "definitions": {
+    "AuthorizationProfile": {
+      "type": "object",
+      "properties": {
+        "groupIds": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "AAD group Ids authorized for data plane access."
+        },
+        "userIds": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "AAD user Ids authorized for data plane access."
+        }
+      },
+      "description": "Authorization profile with details of AAD user Ids and group Ids authorized for data plane access."
+    },
+    "AutoscaleProfile": {
+      "type": "object",
+      "properties": {
+        "autoscaleType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "ScheduleBased",
+                "LoadBased"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "User to specify which type of Autoscale to be implemented - Scheduled Based or Load Based."
+        },
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This indicates whether auto scale is enabled on HDInsight on AKS cluster."
+        },
+        "gracefulDecommissionTimeout": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This property is for graceful decommission timeout; It has a default setting of 3600 seconds before forced shutdown takes place. This is the maximal time to wait for running containers and applications to complete before transition a DECOMMISSIONING node into DECOMMISSIONED. The default value is 3600 seconds. Negative value (like -1) is handled as infinite timeout."
+        },
+        "loadBasedConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/LoadBasedConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile of load based Autoscale."
+        },
+        "scheduleBasedConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ScheduleBasedConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile of schedule based Autoscale."
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "description": "This is the Autoscale profile for the cluster. This will allow customer to create cluster enabled with Autoscale."
+    },
+    "CatalogOptions": {
+      "type": "object",
+      "properties": {
+        "hive": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/HiveCatalogOption"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "hive catalog options."
+        }
+      },
+      "description": "Trino cluster catalog options."
+    },
+    "ClusterComponentsItem": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "ClusterConfigFile": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string",
+          "description": "Free form content of the entire configuration file."
+        },
+        "encoding": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Base64",
+                "None"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This property indicates if the content is encoded and is case-insensitive. Please set the value to base64 if the content is base64 encoded. Set it to none or skip it if the content is plain text."
+        },
+        "fileName": {
+          "type": "string",
+          "description": "Configuration file name."
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of the config file if content is specified."
+        },
+        "values": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of key value pairs\nwhere key represents a valid service configuration name and value represents the value of the config."
+        }
+      },
+      "required": [
+        "fileName"
+      ],
+      "description": "Cluster configuration files."
+    },
+    "ClusterLogAnalyticsApplicationLogs": {
+      "type": "object",
+      "properties": {
+        "stdErrorEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "True if stderror is enabled, otherwise false."
+        },
+        "stdOutEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "True if stdout is enabled, otherwise false."
+        }
+      },
+      "description": "Collection of logs to be enabled or disabled for log analytics."
+    },
+    "ClusterLogAnalyticsProfile": {
+      "type": "object",
+      "properties": {
+        "applicationLogs": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ClusterLogAnalyticsApplicationLogs"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Collection of logs to be enabled or disabled for log analytics."
+        },
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "True if log analytics is enabled for the cluster, otherwise false."
+        },
+        "metricsEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "True if metrics are enabled, otherwise false."
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "description": "Cluster log analytics profile to enable or disable OMS agent for cluster."
+    },
+    "ClusterPoolResourceProperties": {
+      "type": "object",
+      "properties": {
+        "clusterPoolProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ClusterPoolResourcePropertiesClusterPoolProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "CLuster pool profile."
+        },
+        "computeProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ClusterPoolResourcePropertiesComputeProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "CLuster pool compute profile."
+        },
+        "logAnalyticsProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ClusterPoolResourcePropertiesLogAnalyticsProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Cluster pool log analytics profile to enable OMS agent for AKS cluster."
+        },
+        "managedResourceGroupName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40,
+          "description": "A resource group created by RP, to hold the resources created by RP on-behalf of customers. It will also be used to generate aksManagedResourceGroupName by pattern: MC_{managedResourceGroupName}_{clusterPoolName}_{region}. Please make sure it meets resource group name restriction."
+        },
+        "networkProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ClusterPoolResourcePropertiesNetworkProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Cluster pool network profile."
+        }
+      },
+      "required": [
+        "computeProfile"
+      ],
+      "description": "Cluster pool resource properties."
+    },
+    "ClusterPoolResourcePropertiesClusterPoolProfile": {
+      "type": "object",
+      "properties": {
+        "clusterPoolVersion": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(0|[1-9][0-9]{0,18})\\.(0|[1-9][0-9]{0,18})$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Cluster pool version is a 2-part version."
+        }
+      },
+      "required": [
+        "clusterPoolVersion"
+      ],
+      "description": "CLuster pool profile."
+    },
+    "ClusterPoolResourcePropertiesComputeProfile": {
+      "type": "object",
+      "properties": {
+        "vmSize": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9_\\-]{0,256}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The virtual machine SKU."
+        }
+      },
+      "required": [
+        "vmSize"
+      ],
+      "description": "CLuster pool compute profile."
+    },
+    "ClusterPoolResourcePropertiesLogAnalyticsProfile": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "True if log analytics is enabled for cluster pool, otherwise false."
+        },
+        "workspaceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Log analytics workspace to associate with the OMS agent."
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "description": "Cluster pool log analytics profile to enable OMS agent for AKS cluster."
+    },
+    "ClusterPoolResourcePropertiesNetworkProfile": {
+      "type": "object",
+      "properties": {
+        "subnetId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Cluster pool subnet resource id."
+        }
+      },
+      "required": [
+        "subnetId"
+      ],
+      "description": "Cluster pool network profile."
+    },
+    "clusterpools_clusters_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-06-01-preview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the HDInsight cluster."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ClusterResourceProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Cluster resource properties."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "clusters"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.HDInsight/clusterpools/clusters"
+    },
+    "ClusterProfile": {
+      "type": "object",
+      "properties": {
+        "authorizationProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AuthorizationProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Authorization profile with details of AAD user Ids and group Ids authorized for data plane access."
+        },
+        "autoscaleProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AutoscaleProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is the Autoscale profile for the cluster. This will allow customer to create cluster enabled with Autoscale."
+        },
+        "clusterVersion": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(0|[1-9][0-9]{0,18})\\.(0|[1-9][0-9]{0,18})\\.(0|[1-9][0-9]{0,18})(?:\\.(0|[1-9][0-9]{0,18}))?$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Version with 3/4 part."
+        },
+        "components": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ClusterComponentsItem"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Component list of this cluster type and version."
+        },
+        "connectivityProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ConnectivityProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Cluster connectivity profile."
+        },
+        "flinkProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FlinkProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The Flink cluster profile."
+        },
+        "identityProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/IdentityProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Identity Profile with details of an MSI."
+        },
+        "kafkaProfile": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {}
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Kafka cluster profile."
+        },
+        "llapProfile": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {}
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "LLAP cluster profile."
+        },
+        "logAnalyticsProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ClusterLogAnalyticsProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Cluster log analytics profile to enable or disable OMS agent for cluster."
+        },
+        "ossVersion": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(0|[1-9][0-9]{0,18})\\.(0|[1-9][0-9]{0,18})\\.(0|[1-9][0-9]{0,18})$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Version with three part."
+        },
+        "prometheusProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ClusterPrometheusProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Cluster Prometheus profile."
+        },
+        "scriptActionProfiles": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ScriptActionProfile"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The script action profile list."
+        },
+        "secretsProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SecretsProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The cluster secret profile."
+        },
+        "serviceConfigsProfiles": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ClusterServiceConfigsProfile"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The service configs profiles."
+        },
+        "sparkProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SparkProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The spark cluster profile."
+        },
+        "sshProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SshProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Ssh profile for the cluster."
+        },
+        "stubProfile": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {}
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Stub cluster profile."
+        },
+        "trinoProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TrinoProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Trino Cluster profile."
+        }
+      },
+      "required": [
+        "authorizationProfile",
+        "clusterVersion",
+        "identityProfile",
+        "ossVersion"
+      ],
+      "description": "Cluster profile."
+    },
+    "ClusterPrometheusProfile": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Enable Prometheus for cluster or not."
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "description": "Cluster Prometheus profile."
+    },
+    "ClusterResourceProperties": {
+      "type": "object",
+      "properties": {
+        "clusterProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ClusterProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Cluster profile."
+        },
+        "clusterType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z0-9]{0,31}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of cluster."
+        },
+        "computeProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ComputeProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The compute profile."
+        }
+      },
+      "required": [
+        "clusterProfile",
+        "clusterType",
+        "computeProfile"
+      ],
+      "description": "Cluster resource properties."
+    },
+    "ClusterServiceConfig": {
+      "type": "object",
+      "properties": {
+        "component": {
+          "type": "string",
+          "description": "Name of the component the config files should apply to."
+        },
+        "files": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ClusterConfigFile"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of Config Files."
+        }
+      },
+      "required": [
+        "component",
+        "files"
+      ],
+      "description": "Cluster configs per component."
+    },
+    "ClusterServiceConfigsProfile": {
+      "type": "object",
+      "properties": {
+        "configs": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ClusterServiceConfig"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of service configs."
+        },
+        "serviceName": {
+          "type": "string",
+          "description": "Name of the service the configurations should apply to."
+        }
+      },
+      "required": [
+        "configs",
+        "serviceName"
+      ],
+      "description": "Cluster service configs."
+    },
+    "ComparisonRule": {
+      "type": "object",
+      "properties": {
+        "operator": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "greaterThan",
+                "greaterThanOrEqual",
+                "lessThan",
+                "lessThanOrEqual"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The comparison operator."
+        },
+        "threshold": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Threshold setting."
+        }
+      },
+      "required": [
+        "operator",
+        "threshold"
+      ],
+      "description": "The comparison rule."
+    },
+    "ComputeProfile": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/NodeProfile"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The nodes definitions."
+        }
+      },
+      "required": [
+        "nodes"
+      ],
+      "description": "The compute profile."
+    },
+    "ComputeResourceDefinition": {
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The required CPU."
+        },
+        "memory": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The required memory in MB, Container memory will be 110 percentile"
+        }
+      },
+      "required": [
+        "cpu",
+        "memory"
+      ],
+      "description": "The cpu and memory requirement definition."
+    },
+    "ConnectivityProfile": {
+      "type": "object",
+      "properties": {
+        "ssh": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SshConnectivityEndpoint"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of SSH connectivity endpoints."
+        },
+        "web": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ConnectivityProfileWeb"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Web connectivity endpoint details."
+        }
+      },
+      "required": [
+        "web"
+      ],
+      "description": "Cluster connectivity profile."
+    },
+    "ConnectivityProfileWeb": {
+      "type": "object",
+      "properties": {
+        "fqdn": {
+          "type": "string",
+          "description": "Web connectivity endpoint."
+        }
+      },
+      "required": [
+        "fqdn"
+      ],
+      "description": "Web connectivity endpoint details."
+    },
+    "FlinkCatalogOptions": {
+      "type": "object",
+      "properties": {
+        "hive": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FlinkHiveCatalogOption"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Hive Catalog Option for Flink cluster."
+        }
+      },
+      "description": "Flink cluster catalog options."
+    },
+    "FlinkHiveCatalogOption": {
+      "type": "object",
+      "properties": {
+        "metastoreDbConnectionPasswordSecret": {
+          "type": "string",
+          "description": "Secret reference name from secretsProfile.secrets containing password for database connection."
+        },
+        "metastoreDbConnectionURL": {
+          "type": "string",
+          "description": "Connection string for hive metastore database."
+        },
+        "metastoreDbConnectionUserName": {
+          "type": "string",
+          "description": "User name for database connection."
+        }
+      },
+      "required": [
+        "metastoreDbConnectionPasswordSecret",
+        "metastoreDbConnectionURL",
+        "metastoreDbConnectionUserName"
+      ],
+      "description": "Hive Catalog Option for Flink cluster."
+    },
+    "FlinkProfile": {
+      "type": "object",
+      "properties": {
+        "catalogOptions": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FlinkCatalogOptions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Flink cluster catalog options."
+        },
+        "historyServer": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ComputeResourceDefinition"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The cpu and memory requirement definition."
+        },
+        "jobManager": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ComputeResourceDefinition"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The cpu and memory requirement definition."
+        },
+        "numReplicas": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The number of task managers."
+        },
+        "storage": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FlinkStorageProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The storage profile"
+        },
+        "taskManager": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ComputeResourceDefinition"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The cpu and memory requirement definition."
+        }
+      },
+      "required": [
+        "jobManager",
+        "storage",
+        "taskManager"
+      ],
+      "description": "The Flink cluster profile."
+    },
+    "FlinkStorageProfile": {
+      "type": "object",
+      "properties": {
+        "storagekey": {
+          "type": "string",
+          "description": "Storage key is only required for wasb(s) storage."
+        },
+        "storageUri": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(\\w{4,5})://(.*)@(.*).\\b(blob|dfs)\\b\\.core\\.windows\\.net$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Storage account uri which is used for savepoint and checkpoint state."
+        }
+      },
+      "required": [
+        "storageUri"
+      ],
+      "description": "The storage profile"
+    },
+    "HiveCatalogOption": {
+      "type": "object",
+      "properties": {
+        "catalogName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of trino catalog which should use specified hive metastore."
+        },
+        "metastoreDbConnectionPasswordSecret": {
+          "type": "string",
+          "description": "Secret reference name from secretsProfile.secrets containing password for database connection."
+        },
+        "metastoreDbConnectionURL": {
+          "type": "string",
+          "description": "Connection string for hive metastore database."
+        },
+        "metastoreDbConnectionUserName": {
+          "type": "string",
+          "description": "User name for database connection."
+        },
+        "metastoreWarehouseDir": {
+          "type": "string",
+          "description": "Metastore root directory URI, format: abfs[s]://<container>@<account_name>.dfs.core.windows.net/<path>. More details: https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction-abfs-uri"
+        }
+      },
+      "required": [
+        "catalogName",
+        "metastoreDbConnectionPasswordSecret",
+        "metastoreDbConnectionURL",
+        "metastoreDbConnectionUserName",
+        "metastoreWarehouseDir"
+      ],
+      "description": "Hive Catalog Option"
+    },
+    "IdentityProfile": {
+      "type": "object",
+      "properties": {
+        "msiClientId": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[{(]?[0-9A-Fa-f]{8}[-]?(?:[0-9A-Fa-f]{4}[-]?){3}[0-9A-Fa-f]{12}[)}]?$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "ClientId of the MSI."
+        },
+        "msiObjectId": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[{(]?[0-9A-Fa-f]{8}[-]?(?:[0-9A-Fa-f]{4}[-]?){3}[0-9A-Fa-f]{12}[)}]?$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "ObjectId of the MSI."
+        },
+        "msiResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "ResourceId of the MSI."
+        }
+      },
+      "required": [
+        "msiClientId",
+        "msiObjectId",
+        "msiResourceId"
+      ],
+      "description": "Identity Profile with details of an MSI."
+    },
+    "LoadBasedConfig": {
+      "type": "object",
+      "properties": {
+        "cooldownPeriod": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is a cool down period, this is a time period in seconds, which determines the amount of time that must elapse between a scaling activity started by a rule and the start of the next scaling activity, regardless of the rule that triggers it. The default value is 300 seconds."
+        },
+        "maxNodes": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "User needs to set the maximum number of nodes for load based scaling, the load based scaling will use this to scale up and scale down between minimum and maximum number of nodes."
+        },
+        "minNodes": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "User needs to set the minimum number of nodes for load based scaling, the load based scaling will use this to scale up and scale down between minimum and maximum number of nodes."
+        },
+        "pollInterval": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "User can specify the poll interval, this is the time period (in seconds) after which scaling metrics are polled for triggering a scaling operation."
+        },
+        "scalingRules": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ScalingRule"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The scaling rules."
+        }
+      },
+      "required": [
+        "maxNodes",
+        "minNodes",
+        "scalingRules"
+      ],
+      "description": "Profile of load based Autoscale."
+    },
+    "NodeProfile": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The number of virtual machines."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(head|Head|HEAD|worker|Worker|WORKER)$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The node type."
+        },
+        "vmSize": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9_\\-]{0,256}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The virtual machine SKU."
+        }
+      },
+      "required": [
+        "count",
+        "type",
+        "vmSize"
+      ],
+      "description": "The node profile."
+    },
+    "ScalingRule": {
+      "type": "object",
+      "properties": {
+        "actionType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "scaleup",
+                "scaledown"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The action type."
+        },
+        "comparisonRule": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ComparisonRule"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The comparison rule."
+        },
+        "evaluationCount": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is an evaluation count for a scaling condition, the number of times a trigger condition should be successful, before scaling activity is triggered."
+        },
+        "scalingMetric": {
+          "type": "string",
+          "description": "Metrics name for individual workloads. For example: cpu"
+        }
+      },
+      "required": [
+        "actionType",
+        "comparisonRule",
+        "evaluationCount",
+        "scalingMetric"
+      ],
+      "description": "The scaling rule."
+    },
+    "Schedule": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "User has to set the node count anticipated at end of the scaling operation of the set current schedule configuration, format is integer."
+        },
+        "days": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "Sunday",
+                  "Monday",
+                  "Tuesday",
+                  "Wednesday",
+                  "Thursday",
+                  "Friday",
+                  "Saturday"
+                ]
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "User has to set the days where schedule has to be set for autoscale operation."
+        },
+        "endTime": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "User has to set the end time of current schedule configuration, format like 10:30 (HH:MM)."
+        },
+        "startTime": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "User has to set the start time of current schedule configuration, format like 10:30 (HH:MM)."
+        }
+      },
+      "required": [
+        "count",
+        "days",
+        "endTime",
+        "startTime"
+      ],
+      "description": "Schedule definition."
+    },
+    "ScheduleBasedConfig": {
+      "type": "object",
+      "properties": {
+        "defaultCount": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Setting default node count of current schedule configuration. Default node count specifies the number of nodes which are default when an specified scaling operation is executed (scale up/scale down)"
+        },
+        "schedules": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Schedule"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This specifies the schedules where scheduled based Autoscale to be enabled, the user has a choice to set multiple rules within the schedule across days and times (start/end)."
+        },
+        "timeZone": {
+          "type": "string",
+          "description": "User has to specify the timezone on which the schedule has to be set for schedule based autoscale configuration."
+        }
+      },
+      "required": [
+        "defaultCount",
+        "schedules",
+        "timeZone"
+      ],
+      "description": "Profile of schedule based Autoscale."
+    },
+    "ScriptActionProfile": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Script name."
+        },
+        "parameters": {
+          "type": "string",
+          "description": "Additional parameters for the script action. It should be space-separated list of arguments required for script execution."
+        },
+        "services": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of services to apply the script action."
+        },
+        "shouldPersist": {
+          "oneOf": [
+            {
+              "type": "boolean",
+              "default": true
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specify if the script should persist on the cluster."
+        },
+        "timeoutInMinutes": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Timeout duration for the script action in minutes."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the script action. Supported type is bash scripts."
+        },
+        "url": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(https)|(http)|(abfss)|(abfs)|(wasbs)|(wasb)://.*$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Url of the script file."
+        }
+      },
+      "required": [
+        "name",
+        "services",
+        "type",
+        "url"
+      ],
+      "description": "The script action profile."
+    },
+    "SecretReference": {
+      "type": "object",
+      "properties": {
+        "keyVaultObjectName": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,126}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Object identifier name of the secret in key vault."
+        },
+        "referenceName": {
+          "type": "string",
+          "description": "Reference name of the secret to be used in service configs."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Key",
+                "Secret",
+                "Certificate"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Type of key vault object: secret, key or certificate."
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the secret in key vault."
+        }
+      },
+      "required": [
+        "keyVaultObjectName",
+        "referenceName",
+        "type"
+      ],
+      "description": "Secret reference and corresponding properties of a key vault secret."
+    },
+    "SecretsProfile": {
+      "type": "object",
+      "properties": {
+        "keyVaultResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Name of the user Key Vault where all the cluster specific user secrets are stored."
+        },
+        "secrets": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SecretReference"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of Key Vault secret."
+        }
+      },
+      "required": [
+        "keyVaultResourceId"
+      ],
+      "description": "The cluster secret profile."
+    },
+    "SparkMetastoreSpec": {
+      "type": "object",
+      "properties": {
+        "dbName": {
+          "type": "string",
+          "description": "The database name."
+        },
+        "dbPasswordSecretName": {
+          "type": "string",
+          "description": "The secret name which contains the database user password."
+        },
+        "dbServerHost": {
+          "type": "string",
+          "description": "The database server host."
+        },
+        "dbUserName": {
+          "type": "string",
+          "description": "The database user name."
+        },
+        "keyVaultId": {
+          "type": "string",
+          "description": "The key vault resource id."
+        },
+        "thriftUrl": {
+          "type": "string",
+          "description": "The thrift url."
+        }
+      },
+      "required": [
+        "dbName",
+        "dbPasswordSecretName",
+        "dbServerHost",
+        "dbUserName",
+        "keyVaultId"
+      ],
+      "description": "The metastore specification for Spark cluster."
+    },
+    "SparkProfile": {
+      "type": "object",
+      "properties": {
+        "defaultStorageUrl": {
+          "type": "string",
+          "description": "The default storage URL."
+        },
+        "metastoreSpec": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SparkMetastoreSpec"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The metastore specification for Spark cluster."
+        },
+        "userPluginsSpec": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SparkUserPlugins"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Spark user plugins spec"
+        }
+      },
+      "description": "The spark cluster profile."
+    },
+    "SparkUserPlugin": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(https)|(abfss)://.*$",
+              "minLength": 1
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Fully qualified path to the folder containing the plugins."
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "description": "Spark user plugin."
+    },
+    "SparkUserPlugins": {
+      "type": "object",
+      "properties": {
+        "plugins": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SparkUserPlugin"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Spark user plugins."
+        }
+      },
+      "description": "Spark user plugins spec"
+    },
+    "SshConnectivityEndpoint": {
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "type": "string",
+          "description": "SSH connectivity endpoint."
+        }
+      },
+      "required": [
+        "endpoint"
+      ],
+      "description": "SSH connectivity endpoint details."
+    },
+    "SshProfile": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 5
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Number of ssh pods per cluster."
+        }
+      },
+      "required": [
+        "count"
+      ],
+      "description": "Ssh profile for the cluster."
+    },
+    "TrinoCoordinator": {
+      "type": "object",
+      "properties": {
+        "debug": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TrinoDebugConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Trino debug configuration."
+        },
+        "highAvailabilityEnabled": {
+          "oneOf": [
+            {
+              "type": "boolean",
+              "default": true
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The flag that if enable coordinator HA, uses multiple coordinator replicas with auto failover, one per each head node. Default: true."
+        }
+      },
+      "description": "Trino Coordinator."
+    },
+    "TrinoDebugConfig": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "oneOf": [
+            {
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The flag that if enable debug or not."
+        },
+        "port": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "default": "8008"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The debug port."
+        },
+        "suspend": {
+          "oneOf": [
+            {
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The flag that if suspend debug or not."
+        }
+      },
+      "description": "Trino debug configuration."
+    },
+    "TrinoProfile": {
+      "type": "object",
+      "properties": {
+        "catalogOptions": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/CatalogOptions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Trino cluster catalog options."
+        },
+        "coordinator": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TrinoCoordinator"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Trino Coordinator."
+        },
+        "userPluginsSpec": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TrinoUserPlugins"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Trino user plugins spec"
+        },
+        "userTelemetrySpec": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TrinoUserTelemetry"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "User telemetry"
+        },
+        "worker": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TrinoWorker"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Trino worker."
+        }
+      },
+      "description": "Trino Cluster profile."
+    },
+    "TrinoTelemetryConfig": {
+      "type": "object",
+      "properties": {
+        "hivecatalogName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Hive Catalog name used to mount external tables on the logs written by trino, if not specified there tables are not created."
+        },
+        "hivecatalogSchema": {
+          "type": "string",
+          "default": "trinologs",
+          "description": "Schema of the above catalog to use, to mount query logs as external tables, if not specified tables will be mounted under schema trinologs."
+        },
+        "partitionRetentionInDays": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "default": "365"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Retention period for query log table partitions, this doesn't have any affect on actual data."
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Azure storage location of the blobs."
+        }
+      },
+      "description": "Trino user telemetry definition."
+    },
+    "TrinoUserPlugin": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Denotes whether the plugin is active or not."
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "This field maps to the sub-directory in trino plugins location, that will contain all the plugins under path."
+        },
+        "path": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(https)|(abfss)://.*$",
+              "minLength": 1
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Fully qualified path to the folder containing the plugins."
+        }
+      },
+      "description": "Trino user plugin."
+    },
+    "TrinoUserPlugins": {
+      "type": "object",
+      "properties": {
+        "plugins": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TrinoUserPlugin"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Trino user plugins."
+        }
+      },
+      "description": "Trino user plugins spec"
+    },
+    "TrinoUserTelemetry": {
+      "type": "object",
+      "properties": {
+        "storage": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TrinoTelemetryConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Trino user telemetry definition."
+        }
+      },
+      "description": "User telemetry"
+    },
+    "TrinoWorker": {
+      "type": "object",
+      "properties": {
+        "debug": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TrinoDebugConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Trino debug configuration."
+        }
+      },
+      "description": "Trino worker."
+    }
+  }
+}

--- a/schemas/common/autogeneratedResources.json
+++ b/schemas/common/autogeneratedResources.json
@@ -15095,6 +15095,12 @@
           "$ref": "https://schema.management.azure.com/schemas/2023-04-15-preview/Microsoft.HDInsight.json#/resourceDefinitions/clusters_privateEndpointConnections"
         },
         {
+          "$ref": "https://schema.management.azure.com/schemas/2023-06-01-preview/Microsoft.HDInsight.json#/resourceDefinitions/clusterpools"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2023-06-01-preview/Microsoft.HDInsight.json#/resourceDefinitions/clusterpools_clusters"
+        },
+        {
           "$ref": "https://schema.management.azure.com/schemas/2020-10-20/Microsoft.HealthBot.json#/resourceDefinitions/healthBots"
         },
         {


### PR DESCRIPTION
Hi, ARM team. Please help on review of this PR~

We are Microsoft.HDInsight team and has already onboarded to autogen list.

But for some reasons/limitations, the autogen utils can't correctly generated our schemas automatically. (It is due to our json files' directory can't meet the utils' requirement)

So I adjust the directory manually and run the autogen utils to generate these files and raise this PR. The new files are autogenerated by 'npm run generate-single', based on this azure-rest-api-specs branch(https://github.com/jianlongsu/azure-rest-api-specs/tree/hdionaks-schemas)

BTW: How can we utilize the autogen features **by not changing the current specs files directory**? Is it possible?
Or should we adjust our directories? Thanks, hope for you guides.
