### PR TITLE
Fix autogeneration

### DIFF
--- a/generator/autogenlist.ts
+++ b/generator/autogenlist.ts
@@ -1129,10 +1129,6 @@ const autoGenList: AutoGenConfig[] = [
         suffix: 'ServiceMap',
     },
     {
-        basePath: 'confidentialLedger/resource-manager',
-        namespace: 'Microsoft.ConfidentialLedger',
-    },
-    {
         basePath: 'managedservices/resource-manager',
         namespace: 'Microsoft.ManagedServices',
         resourceConfig: [

--- a/generator/generate.ts
+++ b/generator/generate.ts
@@ -117,6 +117,8 @@ function assignScopesToUnknownReferences(knownReferences: SchemaReference[], unk
 
         if (config && (schemaRef.scope & ScopeType.Unknown)) {
             schemaRef.scope = config.scopes || ScopeType.None;
+        } else {
+            schemaRef.scope = ScopeType.Tenant | ScopeType.Subscription | ScopeType.ResourceGroup | ScopeType.ManagementGroup | ScopeType.Extension;
         }
 
         for (const knownReference of knownReferences.filter(r => lowerCaseCompare(r.type, schemaRef.type) === 0)) {


### PR DESCRIPTION
* Don't fail if unknown scope found - instead assume "all scopes"
* Fix generation for confidential ledger schemas