### PR TITLE
[Kusto] changes to Geneva DC schema

### DIFF
--- a/generator/processors/Microsoft.Kusto.ts
+++ b/generator/processors/Microsoft.Kusto.ts
@@ -43,7 +43,12 @@ const genevaDataConnectionProperties = () => ({
   properties: {
     genevaEnvironment: {
       type: 'string',
-      'description': 'The Geneva environment of the geneva data connection.'
+      description: 'The Geneva environment of the geneva data connection.'
+    },
+    extractBondFieldNameWithoutLinkingPolicyState: {
+      type: 'string',
+      enum: ['Enabled', 'Disabled'],
+      description: 'The extractBondFieldNameWithoutLinkingPolicyState property is used to handle Geneva event fields that contain embedded dot (.) characters. When Enabled, field names are not split by dot. Possible values: Enabled or Disabled.'
     }
   },
   required: [
@@ -51,6 +56,7 @@ const genevaDataConnectionProperties = () => ({
   ],
   description: 'Class representing the Kusto Geneva (GDS) connection properties.'
 });
+
 
 const genevaDataConnection = () => ({
   type: 'object',


### PR DESCRIPTION
We have an internal resource called Geneva Data Connection, which is used exclusively by internal Microsoft users. As such, it’s not included in the public Swagger documentation, but it is deployed via ARM and has a corresponding schema.

We’ve recently introduced a new property to this resource and would like to ensure it's reflected in the ARM schema. This PR updates the schema to include the new property, ensuring that the schema is up-to-date and accurate