### PR TITLE
Remove TLS1_3 from Microsoft.Storage minimumTlsVersion enum

### DIFF
--- a/schemas/2023-05-01/Microsoft.Storage.json
+++ b/schemas/2023-05-01/Microsoft.Storage.json
@@ -3878,8 +3878,7 @@
               "enum": [
                 "TLS1_0",
                 "TLS1_1",
-                "TLS1_2",
-                "TLS1_3"
+                "TLS1_2"
               ],
               "type": "string"
             },

--- a/schemas/2024-01-01/Microsoft.Storage.json
+++ b/schemas/2024-01-01/Microsoft.Storage.json
@@ -3982,8 +3982,7 @@
               "enum": [
                 "TLS1_0",
                 "TLS1_1",
-                "TLS1_2",
-                "TLS1_3"
+                "TLS1_2"
               ],
               "type": "string"
             },

--- a/schemas/2025-01-01/Microsoft.Storage.json
+++ b/schemas/2025-01-01/Microsoft.Storage.json
@@ -4150,8 +4150,7 @@
               "enum": [
                 "TLS1_0",
                 "TLS1_1",
-                "TLS1_2",
-                "TLS1_3"
+                "TLS1_2"
               ],
               "type": "string"
             },

--- a/schemas/2025-06-01/Microsoft.Storage.json
+++ b/schemas/2025-06-01/Microsoft.Storage.json
@@ -4200,8 +4200,7 @@
               "enum": [
                 "TLS1_0",
                 "TLS1_1",
-                "TLS1_2",
-                "TLS1_3"
+                "TLS1_2"
               ],
               "type": "string"
             },

--- a/schemas/2025-08-01/Microsoft.Storage.json
+++ b/schemas/2025-08-01/Microsoft.Storage.json
@@ -4453,8 +4453,7 @@
               "enum": [
                 "TLS1_0",
                 "TLS1_1",
-                "TLS1_2",
-                "TLS1_3"
+                "TLS1_2"
               ],
               "type": "string"
             },


### PR DESCRIPTION
Discussed with the PMs. This is not a breaking change because the functionality does not exist (currently returns an error).

/cc @brendandburns 