### PR TITLE
Add AKS 2023-08 ARM schemas

### DIFF
--- a/generator/autogenlist.ts
+++ b/generator/autogenlist.ts
@@ -109,6 +109,12 @@ const disabledProviders: AutoGenConfig[] = [
         namespace: 'Microsoft.ConfidentialLedger',
         disabledForAutogen: true
     },
+    {
+        // Disabled temporally due to unsupported directory structure
+        basePath: 'containerservice/resource-manager',
+        namespace: 'Microsoft.ContainerService',
+        disabledForAutogen: true,
+    },
 ];
 
 // Run "npm run list-basepaths" to discover all the valid readme files to add to this list
@@ -365,10 +371,6 @@ const autoGenList: AutoGenConfig[] = [
     {
         basePath: 'customerlockbox/resource-manager',
         namespace: 'Microsoft.CustomerLockbox',
-    },
-    {
-        basePath: 'containerservice/resource-manager',
-        namespace: 'Microsoft.ContainerService',
     },
     {
         basePath: 'commerce/resource-manager',

--- a/schemas/2019-04-01/deploymentTemplate.json
+++ b/schemas/2019-04-01/deploymentTemplate.json
@@ -663,7 +663,19 @@
                 { "$ref": "https://schema.management.azure.com/schemas/2022-05-05-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles_titledatasets" },
                 { "$ref": "https://schema.management.azure.com/schemas/2022-05-05-preview/Microsoft.PlayFab.json#/resourceDefinitions/titles_titleinternaldatasets" },
                 { "$ref": "https://schema.management.azure.com/schemas/2023-06-01-preview/Microsoft.HDInsight.json#/resourceDefinitions/clusterpools" },
-                { "$ref": "https://schema.management.azure.com/schemas/2023-06-01-preview/Microsoft.HDInsight.json#/resourceDefinitions/clusterpools_clusters" }
+                { "$ref": "https://schema.management.azure.com/schemas/2023-06-01-preview/Microsoft.HDInsight.json#/resourceDefinitions/clusterpools_clusters" },
+                { "$ref": "https://schema.management.azure.com/schemas/2023-08-01/Microsoft.ContainerService.json#/resourceDefinitions/managedClusters" },
+                { "$ref": "https://schema.management.azure.com/schemas/2023-08-01/Microsoft.ContainerService.json#/resourceDefinitions/managedClusters_agentPools" },
+                { "$ref": "https://schema.management.azure.com/schemas/2023-08-01/Microsoft.ContainerService.json#/resourceDefinitions/managedClusters_maintenanceConfigurations" },
+                { "$ref": "https://schema.management.azure.com/schemas/2023-08-01/Microsoft.ContainerService.json#/resourceDefinitions/managedClusters_privateEndpointConnections" },
+                { "$ref": "https://schema.management.azure.com/schemas/2023-08-01/Microsoft.ContainerService.json#/resourceDefinitions/snapshots" },
+                { "$ref": "https://schema.management.azure.com/schemas/2023-08-02-preview/Microsoft.ContainerService.json#/resourceDefinitions/managedClusters" },
+                { "$ref": "https://schema.management.azure.com/schemas/2023-08-02-preview/Microsoft.ContainerService.json#/resourceDefinitions/managedClusters_agentPools" },
+                { "$ref": "https://schema.management.azure.com/schemas/2023-08-02-preview/Microsoft.ContainerService.json#/resourceDefinitions/managedClusters_maintenanceConfigurations" },
+                { "$ref": "https://schema.management.azure.com/schemas/2023-08-02-preview/Microsoft.ContainerService.json#/resourceDefinitions/managedClusters_privateEndpointConnections" },
+                { "$ref": "https://schema.management.azure.com/schemas/2023-08-02-preview/Microsoft.ContainerService.json#/resourceDefinitions/managedClusters_trustedAccessRoleBindings" },
+                { "$ref": "https://schema.management.azure.com/schemas/2023-08-02-preview/Microsoft.ContainerService.json#/resourceDefinitions/managedclustersnapshots" },
+                { "$ref": "https://schema.management.azure.com/schemas/2023-08-02-preview/Microsoft.ContainerService.json#/resourceDefinitions/snapshots" }
               ]
             }
           ]

--- a/schemas/2023-08-01/Microsoft.ContainerService.json
+++ b/schemas/2023-08-01/Microsoft.ContainerService.json
@@ -1,0 +1,4674 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2023-08-01/Microsoft.ContainerService.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.ContainerService",
+  "description": "Microsoft ContainerService Resource Types",
+  "resourceDefinitions": {
+    "managedClusters": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-01"
+          ]
+        },
+        "extendedLocation": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ExtendedLocation"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The complex type of the extended location."
+        },
+        "identity": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterIdentity"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Identity for the managed cluster."
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives"
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$",
+              "minLength": 1,
+              "maxLength": 63
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the managed cluster resource."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of the managed cluster."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/managedClusters_maintenanceConfigurations_childResource"
+              },
+              {
+                "$ref": "#/definitions/managedClusters_agentPools_childResource"
+              },
+              {
+                "$ref": "#/definitions/managedClusters_privateEndpointConnections_childResource"
+              }
+            ]
+          }
+        },
+        "sku": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterSKU"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The SKU of a Managed Cluster."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.ContainerService/managedClusters"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/managedClusters"
+    },
+    "managedClusters_agentPools": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-01"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9]{0,11}$",
+              "minLength": 1,
+              "maxLength": 12
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the agent pool."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAgentPoolProfileProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for the container service agent pool profile."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.ContainerService/managedClusters/agentPools"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/managedClusters/agentPools"
+    },
+    "managedClusters_maintenanceConfigurations": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the maintenance configuration."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MaintenanceConfigurationProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties used to configure planned maintenance for a Managed Cluster."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.ContainerService/managedClusters/maintenanceConfigurations"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/managedClusters/maintenanceConfigurations"
+    },
+    "managedClusters_privateEndpointConnections": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the private endpoint connection."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PrivateEndpointConnectionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a private endpoint connection."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.ContainerService/managedClusters/privateEndpointConnections"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/managedClusters/privateEndpointConnections"
+    },
+    "snapshots": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-01"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives"
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$",
+              "minLength": 1,
+              "maxLength": 63
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the managed cluster resource."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SnapshotProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties used to configure a node pool snapshot."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.ContainerService/snapshots"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/snapshots"
+    }
+  },
+  "definitions": {
+    "AbsoluteMonthlySchedule": {
+      "type": "object",
+      "properties": {
+        "dayOfMonth": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 31
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The date of the month."
+        },
+        "intervalMonths": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 6
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the number of months between each set of occurrences."
+        }
+      },
+      "required": [
+        "dayOfMonth",
+        "intervalMonths"
+      ],
+      "description": "For schedules like: 'recur every month on the 15th' or 'recur every 3 months on the 20th'."
+    },
+    "AgentPoolUpgradeSettings": {
+      "type": "object",
+      "properties": {
+        "drainTimeoutInMinutes": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1440
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The amount of time (in minutes) to wait on eviction of pods and graceful termination per node. This eviction wait time honors waiting on pod disruption budgets. If this time is exceeded, the upgrade fails. If not specified, the default is 30 minutes."
+        },
+        "maxSurge": {
+          "type": "string",
+          "description": "This can either be set to an integer (e.g. '5') or a percentage (e.g. '50%'). If a percentage is specified, it is the percentage of the total agent pool size at the time of the upgrade. For percentages, fractional nodes are rounded up. If not specified, the default is 1. For more information, including best practices, see: https://docs.microsoft.com/azure/aks/upgrade-cluster#customize-node-surge-upgrade"
+        }
+      },
+      "description": "Settings for upgrading an agentpool"
+    },
+    "AzureKeyVaultKms": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable Azure Key Vault key management service. The default is false."
+        },
+        "keyId": {
+          "type": "string",
+          "description": "Identifier of Azure Key Vault key. See [key identifier format](https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name) for more details. When Azure Key Vault key management service is enabled, this field is required and must be a valid key identifier. When Azure Key Vault key management service is disabled, leave the field empty."
+        },
+        "keyVaultNetworkAccess": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Public",
+                "Private"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`."
+        },
+        "keyVaultResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource ID of key vault. When keyVaultNetworkAccess is `Private`, this field is required and must be a valid resource ID. When keyVaultNetworkAccess is `Public`, leave the field empty."
+        }
+      },
+      "description": "Azure Key Vault key management service settings for the security profile."
+    },
+    "ClusterUpgradeSettings": {
+      "type": "object",
+      "properties": {
+        "overrideSettings": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UpgradeOverrideSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Settings for overrides when upgrading a cluster."
+        }
+      },
+      "description": "Settings for upgrading a cluster."
+    },
+    "ContainerServiceLinuxProfile": {
+      "type": "object",
+      "properties": {
+        "adminUsername": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[A-Za-z][-A-Za-z0-9_]*$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The administrator username to use for Linux VMs."
+        },
+        "ssh": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ContainerServiceSshConfiguration"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "SSH configuration for Linux-based VMs running on Azure."
+        }
+      },
+      "required": [
+        "adminUsername",
+        "ssh"
+      ],
+      "description": "Profile for Linux VMs in the container service cluster."
+    },
+    "ContainerServiceNetworkProfile": {
+      "type": "object",
+      "properties": {
+        "dnsServiceIP": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$",
+              "default": "10.0.0.10"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "An IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr."
+        },
+        "ipFamilies": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "IPv4",
+                  "IPv6"
+                ]
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "IP families are used to determine single-stack or dual-stack clusters. For single-stack, the expected value is IPv4. For dual-stack, the expected values are IPv4 and IPv6."
+        },
+        "loadBalancerProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterLoadBalancerProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile of the managed cluster load balancer."
+        },
+        "loadBalancerSku": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "standard",
+                "basic"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The default is 'standard'. See [Azure Load Balancer SKUs](https://docs.microsoft.com/azure/load-balancer/skus) for more information about the differences between load balancer SKUs."
+        },
+        "natGatewayProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterNATGatewayProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile of the managed cluster NAT gateway."
+        },
+        "networkDataplane": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "azure",
+                "cilium"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Network dataplane used in the Kubernetes cluster."
+        },
+        "networkMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "transparent",
+                "bridge"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This cannot be specified if networkPlugin is anything other than 'azure'."
+        },
+        "networkPlugin": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "azure",
+                "kubenet",
+                "none"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Network plugin used for building the Kubernetes network."
+        },
+        "networkPluginMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "overlay"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The mode the network plugin should use."
+        },
+        "networkPolicy": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "calico",
+                "azure",
+                "cilium"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Network policy used for building the Kubernetes network."
+        },
+        "outboundType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "loadBalancer",
+                "userDefinedRouting",
+                "managedNATGateway",
+                "userAssignedNATGateway"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This can only be set at cluster creation time and cannot be changed later. For more information see [egress outbound type](https://docs.microsoft.com/azure/aks/egress-outboundtype)."
+        },
+        "podCidr": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))?$",
+              "default": "10.244.0.0/16"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "A CIDR notation IP range from which to assign pod IPs when kubenet is used."
+        },
+        "podCidrs": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking."
+        },
+        "serviceCidr": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))?$",
+              "default": "10.0.0.0/16"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges."
+        },
+        "serviceCidrs": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking. They must not overlap with any Subnet IP ranges."
+        }
+      },
+      "description": "Profile of network configuration."
+    },
+    "ContainerServiceSshConfiguration": {
+      "type": "object",
+      "properties": {
+        "publicKeys": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ContainerServiceSshPublicKey"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of SSH public keys used to authenticate with Linux-based VMs. A maximum of 1 key may be specified."
+        }
+      },
+      "required": [
+        "publicKeys"
+      ],
+      "description": "SSH configuration for Linux-based VMs running on Azure."
+    },
+    "ContainerServiceSshPublicKey": {
+      "type": "object",
+      "properties": {
+        "keyData": {
+          "type": "string",
+          "description": "Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers."
+        }
+      },
+      "required": [
+        "keyData"
+      ],
+      "description": "Contains information about SSH certificate public key data."
+    },
+    "CreationData": {
+      "type": "object",
+      "properties": {
+        "sourceResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "This is the ARM ID of the source object to be used to create the target object."
+        }
+      },
+      "description": "Data used when creating a target resource from a source resource."
+    },
+    "DailySchedule": {
+      "type": "object",
+      "properties": {
+        "intervalDays": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 7
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the number of days between each set of occurrences."
+        }
+      },
+      "required": [
+        "intervalDays"
+      ],
+      "description": "For schedules like: 'recur every day' or 'recur every 3 days'."
+    },
+    "DateSpan": {
+      "type": "object",
+      "properties": {
+        "end": {
+          "type": "string",
+          "format": "date",
+          "description": "The end date of the date span."
+        },
+        "start": {
+          "type": "string",
+          "format": "date",
+          "description": "The start date of the date span."
+        }
+      },
+      "required": [
+        "end",
+        "start"
+      ],
+      "description": "For example, between '2022-12-23' and '2023-01-05'."
+    },
+    "DelegatedResource": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "The source resource location - internal use only."
+        },
+        "referralResource": {
+          "type": "string",
+          "description": "The delegation id of the referral delegation (optional) - internal use only."
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "The ARM resource id of the delegated resource - internal use only."
+        },
+        "tenantId": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The tenant id of the delegated resource - internal use only."
+        }
+      },
+      "description": "Delegated resource properties - internal use only."
+    },
+    "ExtendedLocation": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the extended location."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "EdgeZone"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of the extended location."
+        }
+      },
+      "description": "The complex type of the extended location."
+    },
+    "IstioCertificateAuthority": {
+      "type": "object",
+      "properties": {
+        "plugin": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/IstioPluginCertificateAuthority"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Plugin certificates information for Service Mesh."
+        }
+      },
+      "description": "Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca"
+    },
+    "IstioComponents": {
+      "type": "object",
+      "properties": {
+        "egressGateways": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/IstioEgressGateway"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Istio egress gateways."
+        },
+        "ingressGateways": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/IstioIngressGateway"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Istio ingress gateways."
+        }
+      },
+      "description": "Istio components configuration."
+    },
+    "IstioEgressGateway": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable the egress gateway."
+        },
+        "nodeSelector": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "NodeSelector for scheduling the egress gateway."
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "description": "Istio egress gateway configuration."
+    },
+    "IstioIngressGateway": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable the ingress gateway."
+        },
+        "mode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "External",
+                "Internal"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Mode of an ingress gateway."
+        }
+      },
+      "required": [
+        "enabled",
+        "mode"
+      ],
+      "description": "Istio ingress gateway configuration. For now, we support up to one external ingress gateway named `aks-istio-ingressgateway-external` and one internal ingress gateway named `aks-istio-ingressgateway-internal`."
+    },
+    "IstioPluginCertificateAuthority": {
+      "type": "object",
+      "properties": {
+        "certChainObjectName": {
+          "type": "string",
+          "description": "Certificate chain object name in Azure Key Vault."
+        },
+        "certObjectName": {
+          "type": "string",
+          "description": "Intermediate certificate object name in Azure Key Vault."
+        },
+        "keyObjectName": {
+          "type": "string",
+          "description": "Intermediate certificate private key object name in Azure Key Vault."
+        },
+        "keyVaultId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the Key Vault."
+        },
+        "rootCertObjectName": {
+          "type": "string",
+          "description": "Root certificate object name in Azure Key Vault."
+        }
+      },
+      "description": "Plugin certificates information for Service Mesh."
+    },
+    "IstioServiceMesh": {
+      "type": "object",
+      "properties": {
+        "certificateAuthority": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/IstioCertificateAuthority"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca"
+        },
+        "components": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/IstioComponents"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Istio components configuration."
+        },
+        "revisions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of revisions of the Istio control plane. When an upgrade is not in progress, this holds one value. When canary upgrade is in progress, this can only hold two consecutive values. For more information, see: https://learn.microsoft.com/en-us/azure/aks/istio-upgrade"
+        }
+      },
+      "description": "Istio service mesh configuration."
+    },
+    "KubeletConfig": {
+      "type": "object",
+      "properties": {
+        "allowedUnsafeSysctls": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Allowed list of unsafe sysctls or unsafe sysctl patterns (ending in `*`)."
+        },
+        "containerLogMaxFiles": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 2
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum number of container log files that can be present for a container. The number must be ≥ 2."
+        },
+        "containerLogMaxSizeMB": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum size (e.g. 10Mi) of container log file before it is rotated."
+        },
+        "cpuCfsQuota": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The default is true."
+        },
+        "cpuCfsQuotaPeriod": {
+          "type": "string",
+          "description": "The default is '100ms.' Valid values are a sequence of decimal numbers with an optional fraction and a unit suffix. For example: '300ms', '2h45m'. Supported units are 'ns', 'us', 'ms', 's', 'm', and 'h'."
+        },
+        "cpuManagerPolicy": {
+          "type": "string",
+          "description": "The default is 'none'. See [Kubernetes CPU management policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-management-policies) for more information. Allowed values are 'none' and 'static'."
+        },
+        "failSwapOn": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "If set to true it will make the Kubelet fail to start if swap is enabled on the node."
+        },
+        "imageGcHighThreshold": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "To disable image garbage collection, set to 100. The default is 85%"
+        },
+        "imageGcLowThreshold": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This cannot be set higher than imageGcHighThreshold. The default is 80%"
+        },
+        "podMaxPids": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum number of processes per pod."
+        },
+        "topologyManagerPolicy": {
+          "type": "string",
+          "description": "For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'."
+        }
+      },
+      "description": "See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details."
+    },
+    "LinuxOSConfig": {
+      "type": "object",
+      "properties": {
+        "swapFileSizeMB": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The size in MB of a swap file that will be created on each node."
+        },
+        "sysctls": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SysctlConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl settings for Linux agent nodes."
+        },
+        "transparentHugePageDefrag": {
+          "type": "string",
+          "description": "Valid values are 'always', 'defer', 'defer+madvise', 'madvise' and 'never'. The default is 'madvise'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge)."
+        },
+        "transparentHugePageEnabled": {
+          "type": "string",
+          "description": "Valid values are 'always', 'madvise', and 'never'. The default is 'always'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge)."
+        }
+      },
+      "description": "See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details."
+    },
+    "MaintenanceConfigurationProperties": {
+      "type": "object",
+      "properties": {
+        "maintenanceWindow": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MaintenanceWindow"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Maintenance window used to configure scheduled auto-upgrade for a Managed Cluster."
+        },
+        "notAllowedTime": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TimeSpan"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Time slots on which upgrade is not allowed."
+        },
+        "timeInWeek": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TimeInWeek"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "If two array entries specify the same day of the week, the applied configuration is the union of times in both entries."
+        }
+      },
+      "description": "Properties used to configure planned maintenance for a Managed Cluster."
+    },
+    "MaintenanceWindow": {
+      "type": "object",
+      "properties": {
+        "durationHours": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 4,
+              "maximum": 24,
+              "default": "24"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Length of maintenance window range from 4 to 24 hours."
+        },
+        "notAllowedDates": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DateSpan"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Date ranges on which upgrade is not allowed. 'utcOffset' applies to this field. For example, with 'utcOffset: +02:00' and 'dateSpan' being '2022-12-23' to '2023-01-03', maintenance will be blocked from '2022-12-22 22:00' to '2023-01-03 22:00' in UTC time."
+        },
+        "schedule": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schedule"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "One and only one of the schedule types should be specified. Choose either 'daily', 'weekly', 'absoluteMonthly' or 'relativeMonthly' for your maintenance schedule."
+        },
+        "startDate": {
+          "type": "string",
+          "format": "date",
+          "description": "The date the maintenance window activates. If the current date is before this date, the maintenance window is inactive and will not be used for upgrades. If not specified, the maintenance window will be active right away."
+        },
+        "startTime": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^\\d{2}:\\d{2}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The start time of the maintenance window. Accepted values are from '00:00' to '23:59'. 'utcOffset' applies to this field. For example: '02:00' with 'utcOffset: +02:00' means UTC time '00:00'."
+        },
+        "utcOffset": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(-|\\+)[0-9]{2}:[0-9]{2}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The UTC offset in format +/-HH:mm. For example, '+05:30' for IST and '-07:00' for PST. If not specified, the default is '+00:00'."
+        }
+      },
+      "required": [
+        "durationHours",
+        "schedule",
+        "startTime"
+      ],
+      "description": "Maintenance window used to configure scheduled auto-upgrade for a Managed Cluster."
+    },
+    "ManagedClusterAADProfile": {
+      "type": "object",
+      "properties": {
+        "adminGroupObjectIDs": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of AAD group object IDs that will have admin role of the cluster."
+        },
+        "clientAppID": {
+          "type": "string",
+          "description": "(DEPRECATED) The client AAD application ID. Learn more at https://aka.ms/aks/aad-legacy."
+        },
+        "enableAzureRBAC": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable Azure RBAC for Kubernetes authorization."
+        },
+        "managed": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable managed AAD."
+        },
+        "serverAppID": {
+          "type": "string",
+          "description": "(DEPRECATED) The server AAD application ID. Learn more at https://aka.ms/aks/aad-legacy."
+        },
+        "serverAppSecret": {
+          "type": "string",
+          "description": "(DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy."
+        },
+        "tenantID": {
+          "type": "string",
+          "description": "The AAD tenant ID to use for authentication. If not specified, will use the tenant of the deployment subscription."
+        }
+      },
+      "description": "For more details see [managed AAD on AKS](https://docs.microsoft.com/azure/aks/managed-aad)."
+    },
+    "ManagedClusterAddonProfile": {
+      "type": "object",
+      "properties": {
+        "config": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Key-value pairs for configuring an add-on."
+        },
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether the add-on is enabled or not."
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "description": "A Kubernetes add-on profile for a managed cluster."
+    },
+    "ManagedClusterAgentPoolProfile": {
+      "type": "object",
+      "properties": {
+        "availabilityZones": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'."
+        },
+        "count": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1."
+        },
+        "creationData": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/CreationData"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Data used when creating a target resource from a source resource."
+        },
+        "enableAutoScaling": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable auto-scaler"
+        },
+        "enableEncryptionAtHost": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption"
+        },
+        "enableFIPS": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details."
+        },
+        "enableNodePublicIP": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false."
+        },
+        "enableUltraSSD": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable UltraSSD"
+        },
+        "gpuInstanceProfile": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "MIG1g",
+                "MIG2g",
+                "MIG3g",
+                "MIG4g",
+                "MIG7g"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU."
+        },
+        "hostGroupID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts)."
+        },
+        "kubeletConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/KubeletConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details."
+        },
+        "kubeletDiskType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "OS",
+                "Temporary"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "linuxOSConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/LinuxOSConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details."
+        },
+        "maxCount": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum number of nodes for auto-scaling"
+        },
+        "maxPods": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum number of pods that can run on a node."
+        },
+        "minCount": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The minimum number of nodes for auto-scaling"
+        },
+        "mode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "System",
+                "User"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9]{0,11}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Windows agent pool names must be 6 characters or less."
+        },
+        "nodeLabels": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The node labels to be persisted across all nodes in agent pool."
+        },
+        "nodePublicIPPrefixID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}"
+        },
+        "nodeTaints": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule."
+        },
+        "orchestratorVersion": {
+          "type": "string",
+          "description": "Both patch version <major.minor.patch> (e.g. 1.20.13) and <major.minor> (e.g. 1.20) are supported. When <major.minor> is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same <major.minor> once it has been created (e.g. 1.14.x -> 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool)."
+        },
+        "osDiskSizeGB": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2048
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified."
+        },
+        "osDiskType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Managed",
+                "Ephemeral"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "osSKU": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Ubuntu",
+                "AzureLinux",
+                "CBLMariner",
+                "Windows2019",
+                "Windows2022"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "osType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Linux",
+                "Windows"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "podSubnetID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
+        },
+        "powerState": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PowerState"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Describes the Power State of the cluster"
+        },
+        "proximityPlacementGroupID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ID for Proximity Placement Group."
+        },
+        "scaleDownMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Delete",
+                "Deallocate"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete."
+        },
+        "scaleSetEvictionPolicy": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Delete",
+                "Deallocate"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'."
+        },
+        "scaleSetPriority": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Spot",
+                "Regular"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'."
+        },
+        "spotMaxPrice": {
+          "oneOf": [
+            {
+              "type": "number",
+              "default": -1.0
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing)"
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The tags to be persisted on the agent pool virtual machine scale set."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "VirtualMachineScaleSets",
+                "AvailabilitySet"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "upgradeSettings": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AgentPoolUpgradeSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Settings for upgrading an agentpool"
+        },
+        "vmSize": {
+          "type": "string",
+          "description": "VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions"
+        },
+        "vnetSubnetID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
+        },
+        "workloadRuntime": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "OCIContainer",
+                "WasmWasi"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "description": "Profile for the container service agent pool."
+    },
+    "ManagedClusterAgentPoolProfileProperties": {
+      "type": "object",
+      "properties": {
+        "availabilityZones": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'."
+        },
+        "count": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1."
+        },
+        "creationData": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/CreationData"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Data used when creating a target resource from a source resource."
+        },
+        "enableAutoScaling": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable auto-scaler"
+        },
+        "enableEncryptionAtHost": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption"
+        },
+        "enableFIPS": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details."
+        },
+        "enableNodePublicIP": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false."
+        },
+        "enableUltraSSD": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable UltraSSD"
+        },
+        "gpuInstanceProfile": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "MIG1g",
+                "MIG2g",
+                "MIG3g",
+                "MIG4g",
+                "MIG7g"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU."
+        },
+        "hostGroupID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts)."
+        },
+        "kubeletConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/KubeletConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details."
+        },
+        "kubeletDiskType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "OS",
+                "Temporary"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "linuxOSConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/LinuxOSConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details."
+        },
+        "maxCount": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum number of nodes for auto-scaling"
+        },
+        "maxPods": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum number of pods that can run on a node."
+        },
+        "minCount": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The minimum number of nodes for auto-scaling"
+        },
+        "mode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "System",
+                "User"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "nodeLabels": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The node labels to be persisted across all nodes in agent pool."
+        },
+        "nodePublicIPPrefixID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}"
+        },
+        "nodeTaints": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule."
+        },
+        "orchestratorVersion": {
+          "type": "string",
+          "description": "Both patch version <major.minor.patch> (e.g. 1.20.13) and <major.minor> (e.g. 1.20) are supported. When <major.minor> is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same <major.minor> once it has been created (e.g. 1.14.x -> 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool)."
+        },
+        "osDiskSizeGB": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2048
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified."
+        },
+        "osDiskType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Managed",
+                "Ephemeral"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "osSKU": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Ubuntu",
+                "AzureLinux",
+                "CBLMariner",
+                "Windows2019",
+                "Windows2022"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "osType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Linux",
+                "Windows"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "podSubnetID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
+        },
+        "powerState": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PowerState"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Describes the Power State of the cluster"
+        },
+        "proximityPlacementGroupID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ID for Proximity Placement Group."
+        },
+        "scaleDownMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Delete",
+                "Deallocate"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete."
+        },
+        "scaleSetEvictionPolicy": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Delete",
+                "Deallocate"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'."
+        },
+        "scaleSetPriority": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Spot",
+                "Regular"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'."
+        },
+        "spotMaxPrice": {
+          "oneOf": [
+            {
+              "type": "number",
+              "default": -1.0
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing)"
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The tags to be persisted on the agent pool virtual machine scale set."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "VirtualMachineScaleSets",
+                "AvailabilitySet"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "upgradeSettings": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AgentPoolUpgradeSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Settings for upgrading an agentpool"
+        },
+        "vmSize": {
+          "type": "string",
+          "description": "VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions"
+        },
+        "vnetSubnetID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
+        },
+        "workloadRuntime": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "OCIContainer",
+                "WasmWasi"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "description": "Properties for the container service agent pool profile."
+    },
+    "ManagedClusterAPIServerAccessProfile": {
+      "type": "object",
+      "properties": {
+        "authorizedIPRanges": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "IP ranges are specified in CIDR format, e.g. 137.117.106.88/29. This feature is not compatible with clusters that use Public IP Per Node, or clusters that are using a Basic Load Balancer. For more information see [API server authorized IP ranges](https://docs.microsoft.com/azure/aks/api-server-authorized-ip-ranges)."
+        },
+        "disableRunCommand": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to disable run command for the cluster or not."
+        },
+        "enablePrivateCluster": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For more details, see [Creating a private AKS cluster](https://docs.microsoft.com/azure/aks/private-clusters)."
+        },
+        "enablePrivateClusterPublicFQDN": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to create additional public FQDN for private cluster or not."
+        },
+        "privateDNSZone": {
+          "type": "string",
+          "description": "The default is System. For more details see [configure private DNS zone](https://docs.microsoft.com/azure/aks/private-clusters#configure-private-dns-zone). Allowed values are 'system' and 'none'."
+        }
+      },
+      "description": "Access profile for managed cluster API server."
+    },
+    "ManagedClusterAutoUpgradeProfile": {
+      "type": "object",
+      "properties": {
+        "nodeOSUpgradeChannel": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "None",
+                "Unmanaged",
+                "NodeImage"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Manner in which the OS on your nodes is updated. The default is NodeImage."
+        },
+        "upgradeChannel": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "rapid",
+                "stable",
+                "patch",
+                "node-image",
+                "none"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For more information see [setting the AKS cluster auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel)."
+        }
+      },
+      "description": "Auto upgrade profile for a managed cluster."
+    },
+    "ManagedClusterAzureMonitorProfile": {
+      "type": "object",
+      "properties": {
+        "metrics": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAzureMonitorProfileMetrics"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview."
+        }
+      },
+      "description": "Azure Monitor addon profiles for monitoring the managed cluster."
+    },
+    "ManagedClusterAzureMonitorProfileKubeStateMetrics": {
+      "type": "object",
+      "properties": {
+        "metricAnnotationsAllowList": {
+          "type": "string",
+          "description": "Comma-separated list of Kubernetes annotation keys that will be used in the resource's labels metric (Example: 'namespaces=[kubernetes.io/team,...],pods=[kubernetes.io/team],...'). By default the metric contains only resource name and namespace labels."
+        },
+        "metricLabelsAllowlist": {
+          "type": "string",
+          "description": "Comma-separated list of additional Kubernetes label keys that will be used in the resource's labels metric (Example: 'namespaces=[k8s-label-1,k8s-label-n,...],pods=[app],...'). By default the metric contains only resource name and namespace labels."
+        }
+      },
+      "description": "Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details."
+    },
+    "ManagedClusterAzureMonitorProfileMetrics": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable or disable the Azure Managed Prometheus addon for Prometheus monitoring. See aka.ms/AzureManagedPrometheus-aks-enable for details on enabling and disabling."
+        },
+        "kubeStateMetrics": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAzureMonitorProfileKubeStateMetrics"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details."
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "description": "Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview."
+    },
+    "ManagedClusterHTTPProxyConfig": {
+      "type": "object",
+      "properties": {
+        "httpProxy": {
+          "type": "string",
+          "description": "The HTTP proxy server endpoint to use."
+        },
+        "httpsProxy": {
+          "type": "string",
+          "description": "The HTTPS proxy server endpoint to use."
+        },
+        "noProxy": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The endpoints that should not go through proxy."
+        },
+        "trustedCa": {
+          "type": "string",
+          "description": "Alternative CA cert to use for connecting to proxy servers."
+        }
+      },
+      "description": "Cluster HTTP proxy configuration."
+    },
+    "ManagedClusterIdentity": {
+      "type": "object",
+      "properties": {
+        "delegatedResources": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/DelegatedResource"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The set of delegated resources. The delegated resources dictionary keys will be source resource internal ids - internal use only."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "SystemAssigned",
+                "UserAssigned",
+                "None"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For more information see [use managed identities in AKS](https://docs.microsoft.com/azure/aks/use-managed-identity)."
+        },
+        "userAssignedIdentities": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/ManagedServiceIdentityUserAssignedIdentitiesValue"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The keys must be ARM resource IDs in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'."
+        }
+      },
+      "description": "Identity for the managed cluster."
+    },
+    "ManagedClusterLoadBalancerProfile": {
+      "type": "object",
+      "properties": {
+        "allocatedOutboundPorts": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 64000,
+              "default": "0"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The desired number of allocated SNAT ports per VM. Allowed values are in the range of 0 to 64000 (inclusive). The default value is 0 which results in Azure dynamically allocating ports."
+        },
+        "effectiveOutboundIPs": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ResourceReference"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The effective outbound IP resources of the cluster load balancer."
+        },
+        "enableMultipleStandardLoadBalancers": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Enable multiple standard load balancers per AKS cluster or not."
+        },
+        "idleTimeoutInMinutes": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 4,
+              "maximum": 120,
+              "default": "30"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 30 minutes."
+        },
+        "managedOutboundIPs": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterLoadBalancerProfileManagedOutboundIPs"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Desired managed outbound IPs for the cluster load balancer."
+        },
+        "outboundIPPrefixes": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterLoadBalancerProfileOutboundIPPrefixes"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Desired outbound IP Prefix resources for the cluster load balancer."
+        },
+        "outboundIPs": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterLoadBalancerProfileOutboundIPs"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Desired outbound IP resources for the cluster load balancer."
+        }
+      },
+      "description": "Profile of the managed cluster load balancer."
+    },
+    "ManagedClusterLoadBalancerProfileManagedOutboundIPs": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": "1"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The desired number of IPv4 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1. "
+        },
+        "countIPv6": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100,
+              "default": "0"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The desired number of IPv6 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 0 for single-stack and 1 for dual-stack. "
+        }
+      },
+      "description": "Desired managed outbound IPs for the cluster load balancer."
+    },
+    "ManagedClusterLoadBalancerProfileOutboundIPPrefixes": {
+      "type": "object",
+      "properties": {
+        "publicIPPrefixes": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ResourceReference"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "A list of public IP prefix resources."
+        }
+      },
+      "description": "Desired outbound IP Prefix resources for the cluster load balancer."
+    },
+    "ManagedClusterLoadBalancerProfileOutboundIPs": {
+      "type": "object",
+      "properties": {
+        "publicIPs": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ResourceReference"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "A list of public IP resources."
+        }
+      },
+      "description": "Desired outbound IP resources for the cluster load balancer."
+    },
+    "ManagedClusterManagedOutboundIPProfile": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 16,
+              "default": "1"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The desired number of outbound IPs created/managed by Azure. Allowed values must be in the range of 1 to 16 (inclusive). The default value is 1. "
+        }
+      },
+      "description": "Profile of the managed outbound IP resources of the managed cluster."
+    },
+    "ManagedClusterNATGatewayProfile": {
+      "type": "object",
+      "properties": {
+        "effectiveOutboundIPs": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ResourceReference"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The effective outbound IP resources of the cluster NAT gateway."
+        },
+        "idleTimeoutInMinutes": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 4,
+              "maximum": 120,
+              "default": "4"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 4 minutes."
+        },
+        "managedOutboundIPProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterManagedOutboundIPProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile of the managed outbound IP resources of the managed cluster."
+        }
+      },
+      "description": "Profile of the managed cluster NAT gateway."
+    },
+    "ManagedClusterOIDCIssuerProfile": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether the OIDC issuer is enabled."
+        }
+      },
+      "description": "The OIDC issuer profile of the Managed Cluster."
+    },
+    "ManagedClusterPodIdentity": {
+      "type": "object",
+      "properties": {
+        "bindingSelector": {
+          "type": "string",
+          "description": "The binding selector to use for the AzureIdentityBinding resource."
+        },
+        "identity": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UserAssignedIdentity"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Details about a user assigned identity."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the pod identity."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "The namespace of the pod identity."
+        }
+      },
+      "required": [
+        "identity",
+        "name",
+        "namespace"
+      ],
+      "description": "Details about the pod identity assigned to the Managed Cluster."
+    },
+    "ManagedClusterPodIdentityException": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the pod identity exception."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "The namespace of the pod identity exception."
+        },
+        "podLabels": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The pod labels to match."
+        }
+      },
+      "required": [
+        "name",
+        "namespace",
+        "podLabels"
+      ],
+      "description": "See [disable AAD Pod Identity for a specific Pod/Application](https://azure.github.io/aad-pod-identity/docs/configure/application_exception/) for more details."
+    },
+    "ManagedClusterPodIdentityProfile": {
+      "type": "object",
+      "properties": {
+        "allowNetworkPluginKubenet": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Running in Kubenet is disabled by default due to the security related nature of AAD Pod Identity and the risks of IP spoofing. See [using Kubenet network plugin with AAD Pod Identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity#using-kubenet-network-plugin-with-azure-active-directory-pod-managed-identities) for more information."
+        },
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether the pod identity addon is enabled."
+        },
+        "userAssignedIdentities": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ManagedClusterPodIdentity"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The pod identities to use in the cluster."
+        },
+        "userAssignedIdentityExceptions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ManagedClusterPodIdentityException"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The pod identity exceptions to allow."
+        }
+      },
+      "description": "See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on pod identity integration."
+    },
+    "ManagedClusterProperties": {
+      "type": "object",
+      "properties": {
+        "aadProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAADProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For more details see [managed AAD on AKS](https://docs.microsoft.com/azure/aks/managed-aad)."
+        },
+        "addonProfiles": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/ManagedClusterAddonProfile"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The profile of managed cluster add-on."
+        },
+        "agentPoolProfiles": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ManagedClusterAgentPoolProfile"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The agent pool properties."
+        },
+        "apiServerAccessProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAPIServerAccessProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Access profile for managed cluster API server."
+        },
+        "autoScalerProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterPropertiesAutoScalerProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Parameters to be applied to the cluster-autoscaler when enabled"
+        },
+        "autoUpgradeProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAutoUpgradeProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Auto upgrade profile for a managed cluster."
+        },
+        "azureMonitorProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAzureMonitorProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Azure Monitor addon profiles for monitoring the managed cluster."
+        },
+        "disableLocalAccounts": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "If set to true, getting static credentials will be disabled for this cluster. This must only be used on Managed Clusters that are AAD enabled. For more details see [disable local accounts](https://docs.microsoft.com/azure/aks/managed-aad#disable-local-accounts-preview)."
+        },
+        "diskEncryptionSetID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'"
+        },
+        "dnsPrefix": {
+          "type": "string",
+          "description": "This cannot be updated once the Managed Cluster has been created."
+        },
+        "enablePodSecurityPolicy": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "(DEPRECATED) Whether to enable Kubernetes pod security policy (preview). PodSecurityPolicy was deprecated in Kubernetes v1.21, and removed from Kubernetes in v1.25. Learn more at https://aka.ms/k8s/psp and https://aka.ms/aks/psp."
+        },
+        "enableRBAC": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable Kubernetes Role-Based Access Control."
+        },
+        "fqdnSubdomain": {
+          "type": "string",
+          "description": "This cannot be updated once the Managed Cluster has been created."
+        },
+        "httpProxyConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterHTTPProxyConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Cluster HTTP proxy configuration."
+        },
+        "identityProfile": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/UserAssignedIdentity"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Identities associated with the cluster."
+        },
+        "kubernetesVersion": {
+          "type": "string",
+          "description": "Both patch version <major.minor.patch> (e.g. 1.20.13) and <major.minor> (e.g. 1.20) are supported. When <major.minor> is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same <major.minor> once it has been created (e.g. 1.14.x -> 1.14) will not trigger an upgrade, even if a newer patch version is available. When you upgrade a supported AKS cluster, Kubernetes minor versions cannot be skipped. All upgrades must be performed sequentially by major version number. For example, upgrades between 1.14.x -> 1.15.x or 1.15.x -> 1.16.x are allowed, however 1.14.x -> 1.16.x is not allowed. See [upgrading an AKS cluster](https://docs.microsoft.com/azure/aks/upgrade-cluster) for more details."
+        },
+        "linuxProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ContainerServiceLinuxProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile for Linux VMs in the container service cluster."
+        },
+        "networkProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ContainerServiceNetworkProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile of network configuration."
+        },
+        "nodeResourceGroup": {
+          "type": "string",
+          "description": "The name of the resource group containing agent pool nodes."
+        },
+        "oidcIssuerProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterOIDCIssuerProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The OIDC issuer profile of the Managed Cluster."
+        },
+        "podIdentityProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterPodIdentityProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on pod identity integration."
+        },
+        "privateLinkResources": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PrivateLinkResource"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Private link resources associated with the cluster."
+        },
+        "publicNetworkAccess": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Allow or deny public network access for AKS."
+        },
+        "securityProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterSecurityProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Security profile for the container service cluster."
+        },
+        "serviceMeshProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServiceMeshProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Service mesh profile for a managed cluster."
+        },
+        "servicePrincipalProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterServicePrincipalProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Information about a service principal identity for the cluster to use for manipulating Azure APIs."
+        },
+        "storageProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterStorageProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Storage profile for the container service cluster."
+        },
+        "supportPlan": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "KubernetesOfficial",
+                "AKSLongTermSupport"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The support plan for the Managed Cluster. If unspecified, the default is 'KubernetesOfficial'."
+        },
+        "upgradeSettings": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ClusterUpgradeSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Settings for upgrading a cluster."
+        },
+        "windowsProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterWindowsProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile for Windows VMs in the managed cluster."
+        },
+        "workloadAutoScalerProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterWorkloadAutoScalerProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Workload Auto-scaler profile for the managed cluster."
+        }
+      },
+      "description": "Properties of the managed cluster."
+    },
+    "ManagedClusterPropertiesAutoScalerProfile": {
+      "type": "object",
+      "properties": {
+        "balance-similar-node-groups": {
+          "type": "string",
+          "description": "Valid values are 'true' and 'false'"
+        },
+        "expander": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "least-waste",
+                "most-pods",
+                "priority",
+                "random"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "If not specified, the default is 'random'. See [expanders](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders) for more information."
+        },
+        "max-empty-bulk-delete": {
+          "type": "string",
+          "description": "The default is 10."
+        },
+        "max-graceful-termination-sec": {
+          "type": "string",
+          "description": "The default is 600."
+        },
+        "max-node-provision-time": {
+          "type": "string",
+          "description": "The default is '15m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported."
+        },
+        "max-total-unready-percentage": {
+          "type": "string",
+          "description": "The default is 45. The maximum is 100 and the minimum is 0."
+        },
+        "new-pod-scale-up-delay": {
+          "type": "string",
+          "description": "For scenarios like burst/batch scale where you don't want CA to act before the kubernetes scheduler could schedule all the pods, you can tell CA to ignore unscheduled pods before they're a certain age. The default is '0s'. Values must be an integer followed by a unit ('s' for seconds, 'm' for minutes, 'h' for hours, etc)."
+        },
+        "ok-total-unready-count": {
+          "type": "string",
+          "description": "This must be an integer. The default is 3."
+        },
+        "scale-down-delay-after-add": {
+          "type": "string",
+          "description": "The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported."
+        },
+        "scale-down-delay-after-delete": {
+          "type": "string",
+          "description": "The default is the scan-interval. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported."
+        },
+        "scale-down-delay-after-failure": {
+          "type": "string",
+          "description": "The default is '3m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported."
+        },
+        "scale-down-unneeded-time": {
+          "type": "string",
+          "description": "The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported."
+        },
+        "scale-down-unready-time": {
+          "type": "string",
+          "description": "The default is '20m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported."
+        },
+        "scale-down-utilization-threshold": {
+          "type": "string",
+          "description": "The default is '0.5'."
+        },
+        "scan-interval": {
+          "type": "string",
+          "description": "The default is '10'. Values must be an integer number of seconds."
+        },
+        "skip-nodes-with-local-storage": {
+          "type": "string",
+          "description": "The default is true."
+        },
+        "skip-nodes-with-system-pods": {
+          "type": "string",
+          "description": "The default is true."
+        }
+      },
+      "description": "Parameters to be applied to the cluster-autoscaler when enabled"
+    },
+    "ManagedClusterSecurityProfile": {
+      "type": "object",
+      "properties": {
+        "azureKeyVaultKms": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AzureKeyVaultKms"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Azure Key Vault key management service settings for the security profile."
+        },
+        "defender": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterSecurityProfileDefender"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Microsoft Defender settings for the security profile."
+        },
+        "imageCleaner": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterSecurityProfileImageCleaner"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Image Cleaner removes unused images from nodes, freeing up disk space and helping to reduce attack surface area. Here are settings for the security profile."
+        },
+        "workloadIdentity": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterSecurityProfileWorkloadIdentity"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Workload identity settings for the security profile."
+        }
+      },
+      "description": "Security profile for the container service cluster."
+    },
+    "ManagedClusterSecurityProfileDefender": {
+      "type": "object",
+      "properties": {
+        "logAnalyticsWorkspaceResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource ID of the Log Analytics workspace to be associated with Microsoft Defender. When Microsoft Defender is enabled, this field is required and must be a valid workspace resource ID. When Microsoft Defender is disabled, leave the field empty."
+        },
+        "securityMonitoring": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterSecurityProfileDefenderSecurityMonitoring"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Microsoft Defender settings for the security profile threat detection."
+        }
+      },
+      "description": "Microsoft Defender settings for the security profile."
+    },
+    "ManagedClusterSecurityProfileDefenderSecurityMonitoring": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable Defender threat detection"
+        }
+      },
+      "description": "Microsoft Defender settings for the security profile threat detection."
+    },
+    "ManagedClusterSecurityProfileImageCleaner": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable Image Cleaner on AKS cluster."
+        },
+        "intervalHours": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Image Cleaner scanning interval in hours."
+        }
+      },
+      "description": "Image Cleaner removes unused images from nodes, freeing up disk space and helping to reduce attack surface area. Here are settings for the security profile."
+    },
+    "ManagedClusterSecurityProfileWorkloadIdentity": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable workload identity."
+        }
+      },
+      "description": "Workload identity settings for the security profile."
+    },
+    "ManagedClusterServicePrincipalProfile": {
+      "type": "object",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The ID for the service principal."
+        },
+        "secret": {
+          "type": "string",
+          "description": "The secret password associated with the service principal in plain text."
+        }
+      },
+      "required": [
+        "clientId"
+      ],
+      "description": "Information about a service principal identity for the cluster to use for manipulating Azure APIs."
+    },
+    "ManagedClusterSKU": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Base"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of a managed cluster SKU."
+        },
+        "tier": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Premium",
+                "Standard",
+                "Free"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "If not specified, the default is 'Free'. See [AKS Pricing Tier](https://learn.microsoft.com/azure/aks/free-standard-pricing-tiers) for more details."
+        }
+      },
+      "description": "The SKU of a Managed Cluster."
+    },
+    "ManagedClusterStorageProfile": {
+      "type": "object",
+      "properties": {
+        "blobCSIDriver": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterStorageProfileBlobCSIDriver"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "AzureBlob CSI Driver settings for the storage profile."
+        },
+        "diskCSIDriver": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterStorageProfileDiskCSIDriver"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "AzureDisk CSI Driver settings for the storage profile."
+        },
+        "fileCSIDriver": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterStorageProfileFileCSIDriver"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "AzureFile CSI Driver settings for the storage profile."
+        },
+        "snapshotController": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterStorageProfileSnapshotController"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Snapshot Controller settings for the storage profile."
+        }
+      },
+      "description": "Storage profile for the container service cluster."
+    },
+    "ManagedClusterStorageProfileBlobCSIDriver": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable AzureBlob CSI Driver. The default value is false."
+        }
+      },
+      "description": "AzureBlob CSI Driver settings for the storage profile."
+    },
+    "ManagedClusterStorageProfileDiskCSIDriver": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable AzureDisk CSI Driver. The default value is true."
+        }
+      },
+      "description": "AzureDisk CSI Driver settings for the storage profile."
+    },
+    "ManagedClusterStorageProfileFileCSIDriver": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable AzureFile CSI Driver. The default value is true."
+        }
+      },
+      "description": "AzureFile CSI Driver settings for the storage profile."
+    },
+    "ManagedClusterStorageProfileSnapshotController": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable Snapshot Controller. The default value is true."
+        }
+      },
+      "description": "Snapshot Controller settings for the storage profile."
+    },
+    "managedClusters_agentPools_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-01"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9]{0,11}$",
+              "minLength": 1,
+              "maxLength": 12
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the agent pool."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAgentPoolProfileProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for the container service agent pool profile."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "agentPools"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/managedClusters/agentPools"
+    },
+    "managedClusters_maintenanceConfigurations_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the maintenance configuration."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MaintenanceConfigurationProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties used to configure planned maintenance for a Managed Cluster."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "maintenanceConfigurations"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/managedClusters/maintenanceConfigurations"
+    },
+    "managedClusters_privateEndpointConnections_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-01"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the private endpoint connection."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PrivateEndpointConnectionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a private endpoint connection."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "privateEndpointConnections"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/managedClusters/privateEndpointConnections"
+    },
+    "ManagedClusterWindowsProfile": {
+      "type": "object",
+      "properties": {
+        "adminPassword": {
+          "type": "string",
+          "description": "Specifies the password of the administrator account. <br><br> **Minimum-length:** 8 characters <br><br> **Max-length:** 123 characters <br><br> **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled <br> Has lower characters <br>Has upper characters <br> Has a digit <br> Has a special character (Regex match [\\W_]) <br><br> **Disallowed values:** \"abc@123\", \"P@$$w0rd\", \"P@ssw0rd\", \"P@ssword123\", \"Pa$$word\", \"pass@word1\", \"Password!\", \"Password1\", \"Password22\", \"iloveyou!\""
+        },
+        "adminUsername": {
+          "type": "string",
+          "description": "Specifies the name of the administrator account. <br><br> **Restriction:** Cannot end in \".\" <br><br> **Disallowed values:** \"administrator\", \"admin\", \"user\", \"user1\", \"test\", \"user2\", \"test1\", \"user3\", \"admin1\", \"1\", \"123\", \"a\", \"actuser\", \"adm\", \"admin2\", \"aspnet\", \"backup\", \"console\", \"david\", \"guest\", \"john\", \"owner\", \"root\", \"server\", \"sql\", \"support\", \"support_388945a0\", \"sys\", \"test2\", \"test3\", \"user4\", \"user5\". <br><br> **Minimum-length:** 1 character <br><br> **Max-length:** 20 characters"
+        },
+        "enableCSIProxy": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For more details on CSI proxy, see the [CSI proxy GitHub repo](https://github.com/kubernetes-csi/csi-proxy)."
+        },
+        "gmsaProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/WindowsGmsaProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Windows gMSA Profile in the managed cluster."
+        },
+        "licenseType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "None",
+                "Windows_Server"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The license type to use for Windows VMs. See [Azure Hybrid User Benefits](https://azure.microsoft.com/pricing/hybrid-benefit/faq/) for more details."
+        }
+      },
+      "required": [
+        "adminUsername"
+      ],
+      "description": "Profile for Windows VMs in the managed cluster."
+    },
+    "ManagedClusterWorkloadAutoScalerProfile": {
+      "type": "object",
+      "properties": {
+        "keda": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterWorkloadAutoScalerProfileKeda"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile."
+        },
+        "verticalPodAutoscaler": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile."
+        }
+      },
+      "description": "Workload Auto-scaler profile for the managed cluster."
+    },
+    "ManagedClusterWorkloadAutoScalerProfileKeda": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable KEDA."
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "description": "KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile."
+    },
+    "ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable VPA. Default value is false."
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "description": "VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile."
+    },
+    "ManagedServiceIdentityUserAssignedIdentitiesValue": {
+      "type": "object",
+      "properties": {}
+    },
+    "PowerState": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Running",
+                "Stopped"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Tells whether the cluster is Running or Stopped."
+        }
+      },
+      "description": "Describes the Power State of the cluster"
+    },
+    "PrivateEndpoint": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The resource ID of the private endpoint"
+        }
+      },
+      "description": "Private endpoint which a connection belongs to."
+    },
+    "PrivateEndpointConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "privateEndpoint": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PrivateEndpoint"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Private endpoint which a connection belongs to."
+        },
+        "privateLinkServiceConnectionState": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PrivateLinkServiceConnectionState"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The state of a private link service connection."
+        }
+      },
+      "required": [
+        "privateLinkServiceConnectionState"
+      ],
+      "description": "Properties of a private endpoint connection."
+    },
+    "PrivateLinkResource": {
+      "type": "object",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "The group ID of the resource."
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the private link resource."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the private link resource."
+        },
+        "requiredMembers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The RequiredMembers of the resource"
+        },
+        "type": {
+          "type": "string",
+          "description": "The resource type."
+        }
+      },
+      "description": "A private link resource"
+    },
+    "PrivateLinkServiceConnectionState": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "The private link service connection description."
+        },
+        "status": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Pending",
+                "Approved",
+                "Rejected",
+                "Disconnected"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The private link service connection status."
+        }
+      },
+      "description": "The state of a private link service connection."
+    },
+    "RelativeMonthlySchedule": {
+      "type": "object",
+      "properties": {
+        "dayOfWeek": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Sunday",
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies on which day of the week the maintenance occurs."
+        },
+        "intervalMonths": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 6
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the number of months between each set of occurrences."
+        },
+        "weekIndex": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "First",
+                "Second",
+                "Third",
+                "Fourth",
+                "Last"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies on which week of the month the dayOfWeek applies."
+        }
+      },
+      "required": [
+        "dayOfWeek",
+        "intervalMonths",
+        "weekIndex"
+      ],
+      "description": "For schedules like: 'recur every month on the first Monday' or 'recur every 3 months on last Friday'."
+    },
+    "ResourceReference": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The fully qualified Azure resource id."
+        }
+      },
+      "description": "A reference to an Azure resource."
+    },
+    "Schedule": {
+      "type": "object",
+      "properties": {
+        "absoluteMonthly": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AbsoluteMonthlySchedule"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For schedules like: 'recur every month on the 15th' or 'recur every 3 months on the 20th'."
+        },
+        "daily": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DailySchedule"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For schedules like: 'recur every day' or 'recur every 3 days'."
+        },
+        "relativeMonthly": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RelativeMonthlySchedule"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For schedules like: 'recur every month on the first Monday' or 'recur every 3 months on last Friday'."
+        },
+        "weekly": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/WeeklySchedule"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For schedules like: 'recur every Monday' or 'recur every 3 weeks on Wednesday'."
+        }
+      },
+      "description": "One and only one of the schedule types should be specified. Choose either 'daily', 'weekly', 'absoluteMonthly' or 'relativeMonthly' for your maintenance schedule."
+    },
+    "ServiceMeshProfile": {
+      "type": "object",
+      "properties": {
+        "istio": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/IstioServiceMesh"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Istio service mesh configuration."
+        },
+        "mode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Istio",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Mode of the service mesh."
+        }
+      },
+      "required": [
+        "mode"
+      ],
+      "description": "Service mesh profile for a managed cluster."
+    },
+    "SnapshotProperties": {
+      "type": "object",
+      "properties": {
+        "creationData": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/CreationData"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Data used when creating a target resource from a source resource."
+        },
+        "snapshotType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "NodePool"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "description": "Properties used to configure a node pool snapshot."
+    },
+    "SysctlConfig": {
+      "type": "object",
+      "properties": {
+        "fsAioMaxNr": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting fs.aio-max-nr."
+        },
+        "fsFileMax": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting fs.file-max."
+        },
+        "fsInotifyMaxUserWatches": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting fs.inotify.max_user_watches."
+        },
+        "fsNrOpen": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting fs.nr_open."
+        },
+        "kernelThreadsMax": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting kernel.threads-max."
+        },
+        "netCoreNetdevMaxBacklog": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.core.netdev_max_backlog."
+        },
+        "netCoreOptmemMax": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.core.optmem_max."
+        },
+        "netCoreRmemDefault": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.core.rmem_default."
+        },
+        "netCoreRmemMax": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.core.rmem_max."
+        },
+        "netCoreSomaxconn": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.core.somaxconn."
+        },
+        "netCoreWmemDefault": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.core.wmem_default."
+        },
+        "netCoreWmemMax": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.core.wmem_max."
+        },
+        "netIpv4IpLocalPortRange": {
+          "type": "string",
+          "description": "Sysctl setting net.ipv4.ip_local_port_range."
+        },
+        "netIpv4NeighDefaultGcThresh1": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.neigh.default.gc_thresh1."
+        },
+        "netIpv4NeighDefaultGcThresh2": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.neigh.default.gc_thresh2."
+        },
+        "netIpv4NeighDefaultGcThresh3": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.neigh.default.gc_thresh3."
+        },
+        "netIpv4TcpFinTimeout": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.tcp_fin_timeout."
+        },
+        "netIpv4TcpkeepaliveIntvl": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 10,
+              "maximum": 90
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.tcp_keepalive_intvl."
+        },
+        "netIpv4TcpKeepaliveProbes": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.tcp_keepalive_probes."
+        },
+        "netIpv4TcpKeepaliveTime": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.tcp_keepalive_time."
+        },
+        "netIpv4TcpMaxSynBacklog": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.tcp_max_syn_backlog."
+        },
+        "netIpv4TcpMaxTwBuckets": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.tcp_max_tw_buckets."
+        },
+        "netIpv4TcpTwReuse": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.tcp_tw_reuse."
+        },
+        "netNetfilterNfConntrackBuckets": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 65536,
+              "maximum": 524288
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.netfilter.nf_conntrack_buckets."
+        },
+        "netNetfilterNfConntrackMax": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 131072,
+              "maximum": 2097152
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.netfilter.nf_conntrack_max."
+        },
+        "vmMaxMapCount": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting vm.max_map_count."
+        },
+        "vmSwappiness": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting vm.swappiness."
+        },
+        "vmVfsCachePressure": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting vm.vfs_cache_pressure."
+        }
+      },
+      "description": "Sysctl settings for Linux agent nodes."
+    },
+    "TimeInWeek": {
+      "type": "object",
+      "properties": {
+        "day": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Sunday",
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The day of the week."
+        },
+        "hourSlots": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Each integer hour represents a time range beginning at 0m after the hour ending at the next hour (non-inclusive). 0 corresponds to 00:00 UTC, 23 corresponds to 23:00 UTC. Specifying [0, 1] means the 00:00 - 02:00 UTC time range."
+        }
+      },
+      "description": "Time in a week."
+    },
+    "TimeSpan": {
+      "type": "object",
+      "properties": {
+        "end": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The end of a time span"
+        },
+        "start": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The start of a time span"
+        }
+      },
+      "description": "For example, between 2021-05-25T13:00:00Z and 2021-05-25T14:00:00Z."
+    },
+    "UpgradeOverrideSettings": {
+      "type": "object",
+      "properties": {
+        "forceUpgrade": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to force upgrade the cluster. Note that this option instructs upgrade operation to bypass upgrade protections such as checking for deprecated API usage. Enable this option only with caution."
+        },
+        "until": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Until when the overrides are effective. Note that this only matches the start time of an upgrade, and the effectiveness won't change once an upgrade starts even if the `until` expires as upgrade proceeds. This field is not set by default. It must be set for the overrides to take effect."
+        }
+      },
+      "description": "Settings for overrides when upgrading a cluster."
+    },
+    "UserAssignedIdentity": {
+      "type": "object",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The client ID of the user assigned identity."
+        },
+        "objectId": {
+          "type": "string",
+          "description": "The object ID of the user assigned identity."
+        },
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the user assigned identity."
+        }
+      },
+      "description": "Details about a user assigned identity."
+    },
+    "WeeklySchedule": {
+      "type": "object",
+      "properties": {
+        "dayOfWeek": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Sunday",
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies on which day of the week the maintenance occurs."
+        },
+        "intervalWeeks": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 4
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the number of weeks between each set of occurrences."
+        }
+      },
+      "required": [
+        "dayOfWeek",
+        "intervalWeeks"
+      ],
+      "description": "For schedules like: 'recur every Monday' or 'recur every 3 weeks on Wednesday'."
+    },
+    "WindowsGmsaProfile": {
+      "type": "object",
+      "properties": {
+        "dnsServer": {
+          "type": "string",
+          "description": "Specifies the DNS server for Windows gMSA. <br><br> Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster."
+        },
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies whether to enable Windows gMSA in the managed cluster."
+        },
+        "rootDomainName": {
+          "type": "string",
+          "description": "Specifies the root domain name for Windows gMSA. <br><br> Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster."
+        }
+      },
+      "description": "Windows gMSA Profile in the managed cluster."
+    }
+  }
+}

--- a/schemas/2023-08-02-preview/Microsoft.ContainerService.json
+++ b/schemas/2023-08-02-preview/Microsoft.ContainerService.json
@@ -1,0 +1,5952 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2023-08-02-preview/Microsoft.ContainerService.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Microsoft.ContainerService",
+  "description": "Microsoft ContainerService Resource Types",
+  "resourceDefinitions": {
+    "managedClusters": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-02-preview"
+          ]
+        },
+        "extendedLocation": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ExtendedLocation"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The complex type of the extended location."
+        },
+        "identity": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterIdentity"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Identity for the managed cluster."
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives"
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$",
+              "minLength": 1,
+              "maxLength": 63
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the managed cluster resource."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of the managed cluster."
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/managedClusters_maintenanceConfigurations_childResource"
+              },
+              {
+                "$ref": "#/definitions/managedClusters_agentPools_childResource"
+              },
+              {
+                "$ref": "#/definitions/managedClusters_privateEndpointConnections_childResource"
+              },
+              {
+                "$ref": "#/definitions/managedClusters_trustedAccessRoleBindings_childResource"
+              }
+            ]
+          }
+        },
+        "sku": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterSKU"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The SKU of a Managed Cluster."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.ContainerService/managedClusters"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/managedClusters"
+    },
+    "managedclustersnapshots": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-02-preview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives"
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$",
+              "minLength": 1,
+              "maxLength": 63
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the managed cluster resource."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterSnapshotProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for a managed cluster snapshot."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.ContainerService/managedclustersnapshots"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/managedclustersnapshots"
+    },
+    "managedClusters_agentPools": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-02-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9]{0,11}$",
+              "minLength": 1,
+              "maxLength": 12
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the agent pool."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAgentPoolProfileProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for the container service agent pool profile."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.ContainerService/managedClusters/agentPools"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/managedClusters/agentPools"
+    },
+    "managedClusters_maintenanceConfigurations": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-02-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the maintenance configuration."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MaintenanceConfigurationProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties used to configure planned maintenance for a Managed Cluster."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.ContainerService/managedClusters/maintenanceConfigurations"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/managedClusters/maintenanceConfigurations"
+    },
+    "managedClusters_privateEndpointConnections": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-02-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the private endpoint connection."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PrivateEndpointConnectionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a private endpoint connection."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.ContainerService/managedClusters/privateEndpointConnections"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/managedClusters/privateEndpointConnections"
+    },
+    "managedClusters_trustedAccessRoleBindings": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-02-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^([A-Za-z0-9-])+$",
+              "minLength": 1,
+              "maxLength": 24
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of trusted access role binding."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TrustedAccessRoleBindingProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for trusted access role binding"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.ContainerService/managedClusters/trustedAccessRoleBindings"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/managedClusters/trustedAccessRoleBindings"
+    },
+    "snapshots": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-02-preview"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives"
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$",
+              "minLength": 1,
+              "maxLength": 63
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the managed cluster resource."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SnapshotProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties used to configure a node pool snapshot."
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource tags."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Microsoft.ContainerService/snapshots"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "location",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/snapshots"
+    }
+  },
+  "definitions": {
+    "AbsoluteMonthlySchedule": {
+      "type": "object",
+      "properties": {
+        "dayOfMonth": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 31
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The date of the month."
+        },
+        "intervalMonths": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 6
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the number of months between each set of occurrences."
+        }
+      },
+      "required": [
+        "dayOfMonth",
+        "intervalMonths"
+      ],
+      "description": "For schedules like: 'recur every month on the 15th' or 'recur every 3 months on the 20th'."
+    },
+    "AgentPoolNetworkProfile": {
+      "type": "object",
+      "properties": {
+        "allowedHostPorts": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PortRange"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The port ranges that are allowed to access. The specified ranges are allowed to overlap."
+        },
+        "applicationSecurityGroups": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The IDs of the application security groups which agent pool will associate when created."
+        },
+        "nodePublicIPTags": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/IPTag"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of tags associated with the node public IP address."
+        }
+      },
+      "description": "Network settings of an agent pool."
+    },
+    "AgentPoolSecurityProfile": {
+      "type": "object",
+      "properties": {
+        "sshAccess": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "LocalUser",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "SSH access method of an agent pool."
+        }
+      },
+      "description": "The security settings of an agent pool."
+    },
+    "AgentPoolUpgradeSettings": {
+      "type": "object",
+      "properties": {
+        "drainTimeoutInMinutes": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1440
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The amount of time (in minutes) to wait on eviction of pods and graceful termination per node. This eviction wait time honors waiting on pod disruption budgets. If this time is exceeded, the upgrade fails. If not specified, the default is 30 minutes."
+        },
+        "maxSurge": {
+          "type": "string",
+          "description": "This can either be set to an integer (e.g. '5') or a percentage (e.g. '50%'). If a percentage is specified, it is the percentage of the total agent pool size at the time of the upgrade. For percentages, fractional nodes are rounded up. If not specified, the default is 1. For more information, including best practices, see: https://docs.microsoft.com/azure/aks/upgrade-cluster#customize-node-surge-upgrade"
+        }
+      },
+      "description": "Settings for upgrading an agentpool"
+    },
+    "AgentPoolWindowsProfile": {
+      "type": "object",
+      "properties": {
+        "disableOutboundNat": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The default value is false. Outbound NAT can only be disabled if the cluster outboundType is NAT Gateway and the Windows agent pool does not have node public IP enabled."
+        }
+      },
+      "description": "The Windows agent pool's specific profile."
+    },
+    "AzureKeyVaultKms": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable Azure Key Vault key management service. The default is false."
+        },
+        "keyId": {
+          "type": "string",
+          "description": "Identifier of Azure Key Vault key. See [key identifier format](https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name) for more details. When Azure Key Vault key management service is enabled, this field is required and must be a valid key identifier. When Azure Key Vault key management service is disabled, leave the field empty."
+        },
+        "keyVaultNetworkAccess": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Public",
+                "Private"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`."
+        },
+        "keyVaultResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource ID of key vault. When keyVaultNetworkAccess is `Private`, this field is required and must be a valid resource ID. When keyVaultNetworkAccess is `Public`, leave the field empty."
+        }
+      },
+      "description": "Azure Key Vault key management service settings for the security profile."
+    },
+    "ClusterUpgradeSettings": {
+      "type": "object",
+      "properties": {
+        "overrideSettings": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UpgradeOverrideSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Settings for overrides when upgrading a cluster."
+        }
+      },
+      "description": "Settings for upgrading a cluster."
+    },
+    "ContainerServiceLinuxProfile": {
+      "type": "object",
+      "properties": {
+        "adminUsername": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[A-Za-z][-A-Za-z0-9_]*$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The administrator username to use for Linux VMs."
+        },
+        "ssh": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ContainerServiceSshConfiguration"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "SSH configuration for Linux-based VMs running on Azure."
+        }
+      },
+      "required": [
+        "adminUsername",
+        "ssh"
+      ],
+      "description": "Profile for Linux VMs in the container service cluster."
+    },
+    "ContainerServiceNetworkProfile": {
+      "type": "object",
+      "properties": {
+        "dnsServiceIP": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$",
+              "default": "10.0.0.10"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "An IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr."
+        },
+        "ipFamilies": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "IPv4",
+                  "IPv6"
+                ]
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "IP families are used to determine single-stack or dual-stack clusters. For single-stack, the expected value is IPv4. For dual-stack, the expected values are IPv4 and IPv6."
+        },
+        "kubeProxyConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ContainerServiceNetworkProfileKubeProxyConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Holds configuration customizations for kube-proxy. Any values not defined will use the kube-proxy defaulting behavior. See https://v<version>.docs.kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/ where <version> is represented by a <major version>-<minor version> string. Kubernetes version 1.23 would be '1-23'."
+        },
+        "loadBalancerProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterLoadBalancerProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile of the managed cluster load balancer."
+        },
+        "loadBalancerSku": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "standard",
+                "basic"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The default is 'standard'. See [Azure Load Balancer SKUs](https://docs.microsoft.com/azure/load-balancer/skus) for more information about the differences between load balancer SKUs."
+        },
+        "monitoring": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/NetworkMonitoring"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This addon can be used to configure network monitoring and generate network monitoring data in Prometheus format"
+        },
+        "natGatewayProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterNATGatewayProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile of the managed cluster NAT gateway."
+        },
+        "networkDataplane": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "azure",
+                "cilium"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Network dataplane used in the Kubernetes cluster."
+        },
+        "networkMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "transparent",
+                "bridge"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This cannot be specified if networkPlugin is anything other than 'azure'."
+        },
+        "networkPlugin": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "azure",
+                "kubenet",
+                "none"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Network plugin used for building the Kubernetes network."
+        },
+        "networkPluginMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "overlay"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Network plugin mode used for building the Kubernetes network."
+        },
+        "networkPolicy": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "none",
+                "calico",
+                "azure",
+                "cilium"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Network policy used for building the Kubernetes network."
+        },
+        "outboundType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "loadBalancer",
+                "userDefinedRouting",
+                "managedNATGateway",
+                "userAssignedNATGateway"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This can only be set at cluster creation time and cannot be changed later. For more information see [egress outbound type](https://docs.microsoft.com/azure/aks/egress-outboundtype)."
+        },
+        "podCidr": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))?$",
+              "default": "10.244.0.0/16"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "A CIDR notation IP range from which to assign pod IPs when kubenet is used."
+        },
+        "podCidrs": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking."
+        },
+        "serviceCidr": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))?$",
+              "default": "10.0.0.0/16"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges."
+        },
+        "serviceCidrs": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking. They must not overlap with any Subnet IP ranges."
+        }
+      },
+      "description": "Profile of network configuration."
+    },
+    "ContainerServiceNetworkProfileKubeProxyConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable on kube-proxy on the cluster (if no 'kubeProxyConfig' exists, kube-proxy is enabled in AKS by default without these customizations)."
+        },
+        "ipvsConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ContainerServiceNetworkProfileKubeProxyConfigIpvsConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Holds configuration customizations for IPVS. May only be specified if 'mode' is set to 'IPVS'."
+        },
+        "mode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "IPTABLES",
+                "IPVS"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specify which proxy mode to use ('IPTABLES' or 'IPVS')."
+        }
+      },
+      "description": "Holds configuration customizations for kube-proxy. Any values not defined will use the kube-proxy defaulting behavior. See https://v<version>.docs.kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/ where <version> is represented by a <major version>-<minor version> string. Kubernetes version 1.23 would be '1-23'."
+    },
+    "ContainerServiceNetworkProfileKubeProxyConfigIpvsConfig": {
+      "type": "object",
+      "properties": {
+        "scheduler": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "RoundRobin",
+                "LeastConnection"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "IPVS scheduler, for more information please see http://www.linuxvirtualserver.org/docs/scheduling.html."
+        },
+        "tcpFinTimeoutSeconds": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The timeout value used for IPVS TCP sessions after receiving a FIN in seconds. Must be a positive integer value."
+        },
+        "tcpTimeoutSeconds": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The timeout value used for idle IPVS TCP sessions in seconds. Must be a positive integer value."
+        },
+        "udpTimeoutSeconds": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The timeout value used for IPVS UDP packets in seconds. Must be a positive integer value."
+        }
+      },
+      "description": "Holds configuration customizations for IPVS. May only be specified if 'mode' is set to 'IPVS'."
+    },
+    "ContainerServiceSshConfiguration": {
+      "type": "object",
+      "properties": {
+        "publicKeys": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ContainerServiceSshPublicKey"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of SSH public keys used to authenticate with Linux-based VMs. A maximum of 1 key may be specified."
+        }
+      },
+      "required": [
+        "publicKeys"
+      ],
+      "description": "SSH configuration for Linux-based VMs running on Azure."
+    },
+    "ContainerServiceSshPublicKey": {
+      "type": "object",
+      "properties": {
+        "keyData": {
+          "type": "string",
+          "description": "Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers."
+        }
+      },
+      "required": [
+        "keyData"
+      ],
+      "description": "Contains information about SSH certificate public key data."
+    },
+    "CreationData": {
+      "type": "object",
+      "properties": {
+        "sourceResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "This is the ARM ID of the source object to be used to create the target object."
+        }
+      },
+      "description": "Data used when creating a target resource from a source resource."
+    },
+    "DailySchedule": {
+      "type": "object",
+      "properties": {
+        "intervalDays": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 7
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the number of days between each set of occurrences."
+        }
+      },
+      "required": [
+        "intervalDays"
+      ],
+      "description": "For schedules like: 'recur every day' or 'recur every 3 days'."
+    },
+    "DateSpan": {
+      "type": "object",
+      "properties": {
+        "end": {
+          "type": "string",
+          "format": "date",
+          "description": "The end date of the date span."
+        },
+        "start": {
+          "type": "string",
+          "format": "date",
+          "description": "The start date of the date span."
+        }
+      },
+      "required": [
+        "end",
+        "start"
+      ],
+      "description": "For example, between '2022-12-23' and '2023-01-05'."
+    },
+    "DelegatedResource": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "The source resource location - internal use only."
+        },
+        "referralResource": {
+          "type": "string",
+          "description": "The delegation id of the referral delegation (optional) - internal use only."
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "The ARM resource id of the delegated resource - internal use only."
+        },
+        "tenantId": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The tenant id of the delegated resource - internal use only."
+        }
+      },
+      "description": "Delegated resource properties - internal use only."
+    },
+    "ExtendedLocation": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the extended location."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "EdgeZone"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of the extended location."
+        }
+      },
+      "description": "The complex type of the extended location."
+    },
+    "GuardrailsProfile": {
+      "type": "object",
+      "properties": {
+        "excludedNamespaces": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "List of namespaces excluded from guardrails checks"
+        },
+        "level": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Off",
+                "Warning",
+                "Enforcement"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The guardrails level to be used. By default, Guardrails is enabled for all namespaces except those that AKS excludes via systemExcludedNamespaces."
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of constraints to use"
+        }
+      },
+      "required": [
+        "level"
+      ],
+      "description": "The Guardrails profile."
+    },
+    "IPTag": {
+      "type": "object",
+      "properties": {
+        "ipTagType": {
+          "type": "string",
+          "description": "The IP tag type. Example: RoutingPreference."
+        },
+        "tag": {
+          "type": "string",
+          "description": "The value of the IP tag associated with the public IP. Example: Internet."
+        }
+      },
+      "description": "Contains the IPTag associated with the object."
+    },
+    "IstioCertificateAuthority": {
+      "type": "object",
+      "properties": {
+        "plugin": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/IstioPluginCertificateAuthority"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Plugin certificates information for Service Mesh."
+        }
+      },
+      "description": "Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca"
+    },
+    "IstioComponents": {
+      "type": "object",
+      "properties": {
+        "egressGateways": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/IstioEgressGateway"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Istio egress gateways."
+        },
+        "ingressGateways": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/IstioIngressGateway"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Istio ingress gateways."
+        }
+      },
+      "description": "Istio components configuration."
+    },
+    "IstioEgressGateway": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable the egress gateway."
+        },
+        "nodeSelector": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "NodeSelector for scheduling the egress gateway."
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "description": "Istio egress gateway configuration."
+    },
+    "IstioIngressGateway": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable the ingress gateway."
+        },
+        "mode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "External",
+                "Internal"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Mode of an ingress gateway."
+        }
+      },
+      "required": [
+        "enabled",
+        "mode"
+      ],
+      "description": "Istio ingress gateway configuration. For now, we support up to one external ingress gateway named `aks-istio-ingressgateway-external` and one internal ingress gateway named `aks-istio-ingressgateway-internal`."
+    },
+    "IstioPluginCertificateAuthority": {
+      "type": "object",
+      "properties": {
+        "certChainObjectName": {
+          "type": "string",
+          "description": "Certificate chain object name in Azure Key Vault."
+        },
+        "certObjectName": {
+          "type": "string",
+          "description": "Intermediate certificate object name in Azure Key Vault."
+        },
+        "keyObjectName": {
+          "type": "string",
+          "description": "Intermediate certificate private key object name in Azure Key Vault."
+        },
+        "keyVaultId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the Key Vault."
+        },
+        "rootCertObjectName": {
+          "type": "string",
+          "description": "Root certificate object name in Azure Key Vault."
+        }
+      },
+      "description": "Plugin certificates information for Service Mesh."
+    },
+    "IstioServiceMesh": {
+      "type": "object",
+      "properties": {
+        "certificateAuthority": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/IstioCertificateAuthority"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca"
+        },
+        "components": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/IstioComponents"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Istio components configuration."
+        },
+        "revisions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of revisions of the Istio control plane. When an upgrade is not in progress, this holds one value. When canary upgrade is in progress, this can only hold two consecutive values. For more information, see: https://learn.microsoft.com/en-us/azure/aks/istio-upgrade"
+        }
+      },
+      "description": "Istio service mesh configuration."
+    },
+    "KubeletConfig": {
+      "type": "object",
+      "properties": {
+        "allowedUnsafeSysctls": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Allowed list of unsafe sysctls or unsafe sysctl patterns (ending in `*`)."
+        },
+        "containerLogMaxFiles": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 2
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum number of container log files that can be present for a container. The number must be ≥ 2."
+        },
+        "containerLogMaxSizeMB": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum size (e.g. 10Mi) of container log file before it is rotated."
+        },
+        "cpuCfsQuota": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The default is true."
+        },
+        "cpuCfsQuotaPeriod": {
+          "type": "string",
+          "description": "The default is '100ms.' Valid values are a sequence of decimal numbers with an optional fraction and a unit suffix. For example: '300ms', '2h45m'. Supported units are 'ns', 'us', 'ms', 's', 'm', and 'h'."
+        },
+        "cpuManagerPolicy": {
+          "type": "string",
+          "description": "The default is 'none'. See [Kubernetes CPU management policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-management-policies) for more information. Allowed values are 'none' and 'static'."
+        },
+        "failSwapOn": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "If set to true it will make the Kubelet fail to start if swap is enabled on the node."
+        },
+        "imageGcHighThreshold": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "To disable image garbage collection, set to 100. The default is 85%"
+        },
+        "imageGcLowThreshold": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This cannot be set higher than imageGcHighThreshold. The default is 80%"
+        },
+        "podMaxPids": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum number of processes per pod."
+        },
+        "topologyManagerPolicy": {
+          "type": "string",
+          "description": "For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'."
+        }
+      },
+      "description": "See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details."
+    },
+    "LinuxOSConfig": {
+      "type": "object",
+      "properties": {
+        "swapFileSizeMB": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The size in MB of a swap file that will be created on each node."
+        },
+        "sysctls": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SysctlConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl settings for Linux agent nodes."
+        },
+        "transparentHugePageDefrag": {
+          "type": "string",
+          "description": "Valid values are 'always', 'defer', 'defer+madvise', 'madvise' and 'never'. The default is 'madvise'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge)."
+        },
+        "transparentHugePageEnabled": {
+          "type": "string",
+          "description": "Valid values are 'always', 'madvise', and 'never'. The default is 'always'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge)."
+        }
+      },
+      "description": "See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details."
+    },
+    "MaintenanceConfigurationProperties": {
+      "type": "object",
+      "properties": {
+        "maintenanceWindow": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MaintenanceWindow"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Maintenance window used to configure scheduled auto-upgrade for a Managed Cluster."
+        },
+        "notAllowedTime": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TimeSpan"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Time slots on which upgrade is not allowed."
+        },
+        "timeInWeek": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TimeInWeek"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "If two array entries specify the same day of the week, the applied configuration is the union of times in both entries."
+        }
+      },
+      "description": "Properties used to configure planned maintenance for a Managed Cluster."
+    },
+    "MaintenanceWindow": {
+      "type": "object",
+      "properties": {
+        "durationHours": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 4,
+              "maximum": 24,
+              "default": "24"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Length of maintenance window range from 4 to 24 hours."
+        },
+        "notAllowedDates": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DateSpan"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Date ranges on which upgrade is not allowed. 'utcOffset' applies to this field. For example, with 'utcOffset: +02:00' and 'dateSpan' being '2022-12-23' to '2023-01-03', maintenance will be blocked from '2022-12-22 22:00' to '2023-01-03 22:00' in UTC time."
+        },
+        "schedule": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schedule"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "One and only one of the schedule types should be specified. Choose either 'daily', 'weekly', 'absoluteMonthly' or 'relativeMonthly' for your maintenance schedule."
+        },
+        "startDate": {
+          "type": "string",
+          "format": "date",
+          "description": "The date the maintenance window activates. If the current date is before this date, the maintenance window is inactive and will not be used for upgrades. If not specified, the maintenance window will be active right away."
+        },
+        "startTime": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^\\d{2}:\\d{2}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The start time of the maintenance window. Accepted values are from '00:00' to '23:59'. 'utcOffset' applies to this field. For example: '02:00' with 'utcOffset: +02:00' means UTC time '00:00'."
+        },
+        "utcOffset": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(-|\\+)[0-9]{2}:[0-9]{2}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The UTC offset in format +/-HH:mm. For example, '+05:30' for IST and '-07:00' for PST. If not specified, the default is '+00:00'."
+        }
+      },
+      "required": [
+        "durationHours",
+        "schedule",
+        "startTime"
+      ],
+      "description": "Maintenance window used to configure scheduled auto-upgrade for a Managed Cluster."
+    },
+    "ManagedClusterAADProfile": {
+      "type": "object",
+      "properties": {
+        "adminGroupObjectIDs": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of AAD group object IDs that will have admin role of the cluster."
+        },
+        "clientAppID": {
+          "type": "string",
+          "description": "(DEPRECATED) The client AAD application ID. Learn more at https://aka.ms/aks/aad-legacy."
+        },
+        "enableAzureRBAC": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable Azure RBAC for Kubernetes authorization."
+        },
+        "managed": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable managed AAD."
+        },
+        "serverAppID": {
+          "type": "string",
+          "description": "(DEPRECATED) The server AAD application ID. Learn more at https://aka.ms/aks/aad-legacy."
+        },
+        "serverAppSecret": {
+          "type": "string",
+          "description": "(DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy."
+        },
+        "tenantID": {
+          "type": "string",
+          "description": "The AAD tenant ID to use for authentication. If not specified, will use the tenant of the deployment subscription."
+        }
+      },
+      "description": "For more details see [managed AAD on AKS](https://docs.microsoft.com/azure/aks/managed-aad)."
+    },
+    "ManagedClusterAddonProfile": {
+      "type": "object",
+      "properties": {
+        "config": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Key-value pairs for configuring an add-on."
+        },
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether the add-on is enabled or not."
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "description": "A Kubernetes add-on profile for a managed cluster."
+    },
+    "ManagedClusterAgentPoolProfile": {
+      "type": "object",
+      "properties": {
+        "availabilityZones": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'."
+        },
+        "capacityReservationGroupID": {
+          "type": "string",
+          "description": "Capacity Reservation Group ID for AgentPool to associate"
+        },
+        "count": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1."
+        },
+        "creationData": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/CreationData"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Data used when creating a target resource from a source resource."
+        },
+        "enableAutoScaling": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable auto-scaler"
+        },
+        "enableCustomCATrust": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "When set to true, AKS adds a label to the node indicating that the feature is enabled and deploys a daemonset along with host services to sync custom certificate authorities from user-provided list of base64 encoded certificates into node trust stores. Defaults to false."
+        },
+        "enableEncryptionAtHost": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption"
+        },
+        "enableFIPS": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details."
+        },
+        "enableNodePublicIP": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false."
+        },
+        "enableUltraSSD": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable UltraSSD"
+        },
+        "gpuInstanceProfile": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "MIG1g",
+                "MIG2g",
+                "MIG3g",
+                "MIG4g",
+                "MIG7g"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU."
+        },
+        "hostGroupID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts)."
+        },
+        "kubeletConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/KubeletConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details."
+        },
+        "kubeletDiskType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "OS",
+                "Temporary"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "linuxOSConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/LinuxOSConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details."
+        },
+        "maxCount": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum number of nodes for auto-scaling"
+        },
+        "maxPods": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum number of pods that can run on a node."
+        },
+        "messageOfTheDay": {
+          "type": "string",
+          "description": "A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script)."
+        },
+        "minCount": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The minimum number of nodes for auto-scaling"
+        },
+        "mode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "System",
+                "User"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9]{0,11}$"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Windows agent pool names must be 6 characters or less."
+        },
+        "networkProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AgentPoolNetworkProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Network settings of an agent pool."
+        },
+        "nodeLabels": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The node labels to be persisted across all nodes in agent pool."
+        },
+        "nodePublicIPPrefixID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}"
+        },
+        "nodeTaints": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule."
+        },
+        "orchestratorVersion": {
+          "type": "string",
+          "description": "Both patch version <major.minor.patch> and <major.minor> are supported. When <major.minor> is specified, the latest supported patch version is chosen automatically. Updating the agent pool with the same <major.minor> once it has been created will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool)."
+        },
+        "osDiskSizeGB": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2048
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified."
+        },
+        "osDiskType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Managed",
+                "Ephemeral"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "osSKU": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Ubuntu",
+                "Mariner",
+                "AzureLinux",
+                "CBLMariner",
+                "Windows2019",
+                "Windows2022"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "osType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Linux",
+                "Windows"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "podSubnetID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
+        },
+        "powerState": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PowerState"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Describes the Power State of the cluster"
+        },
+        "proximityPlacementGroupID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ID for Proximity Placement Group."
+        },
+        "scaleDownMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Delete",
+                "Deallocate"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete."
+        },
+        "scaleSetEvictionPolicy": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Delete",
+                "Deallocate"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'."
+        },
+        "scaleSetPriority": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Spot",
+                "Regular"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'."
+        },
+        "securityProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AgentPoolSecurityProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The security settings of an agent pool."
+        },
+        "spotMaxPrice": {
+          "oneOf": [
+            {
+              "type": "number",
+              "default": -1.0
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing)"
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The tags to be persisted on the agent pool virtual machine scale set."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "VirtualMachineScaleSets",
+                "AvailabilitySet"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "upgradeSettings": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AgentPoolUpgradeSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Settings for upgrading an agentpool"
+        },
+        "vmSize": {
+          "type": "string",
+          "description": "VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions"
+        },
+        "vnetSubnetID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
+        },
+        "windowsProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AgentPoolWindowsProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The Windows agent pool's specific profile."
+        },
+        "workloadRuntime": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "OCIContainer",
+                "WasmWasi",
+                "KataMshvVmIsolation"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "description": "Profile for the container service agent pool."
+    },
+    "ManagedClusterAgentPoolProfileProperties": {
+      "type": "object",
+      "properties": {
+        "availabilityZones": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'."
+        },
+        "capacityReservationGroupID": {
+          "type": "string",
+          "description": "Capacity Reservation Group ID for AgentPool to associate"
+        },
+        "count": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1."
+        },
+        "creationData": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/CreationData"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Data used when creating a target resource from a source resource."
+        },
+        "enableAutoScaling": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable auto-scaler"
+        },
+        "enableCustomCATrust": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "When set to true, AKS adds a label to the node indicating that the feature is enabled and deploys a daemonset along with host services to sync custom certificate authorities from user-provided list of base64 encoded certificates into node trust stores. Defaults to false."
+        },
+        "enableEncryptionAtHost": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption"
+        },
+        "enableFIPS": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details."
+        },
+        "enableNodePublicIP": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false."
+        },
+        "enableUltraSSD": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable UltraSSD"
+        },
+        "gpuInstanceProfile": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "MIG1g",
+                "MIG2g",
+                "MIG3g",
+                "MIG4g",
+                "MIG7g"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU."
+        },
+        "hostGroupID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts)."
+        },
+        "kubeletConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/KubeletConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details."
+        },
+        "kubeletDiskType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "OS",
+                "Temporary"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "linuxOSConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/LinuxOSConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details."
+        },
+        "maxCount": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum number of nodes for auto-scaling"
+        },
+        "maxPods": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum number of pods that can run on a node."
+        },
+        "messageOfTheDay": {
+          "type": "string",
+          "description": "A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script)."
+        },
+        "minCount": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The minimum number of nodes for auto-scaling"
+        },
+        "mode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "System",
+                "User"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "networkProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AgentPoolNetworkProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Network settings of an agent pool."
+        },
+        "nodeLabels": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The node labels to be persisted across all nodes in agent pool."
+        },
+        "nodePublicIPPrefixID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}"
+        },
+        "nodeTaints": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule."
+        },
+        "orchestratorVersion": {
+          "type": "string",
+          "description": "Both patch version <major.minor.patch> and <major.minor> are supported. When <major.minor> is specified, the latest supported patch version is chosen automatically. Updating the agent pool with the same <major.minor> once it has been created will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool)."
+        },
+        "osDiskSizeGB": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2048
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified."
+        },
+        "osDiskType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Managed",
+                "Ephemeral"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "osSKU": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Ubuntu",
+                "Mariner",
+                "AzureLinux",
+                "CBLMariner",
+                "Windows2019",
+                "Windows2022"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "osType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Linux",
+                "Windows"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "podSubnetID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
+        },
+        "powerState": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PowerState"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Describes the Power State of the cluster"
+        },
+        "proximityPlacementGroupID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ID for Proximity Placement Group."
+        },
+        "scaleDownMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Delete",
+                "Deallocate"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete."
+        },
+        "scaleSetEvictionPolicy": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Delete",
+                "Deallocate"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'."
+        },
+        "scaleSetPriority": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Spot",
+                "Regular"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'."
+        },
+        "securityProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AgentPoolSecurityProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The security settings of an agent pool."
+        },
+        "spotMaxPrice": {
+          "oneOf": [
+            {
+              "type": "number",
+              "default": -1.0
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing)"
+        },
+        "tags": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The tags to be persisted on the agent pool virtual machine scale set."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "VirtualMachineScaleSets",
+                "AvailabilitySet"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "upgradeSettings": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AgentPoolUpgradeSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Settings for upgrading an agentpool"
+        },
+        "vmSize": {
+          "type": "string",
+          "description": "VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions"
+        },
+        "vnetSubnetID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
+        },
+        "windowsProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AgentPoolWindowsProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The Windows agent pool's specific profile."
+        },
+        "workloadRuntime": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "OCIContainer",
+                "WasmWasi",
+                "KataMshvVmIsolation"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "description": "Properties for the container service agent pool profile."
+    },
+    "ManagedClusterAPIServerAccessProfile": {
+      "type": "object",
+      "properties": {
+        "authorizedIPRanges": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "IP ranges are specified in CIDR format, e.g. 137.117.106.88/29. This feature is not compatible with clusters that use Public IP Per Node, or clusters that are using a Basic Load Balancer. For more information see [API server authorized IP ranges](https://docs.microsoft.com/azure/aks/api-server-authorized-ip-ranges)."
+        },
+        "disableRunCommand": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to disable run command for the cluster or not."
+        },
+        "enablePrivateCluster": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For more details, see [Creating a private AKS cluster](https://docs.microsoft.com/azure/aks/private-clusters)."
+        },
+        "enablePrivateClusterPublicFQDN": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to create additional public FQDN for private cluster or not."
+        },
+        "enableVnetIntegration": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable apiserver vnet integration for the cluster or not."
+        },
+        "privateDNSZone": {
+          "type": "string",
+          "description": "The default is System. For more details see [configure private DNS zone](https://docs.microsoft.com/azure/aks/private-clusters#configure-private-dns-zone). Allowed values are 'system' and 'none'."
+        },
+        "subnetId": {
+          "type": "string",
+          "description": "It is required when: 1. creating a new cluster with BYO Vnet; 2. updating an existing cluster to enable apiserver vnet integration."
+        }
+      },
+      "description": "Access profile for managed cluster API server."
+    },
+    "ManagedClusterAutoUpgradeProfile": {
+      "type": "object",
+      "properties": {
+        "nodeOSUpgradeChannel": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "None",
+                "Unmanaged",
+                "SecurityPatch",
+                "NodeImage"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The default is Unmanaged, but may change to either NodeImage or SecurityPatch at GA."
+        },
+        "upgradeChannel": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "rapid",
+                "stable",
+                "patch",
+                "node-image",
+                "none"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For more information see [setting the AKS cluster auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel)."
+        }
+      },
+      "description": "Auto upgrade profile for a managed cluster."
+    },
+    "ManagedClusterAzureMonitorProfile": {
+      "type": "object",
+      "properties": {
+        "logs": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAzureMonitorProfileLogs"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Logs profile for the Azure Monitor Infrastructure and Application Logs. Collect out-of-the-box Kubernetes infrastructure & application logs to send to Azure Monitor. See aka.ms/AzureMonitorContainerInsights for an overview."
+        },
+        "metrics": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAzureMonitorProfileMetrics"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Metrics profile for the prometheus service addon"
+        }
+      },
+      "description": "Prometheus addon profile for the container service cluster"
+    },
+    "ManagedClusterAzureMonitorProfileAppMonitoring": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Indicates if Application Monitoring enabled or not."
+        }
+      },
+      "description": "Application Monitoring Profile for Kubernetes Application Container. Collects application logs, metrics and traces through auto-instrumentation of the application using Azure Monitor OpenTelemetry based SDKs. See aka.ms/AzureMonitorApplicationMonitoring for an overview."
+    },
+    "ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Indicates if Application Monitoring Open Telemetry Metrics is enabled or not."
+        }
+      },
+      "description": "Application Monitoring Open Telemetry Metrics Profile for Kubernetes Application Container Metrics. Collects OpenTelemetry metrics through auto-instrumentation of the application using Azure Monitor OpenTelemetry based SDKs. See aka.ms/AzureMonitorApplicationMonitoring for an overview."
+    },
+    "ManagedClusterAzureMonitorProfileContainerInsights": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Indicates if Azure Monitor Container Insights Logs Addon is enabled or not."
+        },
+        "logAnalyticsWorkspaceResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Fully Qualified ARM Resource Id of Azure Log Analytics Workspace for storing Azure Monitor Container Insights Logs."
+        },
+        "windowsHostLogs": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAzureMonitorProfileWindowsHostLogs"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Windows Host Logs Profile for Kubernetes Windows Nodes Log Collection. Collects ETW, Event Logs and Text logs etc. See aka.ms/AzureMonitorContainerInsights for an overview."
+        }
+      },
+      "description": "Azure Monitor Container Insights Profile for Kubernetes Events, Inventory and Container stdout & stderr logs etc. See aka.ms/AzureMonitorContainerInsights for an overview."
+    },
+    "ManagedClusterAzureMonitorProfileKubeStateMetrics": {
+      "type": "object",
+      "properties": {
+        "metricAnnotationsAllowList": {
+          "type": "string",
+          "description": "Comma-separated list of additional Kubernetes label keys that will be used in the resource's labels metric."
+        },
+        "metricLabelsAllowlist": {
+          "type": "string",
+          "description": "Comma-separated list of Kubernetes annotations keys that will be used in the resource's labels metric. "
+        }
+      },
+      "description": "Kube State Metrics for prometheus addon profile for the container service cluster"
+    },
+    "ManagedClusterAzureMonitorProfileLogs": {
+      "type": "object",
+      "properties": {
+        "appMonitoring": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAzureMonitorProfileAppMonitoring"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Application Monitoring Profile for Kubernetes Application Container. Collects application logs, metrics and traces through auto-instrumentation of the application using Azure Monitor OpenTelemetry based SDKs. See aka.ms/AzureMonitorApplicationMonitoring for an overview."
+        },
+        "containerInsights": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAzureMonitorProfileContainerInsights"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Azure Monitor Container Insights Profile for Kubernetes Events, Inventory and Container stdout & stderr logs etc. See aka.ms/AzureMonitorContainerInsights for an overview."
+        }
+      },
+      "description": "Logs profile for the Azure Monitor Infrastructure and Application Logs. Collect out-of-the-box Kubernetes infrastructure & application logs to send to Azure Monitor. See aka.ms/AzureMonitorContainerInsights for an overview."
+    },
+    "ManagedClusterAzureMonitorProfileMetrics": {
+      "type": "object",
+      "properties": {
+        "appMonitoringOpenTelemetryMetrics": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAzureMonitorProfileAppMonitoringOpenTelemetryMetrics"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Application Monitoring Open Telemetry Metrics Profile for Kubernetes Application Container Metrics. Collects OpenTelemetry metrics through auto-instrumentation of the application using Azure Monitor OpenTelemetry based SDKs. See aka.ms/AzureMonitorApplicationMonitoring for an overview."
+        },
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable the Prometheus collector"
+        },
+        "kubeStateMetrics": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAzureMonitorProfileKubeStateMetrics"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Kube State Metrics for prometheus addon profile for the container service cluster"
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "description": "Metrics profile for the prometheus service addon"
+    },
+    "ManagedClusterAzureMonitorProfileWindowsHostLogs": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Indicates if Windows Host Log Collection is enabled or not for Azure Monitor Container Insights Logs Addon."
+        }
+      },
+      "description": "Windows Host Logs Profile for Kubernetes Windows Nodes Log Collection. Collects ETW, Event Logs and Text logs etc. See aka.ms/AzureMonitorContainerInsights for an overview."
+    },
+    "ManagedClusterCostAnalysis": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The Managed Cluster sku.tier must be set to 'Standard' to enable this feature. Enabling this will add Kubernetes Namespace and Deployment details to the Cost Analysis views in the Azure portal. If not specified, the default is false. For more information see aka.ms/aks/docs/cost-analysis."
+        }
+      },
+      "description": "The cost analysis configuration for the cluster"
+    },
+    "ManagedClusterHTTPProxyConfig": {
+      "type": "object",
+      "properties": {
+        "httpProxy": {
+          "type": "string",
+          "description": "The HTTP proxy server endpoint to use."
+        },
+        "httpsProxy": {
+          "type": "string",
+          "description": "The HTTPS proxy server endpoint to use."
+        },
+        "noProxy": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The endpoints that should not go through proxy."
+        },
+        "trustedCa": {
+          "type": "string",
+          "description": "Alternative CA cert to use for connecting to proxy servers."
+        }
+      },
+      "description": "Cluster HTTP proxy configuration."
+    },
+    "ManagedClusterIdentity": {
+      "type": "object",
+      "properties": {
+        "delegatedResources": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/DelegatedResource"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The set of delegated resources. The delegated resources dictionary keys will be source resource internal ids - internal use only."
+        },
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "SystemAssigned",
+                "UserAssigned",
+                "None"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For more information see [use managed identities in AKS](https://docs.microsoft.com/azure/aks/use-managed-identity)."
+        },
+        "userAssignedIdentities": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/ManagedServiceIdentityUserAssignedIdentitiesValue"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The keys must be ARM resource IDs in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'."
+        }
+      },
+      "description": "Identity for the managed cluster."
+    },
+    "ManagedClusterIngressProfile": {
+      "type": "object",
+      "properties": {
+        "webAppRouting": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterIngressProfileWebAppRouting"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Web App Routing settings for the ingress profile."
+        }
+      },
+      "description": "Ingress profile for the container service cluster."
+    },
+    "ManagedClusterIngressProfileWebAppRouting": {
+      "type": "object",
+      "properties": {
+        "dnsZoneResourceIds": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Resource IDs of the public DNS zones to be associated with the Web App Routing add-on. Used only when Web App Routing is enabled. All public DNS zones must be in the same resource group."
+        },
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable Web App Routing."
+        }
+      },
+      "description": "Web App Routing settings for the ingress profile."
+    },
+    "ManagedClusterLoadBalancerProfile": {
+      "type": "object",
+      "properties": {
+        "allocatedOutboundPorts": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 64000,
+              "default": "0"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The desired number of allocated SNAT ports per VM. Allowed values are in the range of 0 to 64000 (inclusive). The default value is 0 which results in Azure dynamically allocating ports."
+        },
+        "backendPoolType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "NodeIPConfiguration",
+                "NodeIP"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The type of the managed inbound Load Balancer BackendPool."
+        },
+        "effectiveOutboundIPs": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ResourceReference"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The effective outbound IP resources of the cluster load balancer."
+        },
+        "enableMultipleStandardLoadBalancers": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Enable multiple standard load balancers per AKS cluster or not."
+        },
+        "idleTimeoutInMinutes": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 4,
+              "maximum": 120,
+              "default": "30"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 30 minutes."
+        },
+        "managedOutboundIPs": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterLoadBalancerProfileManagedOutboundIPs"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Desired managed outbound IPs for the cluster load balancer."
+        },
+        "outboundIPPrefixes": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterLoadBalancerProfileOutboundIPPrefixes"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Desired outbound IP Prefix resources for the cluster load balancer."
+        },
+        "outboundIPs": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterLoadBalancerProfileOutboundIPs"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Desired outbound IP resources for the cluster load balancer."
+        }
+      },
+      "description": "Profile of the managed cluster load balancer."
+    },
+    "ManagedClusterLoadBalancerProfileManagedOutboundIPs": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": "1"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The desired number of IPv4 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1. "
+        },
+        "countIPv6": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100,
+              "default": "0"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The desired number of IPv6 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 0 for single-stack and 1 for dual-stack. "
+        }
+      },
+      "description": "Desired managed outbound IPs for the cluster load balancer."
+    },
+    "ManagedClusterLoadBalancerProfileOutboundIPPrefixes": {
+      "type": "object",
+      "properties": {
+        "publicIPPrefixes": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ResourceReference"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "A list of public IP prefix resources."
+        }
+      },
+      "description": "Desired outbound IP Prefix resources for the cluster load balancer."
+    },
+    "ManagedClusterLoadBalancerProfileOutboundIPs": {
+      "type": "object",
+      "properties": {
+        "publicIPs": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ResourceReference"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "A list of public IP resources."
+        }
+      },
+      "description": "Desired outbound IP resources for the cluster load balancer."
+    },
+    "ManagedClusterManagedOutboundIPProfile": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 16,
+              "default": "1"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The desired number of outbound IPs created/managed by Azure. Allowed values must be in the range of 1 to 16 (inclusive). The default value is 1. "
+        }
+      },
+      "description": "Profile of the managed outbound IP resources of the managed cluster."
+    },
+    "ManagedClusterMetricsProfile": {
+      "type": "object",
+      "properties": {
+        "costAnalysis": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterCostAnalysis"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The cost analysis configuration for the cluster"
+        }
+      },
+      "description": "The metrics profile for the ManagedCluster."
+    },
+    "ManagedClusterNATGatewayProfile": {
+      "type": "object",
+      "properties": {
+        "effectiveOutboundIPs": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ResourceReference"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The effective outbound IP resources of the cluster NAT gateway."
+        },
+        "idleTimeoutInMinutes": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 4,
+              "maximum": 120,
+              "default": "4"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 4 minutes."
+        },
+        "managedOutboundIPProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterManagedOutboundIPProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile of the managed outbound IP resources of the managed cluster."
+        }
+      },
+      "description": "Profile of the managed cluster NAT gateway."
+    },
+    "ManagedClusterNodeResourceGroupProfile": {
+      "type": "object",
+      "properties": {
+        "restrictionLevel": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Unrestricted",
+                "ReadOnly"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The restriction level applied to the cluster's node resource group."
+        }
+      },
+      "description": "Node resource group lockdown profile for a managed cluster."
+    },
+    "ManagedClusterOIDCIssuerProfile": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether the OIDC issuer is enabled."
+        }
+      },
+      "description": "The OIDC issuer profile of the Managed Cluster."
+    },
+    "ManagedClusterPodIdentity": {
+      "type": "object",
+      "properties": {
+        "bindingSelector": {
+          "type": "string",
+          "description": "The binding selector to use for the AzureIdentityBinding resource."
+        },
+        "identity": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UserAssignedIdentity"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Details about a user assigned identity."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the pod identity."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "The namespace of the pod identity."
+        }
+      },
+      "required": [
+        "identity",
+        "name",
+        "namespace"
+      ],
+      "description": "Details about the pod identity assigned to the Managed Cluster."
+    },
+    "ManagedClusterPodIdentityException": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the pod identity exception."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "The namespace of the pod identity exception."
+        },
+        "podLabels": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The pod labels to match."
+        }
+      },
+      "required": [
+        "name",
+        "namespace",
+        "podLabels"
+      ],
+      "description": "See [disable AAD Pod Identity for a specific Pod/Application](https://azure.github.io/aad-pod-identity/docs/configure/application_exception/) for more details."
+    },
+    "ManagedClusterPodIdentityProfile": {
+      "type": "object",
+      "properties": {
+        "allowNetworkPluginKubenet": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Running in Kubenet is disabled by default due to the security related nature of AAD Pod Identity and the risks of IP spoofing. See [using Kubenet network plugin with AAD Pod Identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity#using-kubenet-network-plugin-with-azure-active-directory-pod-managed-identities) for more information."
+        },
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether the pod identity addon is enabled."
+        },
+        "userAssignedIdentities": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ManagedClusterPodIdentity"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The pod identities to use in the cluster."
+        },
+        "userAssignedIdentityExceptions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ManagedClusterPodIdentityException"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The pod identity exceptions to allow."
+        }
+      },
+      "description": "See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on pod identity integration."
+    },
+    "ManagedClusterProperties": {
+      "type": "object",
+      "properties": {
+        "aadProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAADProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For more details see [managed AAD on AKS](https://docs.microsoft.com/azure/aks/managed-aad)."
+        },
+        "addonProfiles": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/ManagedClusterAddonProfile"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The profile of managed cluster add-on."
+        },
+        "agentPoolProfiles": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ManagedClusterAgentPoolProfile"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The agent pool properties."
+        },
+        "apiServerAccessProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAPIServerAccessProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Access profile for managed cluster API server."
+        },
+        "autoScalerProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterPropertiesAutoScalerProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Parameters to be applied to the cluster-autoscaler when enabled"
+        },
+        "autoUpgradeProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAutoUpgradeProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Auto upgrade profile for a managed cluster."
+        },
+        "azureMonitorProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAzureMonitorProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Prometheus addon profile for the container service cluster"
+        },
+        "creationData": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/CreationData"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Data used when creating a target resource from a source resource."
+        },
+        "disableLocalAccounts": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "If set to true, getting static credentials will be disabled for this cluster. This must only be used on Managed Clusters that are AAD enabled. For more details see [disable local accounts](https://docs.microsoft.com/azure/aks/managed-aad#disable-local-accounts-preview)."
+        },
+        "diskEncryptionSetID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'"
+        },
+        "dnsPrefix": {
+          "type": "string",
+          "description": "This cannot be updated once the Managed Cluster has been created."
+        },
+        "enableNamespaceResources": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The default value is false. It can be enabled/disabled on creation and updating of the managed cluster. See [https://aka.ms/NamespaceARMResource](https://aka.ms/NamespaceARMResource) for more details on Namespace as a ARM Resource."
+        },
+        "enablePodSecurityPolicy": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "(DEPRECATED) Whether to enable Kubernetes pod security policy (preview). PodSecurityPolicy was deprecated in Kubernetes v1.21, and removed from Kubernetes in v1.25. Learn more at https://aka.ms/k8s/psp and https://aka.ms/aks/psp."
+        },
+        "enableRBAC": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable Kubernetes Role-Based Access Control."
+        },
+        "fqdnSubdomain": {
+          "type": "string",
+          "description": "This cannot be updated once the Managed Cluster has been created."
+        },
+        "guardrailsProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/GuardrailsProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The Guardrails profile."
+        },
+        "httpProxyConfig": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterHTTPProxyConfig"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Cluster HTTP proxy configuration."
+        },
+        "identityProfile": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/UserAssignedIdentity"
+              },
+              "properties": {}
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Identities associated with the cluster."
+        },
+        "ingressProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterIngressProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Ingress profile for the container service cluster."
+        },
+        "kubernetesVersion": {
+          "type": "string",
+          "description": "When you upgrade a supported AKS cluster, Kubernetes minor versions cannot be skipped. All upgrades must be performed sequentially by major version number. For example, upgrades between 1.14.x -> 1.15.x or 1.15.x -> 1.16.x are allowed, however 1.14.x -> 1.16.x is not allowed. See [upgrading an AKS cluster](https://docs.microsoft.com/azure/aks/upgrade-cluster) for more details."
+        },
+        "linuxProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ContainerServiceLinuxProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile for Linux VMs in the container service cluster."
+        },
+        "metricsProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterMetricsProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The metrics profile for the ManagedCluster."
+        },
+        "networkProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ContainerServiceNetworkProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile of network configuration."
+        },
+        "nodeResourceGroup": {
+          "type": "string",
+          "description": "The name of the resource group containing agent pool nodes."
+        },
+        "nodeResourceGroupProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterNodeResourceGroupProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Node resource group lockdown profile for a managed cluster."
+        },
+        "oidcIssuerProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterOIDCIssuerProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The OIDC issuer profile of the Managed Cluster."
+        },
+        "podIdentityProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterPodIdentityProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on pod identity integration."
+        },
+        "privateLinkResources": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PrivateLinkResource"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Private link resources associated with the cluster."
+        },
+        "publicNetworkAccess": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled",
+                "SecuredByPerimeter"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Allow or deny public network access for AKS."
+        },
+        "securityProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterSecurityProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Security profile for the container service cluster."
+        },
+        "serviceMeshProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ServiceMeshProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Service mesh profile for a managed cluster."
+        },
+        "servicePrincipalProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterServicePrincipalProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Information about a service principal identity for the cluster to use for manipulating Azure APIs."
+        },
+        "storageProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterStorageProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Storage profile for the container service cluster."
+        },
+        "supportPlan": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "KubernetesOfficial",
+                "AKSLongTermSupport"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The support plan for the Managed Cluster. If unspecified, the default is 'KubernetesOfficial'."
+        },
+        "upgradeSettings": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ClusterUpgradeSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Settings for upgrading a cluster."
+        },
+        "windowsProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterWindowsProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Profile for Windows VMs in the managed cluster."
+        },
+        "workloadAutoScalerProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterWorkloadAutoScalerProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Workload Auto-scaler profile for the managed cluster."
+        }
+      },
+      "description": "Properties of the managed cluster."
+    },
+    "ManagedClusterPropertiesAutoScalerProfile": {
+      "type": "object",
+      "properties": {
+        "balance-similar-node-groups": {
+          "type": "string",
+          "description": "Valid values are 'true' and 'false'"
+        },
+        "daemonset-eviction-for-empty-nodes": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "If set to true, all daemonset pods on empty nodes will be evicted before deletion of the node. If the daemonset pod cannot be evicted another node will be chosen for scaling. If set to false, the node will be deleted without ensuring that daemonset pods are deleted or evicted."
+        },
+        "daemonset-eviction-for-occupied-nodes": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "If set to true, all daemonset pods on occupied nodes will be evicted before deletion of the node. If the daemonset pod cannot be evicted another node will be chosen for scaling. If set to false, the node will be deleted without ensuring that daemonset pods are deleted or evicted."
+        },
+        "expander": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "least-waste",
+                "most-pods",
+                "priority",
+                "random"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Available values are: 'least-waste', 'most-pods', 'priority', 'random'."
+        },
+        "expanders": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "least-waste",
+                  "most-pods",
+                  "priority",
+                  "random"
+                ]
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Available values are: 'least-waste', 'most-pods', 'priority', 'random'. If multiple expanders are configured, they will be considered in the order in which they are listed, with the first one being considered first."
+        },
+        "ignore-daemonsets-utilization": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "If set to true, the resources used by daemonset will be taken into account when making scaling down decisions."
+        },
+        "max-empty-bulk-delete": {
+          "type": "string",
+          "description": "The default is 10."
+        },
+        "max-graceful-termination-sec": {
+          "type": "string",
+          "description": "The default is 600."
+        },
+        "max-node-provision-time": {
+          "type": "string",
+          "description": "The default is '15m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported."
+        },
+        "max-total-unready-percentage": {
+          "type": "string",
+          "description": "The default is 45. The maximum is 100 and the minimum is 0."
+        },
+        "new-pod-scale-up-delay": {
+          "type": "string",
+          "description": "For scenarios like burst/batch scale where you don't want CA to act before the kubernetes scheduler could schedule all the pods, you can tell CA to ignore unscheduled pods before they're a certain age. The default is '0s'. Values must be an integer followed by a unit ('s' for seconds, 'm' for minutes, 'h' for hours, etc)."
+        },
+        "ok-total-unready-count": {
+          "type": "string",
+          "description": "This must be an integer. The default is 3."
+        },
+        "scale-down-delay-after-add": {
+          "type": "string",
+          "description": "The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported."
+        },
+        "scale-down-delay-after-delete": {
+          "type": "string",
+          "description": "The default is the scan-interval. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported."
+        },
+        "scale-down-delay-after-failure": {
+          "type": "string",
+          "description": "The default is '3m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported."
+        },
+        "scale-down-unneeded-time": {
+          "type": "string",
+          "description": "The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported."
+        },
+        "scale-down-unready-time": {
+          "type": "string",
+          "description": "The default is '20m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported."
+        },
+        "scale-down-utilization-threshold": {
+          "type": "string",
+          "description": "The default is '0.5'."
+        },
+        "scan-interval": {
+          "type": "string",
+          "description": "The default is '10'. Values must be an integer number of seconds."
+        },
+        "skip-nodes-with-local-storage": {
+          "type": "string",
+          "description": "The default is true."
+        },
+        "skip-nodes-with-system-pods": {
+          "type": "string",
+          "description": "The default is true."
+        }
+      },
+      "description": "Parameters to be applied to the cluster-autoscaler when enabled"
+    },
+    "ManagedClusterPropertiesForSnapshot": {
+      "type": "object",
+      "properties": {
+        "enableRbac": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether the cluster has enabled Kubernetes Role-Based Access Control or not."
+        },
+        "kubernetesVersion": {
+          "type": "string",
+          "description": "The current kubernetes version."
+        },
+        "networkProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/NetworkProfileForSnapshot"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "network profile for managed cluster snapshot, these properties are read only."
+        },
+        "sku": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterSKU"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The SKU of a Managed Cluster."
+        }
+      },
+      "description": "managed cluster properties for snapshot, these properties are read only."
+    },
+    "ManagedClusterSecurityProfile": {
+      "type": "object",
+      "properties": {
+        "azureKeyVaultKms": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AzureKeyVaultKms"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Azure Key Vault key management service settings for the security profile."
+        },
+        "customCATrustCertificates": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^(?:[A-Za-z0-9+\\/]{4})*(?:[A-Za-z0-9+\\/]{2}==|[A-Za-z0-9+\\/]{3}=)?$"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Certificates will only be added to trust stores on node pools that have enableCustomCATrust field set to true. If updated, the new list of certificates will be installed in the trust store in place of the old certificates. The certificates are applied asynchronously and will be available a short time after the list is updated."
+        },
+        "defender": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterSecurityProfileDefender"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Microsoft Defender settings for the security profile."
+        },
+        "imageCleaner": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterSecurityProfileImageCleaner"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Image Cleaner removes unused images from nodes, freeing up disk space and helping to reduce attack surface area. Here are settings for the security profile."
+        },
+        "imageIntegrity": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterSecurityProfileImageIntegrity"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Image integrity related settings for the security profile."
+        },
+        "nodeRestriction": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterSecurityProfileNodeRestriction"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Node Restriction settings for the security profile."
+        },
+        "workloadIdentity": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterSecurityProfileWorkloadIdentity"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Workload identity settings for the security profile."
+        }
+      },
+      "description": "Security profile for the container service cluster."
+    },
+    "ManagedClusterSecurityProfileDefender": {
+      "type": "object",
+      "properties": {
+        "logAnalyticsWorkspaceResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource ID of the Log Analytics workspace to be associated with Microsoft Defender. When Microsoft Defender is enabled, this field is required and must be a valid workspace resource ID. When Microsoft Defender is disabled, leave the field empty."
+        },
+        "securityMonitoring": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterSecurityProfileDefenderSecurityMonitoring"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Microsoft Defender settings for the security profile threat detection."
+        }
+      },
+      "description": "Microsoft Defender settings for the security profile."
+    },
+    "ManagedClusterSecurityProfileDefenderSecurityMonitoring": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable Defender threat detection"
+        }
+      },
+      "description": "Microsoft Defender settings for the security profile threat detection."
+    },
+    "ManagedClusterSecurityProfileImageCleaner": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable Image Cleaner on AKS cluster."
+        },
+        "intervalHours": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Image Cleaner scanning interval in hours."
+        }
+      },
+      "description": "Image Cleaner removes unused images from nodes, freeing up disk space and helping to reduce attack surface area. Here are settings for the security profile."
+    },
+    "ManagedClusterSecurityProfileImageIntegrity": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable image integrity. The default value is false."
+        }
+      },
+      "description": "Image integrity related settings for the security profile."
+    },
+    "ManagedClusterSecurityProfileNodeRestriction": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable Node Restriction"
+        }
+      },
+      "description": "Node Restriction settings for the security profile."
+    },
+    "ManagedClusterSecurityProfileWorkloadIdentity": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable workload identity."
+        }
+      },
+      "description": "Workload identity settings for the security profile."
+    },
+    "ManagedClusterServicePrincipalProfile": {
+      "type": "object",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The ID for the service principal."
+        },
+        "secret": {
+          "type": "string",
+          "description": "The secret password associated with the service principal in plain text."
+        }
+      },
+      "required": [
+        "clientId"
+      ],
+      "description": "Information about a service principal identity for the cluster to use for manipulating Azure APIs."
+    },
+    "ManagedClusterSKU": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Base"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of a managed cluster SKU."
+        },
+        "tier": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Premium",
+                "Standard",
+                "Free"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "If not specified, the default is 'Free'. See [AKS Pricing Tier](https://learn.microsoft.com/azure/aks/free-standard-pricing-tiers) for more details."
+        }
+      },
+      "description": "The SKU of a Managed Cluster."
+    },
+    "ManagedClusterSnapshotProperties": {
+      "type": "object",
+      "properties": {
+        "creationData": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/CreationData"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Data used when creating a target resource from a source resource."
+        },
+        "managedClusterPropertiesReadOnly": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterPropertiesForSnapshot"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "managed cluster properties for snapshot, these properties are read only."
+        },
+        "snapshotType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "NodePool",
+                "ManagedCluster"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "description": "Properties for a managed cluster snapshot."
+    },
+    "ManagedClusterStorageProfile": {
+      "type": "object",
+      "properties": {
+        "blobCSIDriver": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterStorageProfileBlobCSIDriver"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "AzureBlob CSI Driver settings for the storage profile."
+        },
+        "diskCSIDriver": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterStorageProfileDiskCSIDriver"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "AzureDisk CSI Driver settings for the storage profile."
+        },
+        "fileCSIDriver": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterStorageProfileFileCSIDriver"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "AzureFile CSI Driver settings for the storage profile."
+        },
+        "snapshotController": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterStorageProfileSnapshotController"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Snapshot Controller settings for the storage profile."
+        }
+      },
+      "description": "Storage profile for the container service cluster."
+    },
+    "ManagedClusterStorageProfileBlobCSIDriver": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable AzureBlob CSI Driver. The default value is false."
+        }
+      },
+      "description": "AzureBlob CSI Driver settings for the storage profile."
+    },
+    "ManagedClusterStorageProfileDiskCSIDriver": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable AzureDisk CSI Driver. The default value is true."
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of AzureDisk CSI Driver. The default value is v1."
+        }
+      },
+      "description": "AzureDisk CSI Driver settings for the storage profile."
+    },
+    "ManagedClusterStorageProfileFileCSIDriver": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable AzureFile CSI Driver. The default value is true."
+        }
+      },
+      "description": "AzureFile CSI Driver settings for the storage profile."
+    },
+    "ManagedClusterStorageProfileSnapshotController": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable Snapshot Controller. The default value is true."
+        }
+      },
+      "description": "Snapshot Controller settings for the storage profile."
+    },
+    "managedClusters_agentPools_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-02-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9]{0,11}$",
+              "minLength": 1,
+              "maxLength": 12
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of the agent pool."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterAgentPoolProfileProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for the container service agent pool profile."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "agentPools"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/managedClusters/agentPools"
+    },
+    "managedClusters_maintenanceConfigurations_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-02-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the maintenance configuration."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/MaintenanceConfigurationProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties used to configure planned maintenance for a Managed Cluster."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "maintenanceConfigurations"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/managedClusters/maintenanceConfigurations"
+    },
+    "managedClusters_privateEndpointConnections_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-02-preview"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the private endpoint connection."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PrivateEndpointConnectionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties of a private endpoint connection."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "privateEndpointConnections"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/managedClusters/privateEndpointConnections"
+    },
+    "managedClusters_trustedAccessRoleBindings_childResource": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "2023-08-02-preview"
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^([A-Za-z0-9-])+$",
+              "minLength": 1,
+              "maxLength": 24
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The name of trusted access role binding."
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/TrustedAccessRoleBindingProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Properties for trusted access role binding"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "trustedAccessRoleBindings"
+          ]
+        }
+      },
+      "required": [
+        "apiVersion",
+        "name",
+        "properties",
+        "type"
+      ],
+      "description": "Microsoft.ContainerService/managedClusters/trustedAccessRoleBindings"
+    },
+    "ManagedClusterWindowsProfile": {
+      "type": "object",
+      "properties": {
+        "adminPassword": {
+          "type": "string",
+          "description": "Specifies the password of the administrator account. <br><br> **Minimum-length:** 8 characters <br><br> **Max-length:** 123 characters <br><br> **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled <br> Has lower characters <br>Has upper characters <br> Has a digit <br> Has a special character (Regex match [\\W_]) <br><br> **Disallowed values:** \"abc@123\", \"P@$$w0rd\", \"P@ssw0rd\", \"P@ssword123\", \"Pa$$word\", \"pass@word1\", \"Password!\", \"Password1\", \"Password22\", \"iloveyou!\""
+        },
+        "adminUsername": {
+          "type": "string",
+          "description": "Specifies the name of the administrator account. <br><br> **Restriction:** Cannot end in \".\" <br><br> **Disallowed values:** \"administrator\", \"admin\", \"user\", \"user1\", \"test\", \"user2\", \"test1\", \"user3\", \"admin1\", \"1\", \"123\", \"a\", \"actuser\", \"adm\", \"admin2\", \"aspnet\", \"backup\", \"console\", \"david\", \"guest\", \"john\", \"owner\", \"root\", \"server\", \"sql\", \"support\", \"support_388945a0\", \"sys\", \"test2\", \"test3\", \"user4\", \"user5\". <br><br> **Minimum-length:** 1 character <br><br> **Max-length:** 20 characters"
+        },
+        "enableCSIProxy": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For more details on CSI proxy, see the [CSI proxy GitHub repo](https://github.com/kubernetes-csi/csi-proxy)."
+        },
+        "gmsaProfile": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/WindowsGmsaProfile"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Windows gMSA Profile in the managed cluster."
+        },
+        "licenseType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "None",
+                "Windows_Server"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The license type to use for Windows VMs. See [Azure Hybrid User Benefits](https://azure.microsoft.com/pricing/hybrid-benefit/faq/) for more details."
+        }
+      },
+      "required": [
+        "adminUsername"
+      ],
+      "description": "Profile for Windows VMs in the managed cluster."
+    },
+    "ManagedClusterWorkloadAutoScalerProfile": {
+      "type": "object",
+      "properties": {
+        "keda": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterWorkloadAutoScalerProfileKeda"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile."
+        },
+        "verticalPodAutoscaler": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "description": "Workload Auto-scaler profile for the managed cluster."
+    },
+    "ManagedClusterWorkloadAutoScalerProfileKeda": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable KEDA."
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "description": "KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile."
+    },
+    "ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler": {
+      "type": "object",
+      "properties": {
+        "addonAutoscaling": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether VPA add-on is enabled and configured to scale AKS-managed add-ons."
+        },
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to enable VPA add-on in cluster. Default value is false."
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "ManagedServiceIdentityUserAssignedIdentitiesValue": {
+      "type": "object",
+      "properties": {}
+    },
+    "NetworkMonitoring": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Enable or disable the network monitoring plugin on the cluster"
+        }
+      },
+      "description": "This addon can be used to configure network monitoring and generate network monitoring data in Prometheus format"
+    },
+    "NetworkProfileForSnapshot": {
+      "type": "object",
+      "properties": {
+        "loadBalancerSku": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "standard",
+                "basic"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "loadBalancerSku for managed cluster snapshot."
+        },
+        "networkMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "transparent",
+                "bridge"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "networkMode for managed cluster snapshot."
+        },
+        "networkPlugin": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "azure",
+                "kubenet",
+                "none"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "networkPlugin for managed cluster snapshot."
+        },
+        "networkPluginMode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "overlay"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "NetworkPluginMode for managed cluster snapshot."
+        },
+        "networkPolicy": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "none",
+                "calico",
+                "azure",
+                "cilium"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "networkPolicy for managed cluster snapshot."
+        }
+      },
+      "description": "network profile for managed cluster snapshot, these properties are read only."
+    },
+    "PortRange": {
+      "type": "object",
+      "properties": {
+        "portEnd": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The maximum port that is included in the range. It should be ranged from 1 to 65535, and be greater than or equal to portStart."
+        },
+        "portStart": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The minimum port that is included in the range. It should be ranged from 1 to 65535, and be less than or equal to portEnd."
+        },
+        "protocol": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "TCP",
+                "UDP"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The network protocol of the port."
+        }
+      },
+      "description": "The port range."
+    },
+    "PowerState": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Running",
+                "Stopped"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Tells whether the cluster is Running or Stopped."
+        }
+      },
+      "description": "Describes the Power State of the cluster"
+    },
+    "PrivateEndpoint": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The resource ID of the private endpoint"
+        }
+      },
+      "description": "Private endpoint which a connection belongs to."
+    },
+    "PrivateEndpointConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "privateEndpoint": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PrivateEndpoint"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Private endpoint which a connection belongs to."
+        },
+        "privateLinkServiceConnectionState": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/PrivateLinkServiceConnectionState"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The state of a private link service connection."
+        }
+      },
+      "required": [
+        "privateLinkServiceConnectionState"
+      ],
+      "description": "Properties of a private endpoint connection."
+    },
+    "PrivateLinkResource": {
+      "type": "object",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "The group ID of the resource."
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the private link resource."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the private link resource."
+        },
+        "requiredMembers": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The RequiredMembers of the resource"
+        },
+        "type": {
+          "type": "string",
+          "description": "The resource type."
+        }
+      },
+      "description": "A private link resource"
+    },
+    "PrivateLinkServiceConnectionState": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "The private link service connection description."
+        },
+        "status": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Pending",
+                "Approved",
+                "Rejected",
+                "Disconnected"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The private link service connection status."
+        }
+      },
+      "description": "The state of a private link service connection."
+    },
+    "RelativeMonthlySchedule": {
+      "type": "object",
+      "properties": {
+        "dayOfWeek": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Sunday",
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies on which day of the week the maintenance occurs."
+        },
+        "intervalMonths": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 6
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the number of months between each set of occurrences."
+        },
+        "weekIndex": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "First",
+                "Second",
+                "Third",
+                "Fourth",
+                "Last"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies on which instance of the allowed days specified in daysOfWeek the maintenance occurs."
+        }
+      },
+      "required": [
+        "dayOfWeek",
+        "intervalMonths",
+        "weekIndex"
+      ],
+      "description": "For schedules like: 'recur every month on the first Monday' or 'recur every 3 months on last Friday'."
+    },
+    "ResourceReference": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The fully qualified Azure resource id."
+        }
+      },
+      "description": "A reference to an Azure resource."
+    },
+    "Schedule": {
+      "type": "object",
+      "properties": {
+        "absoluteMonthly": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/AbsoluteMonthlySchedule"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For schedules like: 'recur every month on the 15th' or 'recur every 3 months on the 20th'."
+        },
+        "daily": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DailySchedule"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For schedules like: 'recur every day' or 'recur every 3 days'."
+        },
+        "relativeMonthly": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RelativeMonthlySchedule"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For schedules like: 'recur every month on the first Monday' or 'recur every 3 months on last Friday'."
+        },
+        "weekly": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/WeeklySchedule"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "For schedules like: 'recur every Monday' or 'recur every 3 weeks on Wednesday'."
+        }
+      },
+      "description": "One and only one of the schedule types should be specified. Choose either 'daily', 'weekly', 'absoluteMonthly' or 'relativeMonthly' for your maintenance schedule."
+    },
+    "ServiceMeshProfile": {
+      "type": "object",
+      "properties": {
+        "istio": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/IstioServiceMesh"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Istio service mesh configuration."
+        },
+        "mode": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Istio",
+                "Disabled"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Mode of the service mesh."
+        }
+      },
+      "required": [
+        "mode"
+      ],
+      "description": "Service mesh profile for a managed cluster."
+    },
+    "SnapshotProperties": {
+      "type": "object",
+      "properties": {
+        "creationData": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/CreationData"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Data used when creating a target resource from a source resource."
+        },
+        "snapshotType": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "NodePool",
+                "ManagedCluster"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "description": "Properties used to configure a node pool snapshot."
+    },
+    "SysctlConfig": {
+      "type": "object",
+      "properties": {
+        "fsAioMaxNr": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting fs.aio-max-nr."
+        },
+        "fsFileMax": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting fs.file-max."
+        },
+        "fsInotifyMaxUserWatches": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting fs.inotify.max_user_watches."
+        },
+        "fsNrOpen": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting fs.nr_open."
+        },
+        "kernelThreadsMax": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting kernel.threads-max."
+        },
+        "netCoreNetdevMaxBacklog": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.core.netdev_max_backlog."
+        },
+        "netCoreOptmemMax": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.core.optmem_max."
+        },
+        "netCoreRmemDefault": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.core.rmem_default."
+        },
+        "netCoreRmemMax": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.core.rmem_max."
+        },
+        "netCoreSomaxconn": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.core.somaxconn."
+        },
+        "netCoreWmemDefault": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.core.wmem_default."
+        },
+        "netCoreWmemMax": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.core.wmem_max."
+        },
+        "netIpv4IpLocalPortRange": {
+          "type": "string",
+          "description": "Sysctl setting net.ipv4.ip_local_port_range."
+        },
+        "netIpv4NeighDefaultGcThresh1": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.neigh.default.gc_thresh1."
+        },
+        "netIpv4NeighDefaultGcThresh2": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.neigh.default.gc_thresh2."
+        },
+        "netIpv4NeighDefaultGcThresh3": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.neigh.default.gc_thresh3."
+        },
+        "netIpv4TcpFinTimeout": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.tcp_fin_timeout."
+        },
+        "netIpv4TcpkeepaliveIntvl": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 10,
+              "maximum": 90
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.tcp_keepalive_intvl."
+        },
+        "netIpv4TcpKeepaliveProbes": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.tcp_keepalive_probes."
+        },
+        "netIpv4TcpKeepaliveTime": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.tcp_keepalive_time."
+        },
+        "netIpv4TcpMaxSynBacklog": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.tcp_max_syn_backlog."
+        },
+        "netIpv4TcpMaxTwBuckets": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.tcp_max_tw_buckets."
+        },
+        "netIpv4TcpTwReuse": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.ipv4.tcp_tw_reuse."
+        },
+        "netNetfilterNfConntrackBuckets": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 65536,
+              "maximum": 524288
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.netfilter.nf_conntrack_buckets."
+        },
+        "netNetfilterNfConntrackMax": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 131072,
+              "maximum": 2097152
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting net.netfilter.nf_conntrack_max."
+        },
+        "vmMaxMapCount": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting vm.max_map_count."
+        },
+        "vmSwappiness": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting vm.swappiness."
+        },
+        "vmVfsCachePressure": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Sysctl setting vm.vfs_cache_pressure."
+        }
+      },
+      "description": "Sysctl settings for Linux agent nodes."
+    },
+    "TimeInWeek": {
+      "type": "object",
+      "properties": {
+        "day": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Sunday",
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "The day of the week."
+        },
+        "hourSlots": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Each integer hour represents a time range beginning at 0m after the hour ending at the next hour (non-inclusive). 0 corresponds to 00:00 UTC, 23 corresponds to 23:00 UTC. Specifying [0, 1] means the 00:00 - 02:00 UTC time range."
+        }
+      },
+      "description": "Time in a week."
+    },
+    "TimeSpan": {
+      "type": "object",
+      "properties": {
+        "end": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The end of a time span"
+        },
+        "start": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The start of a time span"
+        }
+      },
+      "description": "For example, between 2021-05-25T13:00:00Z and 2021-05-25T14:00:00Z."
+    },
+    "TrustedAccessRoleBindingProperties": {
+      "type": "object",
+      "properties": {
+        "roles": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "A list of roles to bind, each item is a resource type qualified role name. For example: 'Microsoft.MachineLearningServices/workspaces/reader'."
+        },
+        "sourceResourceId": {
+          "type": "string",
+          "description": "The ARM resource ID of source resource that trusted access is configured for."
+        }
+      },
+      "required": [
+        "roles",
+        "sourceResourceId"
+      ],
+      "description": "Properties for trusted access role binding"
+    },
+    "UpgradeOverrideSettings": {
+      "type": "object",
+      "properties": {
+        "forceUpgrade": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Whether to force upgrade the cluster. Note that this option instructs upgrade operation to bypass upgrade protections such as checking for deprecated API usage. Enable this option only with caution."
+        },
+        "until": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Until when the overrides are effective. Note that this only matches the start time of an upgrade, and the effectiveness won't change once an upgrade starts even if the `until` expires as upgrade proceeds. This field is not set by default. It must be set for the overrides to take effect."
+        }
+      },
+      "description": "Settings for overrides when upgrading a cluster."
+    },
+    "UserAssignedIdentity": {
+      "type": "object",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The client ID of the user assigned identity."
+        },
+        "objectId": {
+          "type": "string",
+          "description": "The object ID of the user assigned identity."
+        },
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the user assigned identity."
+        }
+      },
+      "description": "Details about a user assigned identity."
+    },
+    "WeeklySchedule": {
+      "type": "object",
+      "properties": {
+        "dayOfWeek": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Sunday",
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday"
+              ]
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies on which day of the week the maintenance occurs."
+        },
+        "intervalWeeks": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 4
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies the number of weeks between each set of occurrences."
+        }
+      },
+      "required": [
+        "dayOfWeek",
+        "intervalWeeks"
+      ],
+      "description": "For schedules like: 'recur every Monday' or 'recur every 3 weeks on Wednesday'."
+    },
+    "WindowsGmsaProfile": {
+      "type": "object",
+      "properties": {
+        "dnsServer": {
+          "type": "string",
+          "description": "Specifies the DNS server for Windows gMSA. <br><br> Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster."
+        },
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ],
+          "description": "Specifies whether to enable Windows gMSA in the managed cluster."
+        },
+        "rootDomainName": {
+          "type": "string",
+          "description": "Specifies the root domain name for Windows gMSA. <br><br> Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster."
+        }
+      },
+      "description": "Windows gMSA Profile in the managed cluster."
+    }
+  }
+}

--- a/tests/2023-08-01/Microsoft.ContainerService.tests.json
+++ b/tests/2023-08-01/Microsoft.ContainerService.tests.json
@@ -1,0 +1,56 @@
+{
+  "tests": [
+    {
+      "name": "ManagedClusters - Basic",
+      "definition": "https://schema.management.azure.com/schemas/2023-08-01/Microsoft.ContainerService.json#/resourceDefinitions/managedClusters",
+      "json": {
+        "name": "[parameters('resourceName')]",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "apiVersion": "2023-08-01",
+        "location": "[resourceGroup().location]",
+        "properties": {
+          "kubernetesVersion": "[parameters('kubernetesVersion')]",
+          "dnsPrefix": "[parameters('dnsPrefix')]",
+          "agentPoolProfiles": [
+            {
+              "name": "[parameters('agentPoolName')]",
+              "vmSize": "[parameters('vmSize')]",
+              "count": "[parameters('agentPoolCount')]",
+              "dnsPrefix": "[parameters('dnsPrefix')]",
+              "storageProfile": "ManagedDisks",
+              "osType": "Linux",
+              "enableAutoScaling": true,
+              "maxCount": 5,
+              "minCount": 1,
+              "orchestratorVersion": "[parameters('orchestratorVersion')]"
+            }
+          ],
+          "linuxProfile": {
+            "adminUsername": "[parameters('adminUsername')]",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "[parameters('keyData')]"
+                }
+              ]
+            }
+          },
+          "windowsProfile": {
+            "adminUsername": "[parameters('adminUsername')]",
+            "adminPassword": "[parameters('adminPassword')]"
+          },
+          "networkProfile": {
+            "loadBalancerSku": "basic"
+          },
+          "servicePrincipalProfile": {
+            "clientId": "[parameters('servicePrincipalClientId')]",
+            "secret": "[parameters('servicePrincipalSecret')]"
+          },
+          "addonProfiles": {
+          },
+          "enableRBAC": "[parameters('enableRbac')]"
+        }
+      }
+    }
+  ]
+}

--- a/tests/2023-08-02-preview/Microsoft.ContainerService.tests.json
+++ b/tests/2023-08-02-preview/Microsoft.ContainerService.tests.json
@@ -1,0 +1,56 @@
+{
+  "tests": [
+    {
+      "name": "ManagedClusters - Basic",
+      "definition": "https://schema.management.azure.com/schemas/2023-08-02-preview/Microsoft.ContainerService.json#/resourceDefinitions/managedClusters",
+      "json": {
+        "name": "[parameters('resourceName')]",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "apiVersion": "2023-08-02-preview",
+        "location": "[resourceGroup().location]",
+        "properties": {
+          "kubernetesVersion": "[parameters('kubernetesVersion')]",
+          "dnsPrefix": "[parameters('dnsPrefix')]",
+          "agentPoolProfiles": [
+            {
+              "name": "[parameters('agentPoolName')]",
+              "vmSize": "[parameters('vmSize')]",
+              "count": "[parameters('agentPoolCount')]",
+              "dnsPrefix": "[parameters('dnsPrefix')]",
+              "storageProfile": "ManagedDisks",
+              "osType": "Linux",
+              "enableAutoScaling": true,
+              "maxCount": 5,
+              "minCount": 1,
+              "orchestratorVersion": "[parameters('orchestratorVersion')]"
+            }
+          ],
+          "linuxProfile": {
+            "adminUsername": "[parameters('adminUsername')]",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "[parameters('keyData')]"
+                }
+              ]
+            }
+          },
+          "windowsProfile": {
+            "adminUsername": "[parameters('adminUsername')]",
+            "adminPassword": "[parameters('adminPassword')]"
+          },
+          "networkProfile": {
+            "loadBalancerSku": "basic"
+          },
+          "servicePrincipalProfile": {
+            "clientId": "[parameters('servicePrincipalClientId')]",
+            "secret": "[parameters('servicePrincipalSecret')]"
+          },
+          "addonProfiles": {
+          },
+          "enableRBAC": "[parameters('enableRbac')]"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Manually generated these the ARM schemas for AKS based on 2023-08-01 and 2023-08-02-preview swagger specs. To bypass the path issues, the directory structure under namespace Microsoft.ContainerService was modified as in [PR #26256](https://github.com/Azure/azure-rest-api-specs/pull/26256).
```
autorest --version=3.0.6374 --use=@autorest/azureresourceschema@3.0.109 --azureresourceschema --output-folder=/home/fumingzhang/azure-resource-manager-schemas/schemas --pass-thru:subset-reducer --pass-thru:schema-validator-swagger --tag=package-2023-08 /home/fumingzhang/azure-rest-api-specs/specification/containerservice/resource-manager/readme.md
autorest --version=3.0.6374 --use=@autorest/azureresourceschema@3.0.109 --azureresourceschema --output-folder=/home/fumingzhang/azure-resource-manager-schemas/schemas --pass-thru:subset-reducer --pass-thru:schema-validator-swagger --tag=package-preview-2023-08 /home/fumingzhang/azure-rest-api-specs/specification/containerservice/resource-manager/readme.md
```

![image](https://github.com/Azure/azure-resource-manager-schemas/assets/81607949/0e603053-6c94-4b93-8c9c-49cb1d3df013)