### PR TITLE
Fix broken generation

### DIFF
--- a/generator/autogenlist.ts
+++ b/generator/autogenlist.ts
@@ -16,6 +16,7 @@ import { postProcessor as networkPostProcessor } from './processors/Microsoft.Ne
 import { postProcessor as azureStackHciPostProcessor } from './processors/Microsoft.AzureStackHCI';
 import { postProcessor as resourcesPostProcessor } from './processors/Microsoft.Resources';
 import { postProcessor as serviceFabricPostProcessor } from './processors/Microsoft.ServiceFabric';
+import { postProcessor as awsConnectorPostProcessor } from './processors/Microsoft.AwsConnector';
 import { lowerCaseEquals } from './utils';
 import { detectProviderNamespaces } from './generate';
 
@@ -167,6 +168,11 @@ const autoGenList: AutoGenConfig[] = [
     {
         basePath: 'automation/resource-manager',
         namespace: 'Microsoft.Automation',
+    },
+    {
+        basePath: 'awsConnector/resource-manager',
+        namespace: 'Microsoft.AwsConnector',
+        postProcessor: awsConnectorPostProcessor
     },
     {
         basePath: 'azurearcdata/resource-manager',

--- a/generator/utils.ts
+++ b/generator/utils.ts
@@ -14,7 +14,11 @@ export function executeCmd(cwd: string, cmd: string, args: string[]) : Promise<n
         const child = spawn(cmd, args, {
             cwd: cwd,
             windowsHide: true,
-            env: { ...process.env, 'DOTNET_SYSTEM_GLOBALIZATION_INVARIANT': 1},
+            env: {
+              ...process.env,
+              // needed to workaround dotnet globalization issues in autorest .NET plugins
+              DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: '1',
+            },
         });
 
         child.stdout.on('data', data => process.stdout.write(colors.grey(data.toString())));

--- a/generator/utils.ts
+++ b/generator/utils.ts
@@ -14,6 +14,7 @@ export function executeCmd(cwd: string, cmd: string, args: string[]) : Promise<n
         const child = spawn(cmd, args, {
             cwd: cwd,
             windowsHide: true,
+            env: { ...process.env, 'DOTNET_SYSTEM_GLOBALIZATION_INVARIANT': 1},
         });
 
         child.stdout.on('data', data => process.stdout.write(colors.grey(data.toString())));


### PR DESCRIPTION
This PR fixes 2 issues with schemas and its generation
1. Include the AwsConnector post processor in generation to fix the cyclic schema errors encountered by that RP
2.  Set the 'DOTNET_SYSTEM_GLOBALIZATION_INVARIANT' environment variable to remove dependency on ICU package during schema generation.