### PR TITLE
[initScript.sh] Use npm version bundled with node

### DIFF
--- a/.sdkauto/initScript.sh
+++ b/.sdkauto/initScript.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-npm install -g npm
-
 pushd generator
 
 npm ci


### PR DESCRIPTION
- In general, scripts should use the version of `npm` bundled with whatever version of `node` they are using
