### PR TITLE
Stop auto-gen for HDI & fix the api-version

### DIFF
--- a/generator/autogenlist.ts
+++ b/generator/autogenlist.ts
@@ -463,6 +463,9 @@ const autoGenList: AutoGenConfig[] = [
     {
         basePath: 'hdinsight/resource-manager',
         namespace: 'Microsoft.HDInsight',
+        // Disable auto-gen temporally due to we want to force it use 2023-04-15-preview as newest version.
+        // Since 2023-08-15-preview is not public available.
+        disabledForAutogen: true,
     },
     {
         basePath: 'resourcehealth/resource-manager',

--- a/schemas/common/autogeneratedResources.json
+++ b/schemas/common/autogeneratedResources.json
@@ -17219,18 +17219,6 @@
           "$ref": "https://schema.management.azure.com/schemas/2023-04-15-preview/Microsoft.HDInsight.json#/resourceDefinitions/clusters_privateEndpointConnections"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2023-08-15-preview/Microsoft.HDInsight.json#/resourceDefinitions/clusters"
-        },
-        {
-          "$ref": "https://schema.management.azure.com/schemas/2023-08-15-preview/Microsoft.HDInsight.json#/resourceDefinitions/clusters_applications"
-        },
-        {
-          "$ref": "https://schema.management.azure.com/schemas/2023-08-15-preview/Microsoft.HDInsight.json#/resourceDefinitions/clusters_extensions"
-        },
-        {
-          "$ref": "https://schema.management.azure.com/schemas/2023-08-15-preview/Microsoft.HDInsight.json#/resourceDefinitions/clusters_privateEndpointConnections"
-        },
-        {
           "$ref": "https://schema.management.azure.com/schemas/2020-10-20/Microsoft.HealthBot.json#/resourceDefinitions/healthBots"
         },
         {


### PR DESCRIPTION
Hi, I am Microsoft HDI team. I raise this PR for fixing the api-version issue of "Template Export" for HDI resources.

Recent months ago, HDI RP team onboarded a new api-version(https://github.com/Azure/azure-rest-api-specs/tree/main/specification/hdinsight/resource-manager/Microsoft.HDInsight/preview/2023-08-15-preview). And it was auto-gen by this repo's pipeline/tool and introduced to it.

So today, every requests of "Template Export" for HDI resources are routed to HDI RP with 2023-08-15-preview.

However, 2023-08-15-preview is not public available yet. Currently, only those subscriptions with required AFEC flags can arrive it.

So I want to stop the auto-gen temporarily until this api-version is GA. And remove the "2023-08-15-preview" from HDI part.