### PR TITLE
Fix bug with generating schemas in windows with path separator.

### DIFF
--- a/generator/specs.ts
+++ b/generator/specs.ts
@@ -103,7 +103,7 @@ export async function prepareReadme(readme: string, autoGenConfig: AutoGenConfig
 
     let readmeTag = {} as ReadmeTag;
     for (const inputFile of fileSet) {
-        const pathComponents = inputFile.split(path.sep);
+        const pathComponents = inputFile.split("/");
 
         if (!autoGenConfig.useNamespaceFromConfig &&
             !lowerCaseContains(pathComponents, autoGenConfig.namespace)) {


### PR DESCRIPTION
Path.sep had a bug in windows wherein it returned "\" as the separating character but the path itself had "/" as the character. As a result, generate commands didn't generate the schema files in windows. This PR fixes that.