### PR TITLE
Enable autogen for Microsoft.BotService and regenerate schemas

### DIFF
--- a/generator/autogenlist.ts
+++ b/generator/autogenlist.ts
@@ -57,12 +57,9 @@ const disabledProviders: AutoGenConfig[] = [
         disabledForAutogen: true,
     },
     {
-        //Disabled until errors are fixed
-        //'Microsoft.BotService/preview/2023-09-15-preview/botservice.json:3492:5' - TypeError: Cannot convert undefined or null to object
         basePath: 'botservice/resource-manager/Microsoft.BotService/BotService',
         namespace: 'Microsoft.BotService',
         useNamespaceFromConfig: true,
-        disabledForAutogen: true,
     },
     {
         // Duplicated under 'containerservice/resource-manager/Microsoft.ContainerService/aks'

--- a/schemas/2021-03-01/Microsoft.BotService.json
+++ b/schemas/2021-03-01/Microsoft.BotService.json
@@ -427,6 +427,7 @@
           "type": "string"
         },
         "iconUrl": {
+          "default": "",
           "description": "The Icon Url of the bot",
           "type": "string"
         },
@@ -434,6 +435,7 @@
           "description": "Whether Cmek is enabled",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -445,6 +447,7 @@
           "description": "Whether the bot is streaming supported",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1009,6 +1012,7 @@
           "type": "string"
         },
         "location": {
+          "default": "global",
           "description": "Specifies the location of the resource.",
           "type": "string"
         }
@@ -1059,6 +1063,7 @@
           "type": "string"
         },
         "scopes": {
+          "default": "",
           "description": "Scopes associated with the Connection Setting",
           "type": "string"
         },
@@ -1081,10 +1086,12 @@
           "type": "string"
         },
         "extensionKey1": {
+          "default": "",
           "description": "The extensionKey1",
           "type": "string"
         },
         "extensionKey2": {
+          "default": "",
           "description": "The extensionKey2",
           "type": "string"
         },
@@ -1208,6 +1215,7 @@
           "description": "Whether this site is enabled for Webchat Speech",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1219,6 +1227,7 @@
           "description": "Whether this site is enabled for preview versions of Webchat",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1510,6 +1519,7 @@
           "type": "string"
         },
         "deploymentEnvironment": {
+          "default": "FallbackDeploymentEnvironment",
           "description": "Deployment environment for Microsoft Teams channel calls",
           "type": "string"
         },
@@ -1517,6 +1527,7 @@
           "description": "Enable calling for Microsoft Teams channel",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1580,6 +1591,7 @@
           "description": "Enable calling for Skype channel",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -2051,6 +2063,7 @@
           "description": "Whether this site is enabled for Webchat Speech",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -2062,6 +2075,7 @@
           "description": "Whether this site is enabled for preview versions of Webchat",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {

--- a/schemas/2021-05-01-preview/Microsoft.BotService.json
+++ b/schemas/2021-05-01-preview/Microsoft.BotService.json
@@ -469,6 +469,7 @@
           "type": "string"
         },
         "iconUrl": {
+          "default": "",
           "description": "The Icon Url of the bot",
           "type": "string"
         },
@@ -476,6 +477,7 @@
           "description": "Whether Cmek is enabled",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -487,6 +489,7 @@
           "description": "Whether the bot is streaming supported",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1051,6 +1054,7 @@
           "type": "string"
         },
         "location": {
+          "default": "global",
           "description": "Specifies the location of the resource.",
           "type": "string"
         }
@@ -1109,6 +1113,7 @@
           "type": "string"
         },
         "scopes": {
+          "default": "",
           "description": "Scopes associated with the Connection Setting",
           "type": "string"
         },
@@ -1131,10 +1136,12 @@
           "type": "string"
         },
         "extensionKey1": {
+          "default": "",
           "description": "The extensionKey1",
           "type": "string"
         },
         "extensionKey2": {
+          "default": "",
           "description": "The extensionKey2",
           "type": "string"
         },
@@ -1258,6 +1265,7 @@
           "description": "Whether this site is enabled for Webchat Speech",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1269,6 +1277,7 @@
           "description": "Whether this site is enabled for preview versions of Webchat",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1560,6 +1569,7 @@
           "type": "string"
         },
         "deploymentEnvironment": {
+          "default": "FallbackDeploymentEnvironment",
           "description": "Deployment environment for Microsoft Teams channel calls",
           "type": "string"
         },
@@ -1567,6 +1577,7 @@
           "description": "Enable calling for Microsoft Teams channel",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1710,6 +1721,7 @@
           "description": "Enable calling for Skype channel",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -2181,6 +2193,7 @@
           "description": "Whether this site is enabled for Webchat Speech",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -2192,6 +2205,7 @@
           "description": "Whether this site is enabled for preview versions of Webchat",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {

--- a/schemas/2022-06-15-preview/Microsoft.BotService.json
+++ b/schemas/2022-06-15-preview/Microsoft.BotService.json
@@ -469,6 +469,7 @@
           "type": "string"
         },
         "iconUrl": {
+          "default": "",
           "description": "The Icon Url of the bot",
           "type": "string"
         },
@@ -476,6 +477,7 @@
           "description": "Whether Cmek is enabled",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -487,6 +489,7 @@
           "description": "Whether the bot is streaming supported",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1051,6 +1054,7 @@
           "type": "string"
         },
         "location": {
+          "default": "global",
           "description": "Specifies the location of the resource.",
           "type": "string"
         }
@@ -1109,6 +1113,7 @@
           "type": "string"
         },
         "scopes": {
+          "default": "",
           "description": "Scopes associated with the Connection Setting",
           "type": "string"
         },
@@ -1131,10 +1136,12 @@
           "type": "string"
         },
         "extensionKey1": {
+          "default": "",
           "description": "The extensionKey1",
           "type": "string"
         },
         "extensionKey2": {
+          "default": "",
           "description": "The extensionKey2",
           "type": "string"
         },
@@ -1258,6 +1265,7 @@
           "description": "Whether this site is enabled for Webchat Speech",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1269,6 +1277,7 @@
           "description": "Whether this site is enabled for preview versions of Webchat",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1560,6 +1569,7 @@
           "type": "string"
         },
         "deploymentEnvironment": {
+          "default": "FallbackDeploymentEnvironment",
           "description": "Deployment environment for Microsoft Teams channel calls",
           "type": "string"
         },
@@ -1567,6 +1577,7 @@
           "description": "Enable calling for Microsoft Teams channel",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1710,6 +1721,7 @@
           "description": "Enable calling for Skype channel",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -2181,6 +2193,7 @@
           "description": "Whether this site is enabled for Webchat Speech",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -2192,6 +2205,7 @@
           "description": "Whether this site is enabled for preview versions of Webchat",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {

--- a/schemas/2022-09-15/Microsoft.BotService.json
+++ b/schemas/2022-09-15/Microsoft.BotService.json
@@ -469,6 +469,7 @@
           "type": "string"
         },
         "iconUrl": {
+          "default": "",
           "description": "The Icon Url of the bot",
           "type": "string"
         },
@@ -476,6 +477,7 @@
           "description": "Whether Cmek is enabled",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -487,6 +489,7 @@
           "description": "Whether the bot is streaming supported",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1051,6 +1054,7 @@
           "type": "string"
         },
         "location": {
+          "default": "global",
           "description": "Specifies the location of the resource.",
           "type": "string"
         }
@@ -1109,6 +1113,7 @@
           "type": "string"
         },
         "scopes": {
+          "default": "",
           "description": "Scopes associated with the Connection Setting",
           "type": "string"
         },
@@ -1131,10 +1136,12 @@
           "type": "string"
         },
         "extensionKey1": {
+          "default": "",
           "description": "The extensionKey1",
           "type": "string"
         },
         "extensionKey2": {
+          "default": "",
           "description": "The extensionKey2",
           "type": "string"
         },
@@ -1258,6 +1265,7 @@
           "description": "Whether this site is enabled for Webchat Speech",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1269,6 +1277,7 @@
           "description": "Whether this site is enabled for preview versions of Webchat",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1560,6 +1569,7 @@
           "type": "string"
         },
         "deploymentEnvironment": {
+          "default": "FallbackDeploymentEnvironment",
           "description": "Deployment environment for Microsoft Teams channel calls",
           "type": "string"
         },
@@ -1567,6 +1577,7 @@
           "description": "Enable calling for Microsoft Teams channel",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1710,6 +1721,7 @@
           "description": "Enable calling for Skype channel",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -2192,6 +2204,7 @@
           "description": "Whether this site is enabled for Webchat Speech",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -2203,6 +2216,7 @@
           "description": "Whether this site is enabled for preview versions of Webchat",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {

--- a/schemas/2023-09-15-preview/Microsoft.BotService.json
+++ b/schemas/2023-09-15-preview/Microsoft.BotService.json
@@ -469,6 +469,7 @@
           "type": "string"
         },
         "iconUrl": {
+          "default": "",
           "description": "The Icon Url of the bot",
           "type": "string"
         },
@@ -476,6 +477,7 @@
           "description": "Whether Cmek is enabled",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -487,6 +489,7 @@
           "description": "Whether the bot is streaming supported",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1052,6 +1055,7 @@
           "type": "string"
         },
         "location": {
+          "default": "global",
           "description": "Specifies the location of the resource.",
           "type": "string"
         }
@@ -1110,6 +1114,7 @@
           "type": "string"
         },
         "scopes": {
+          "default": "",
           "description": "Scopes associated with the Connection Setting",
           "type": "string"
         },
@@ -1132,10 +1137,12 @@
           "type": "string"
         },
         "extensionKey1": {
+          "default": "",
           "description": "The extensionKey1",
           "type": "string"
         },
         "extensionKey2": {
+          "default": "",
           "description": "The extensionKey2",
           "type": "string"
         },
@@ -1259,6 +1266,7 @@
           "description": "Whether this site is enabled for Webchat Speech",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1270,6 +1278,7 @@
           "description": "Whether this site is enabled for preview versions of Webchat",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1561,6 +1570,7 @@
           "type": "string"
         },
         "deploymentEnvironment": {
+          "default": "CommercialDeployment",
           "description": "Deployment environment for Microsoft Teams channel calls",
           "type": "string"
         },
@@ -1568,6 +1578,7 @@
           "description": "Enable calling for Microsoft Teams channel",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -1711,6 +1722,7 @@
           "description": "Enable calling for Skype channel",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -2193,6 +2205,7 @@
           "description": "Whether this site is enabled for Webchat Speech",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {
@@ -2204,6 +2217,7 @@
           "description": "Whether this site is enabled for preview versions of Webchat",
           "oneOf": [
             {
+              "default": false,
               "type": "boolean"
             },
             {

--- a/schemas/common/autogeneratedResources.json
+++ b/schemas/common/autogeneratedResources.json
@@ -9851,6 +9851,93 @@
           "$ref": "https://schema.management.azure.com/schemas/2025-12-01-preview/Microsoft.BillingBenefits.json#/resourceDefinitions/maccs"
         },
         {
+          "$ref": "https://schema.management.azure.com/schemas/2017-12-01/Microsoft.BotService.json#/resourceDefinitions/botServices"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2017-12-01/Microsoft.BotService.json#/resourceDefinitions/botServices_channels"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2017-12-01/Microsoft.BotService.json#/resourceDefinitions/botServices_Connections"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-07-12/Microsoft.BotService.json#/resourceDefinitions/botServices"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-07-12/Microsoft.BotService.json#/resourceDefinitions/botServices_channels"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-07-12/Microsoft.BotService.json#/resourceDefinitions/botServices_Connections"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2018-07-12/Microsoft.BotService.json#/resourceDefinitions/enterpriseChannels"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-06-02/Microsoft.BotService.json#/resourceDefinitions/botServices"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-06-02/Microsoft.BotService.json#/resourceDefinitions/botServices_channels"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-06-02/Microsoft.BotService.json#/resourceDefinitions/botServices_connections"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2021-03-01/Microsoft.BotService.json#/resourceDefinitions/botServices"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2021-03-01/Microsoft.BotService.json#/resourceDefinitions/botServices_channels"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2021-03-01/Microsoft.BotService.json#/resourceDefinitions/botServices_connections"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2021-05-01-preview/Microsoft.BotService.json#/resourceDefinitions/botServices"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2021-05-01-preview/Microsoft.BotService.json#/resourceDefinitions/botServices_channels"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2021-05-01-preview/Microsoft.BotService.json#/resourceDefinitions/botServices_connections"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2021-05-01-preview/Microsoft.BotService.json#/resourceDefinitions/botServices_privateEndpointConnections"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2022-06-15-preview/Microsoft.BotService.json#/resourceDefinitions/botServices"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2022-06-15-preview/Microsoft.BotService.json#/resourceDefinitions/botServices_channels"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2022-06-15-preview/Microsoft.BotService.json#/resourceDefinitions/botServices_connections"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2022-06-15-preview/Microsoft.BotService.json#/resourceDefinitions/botServices_privateEndpointConnections"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2022-09-15/Microsoft.BotService.json#/resourceDefinitions/botServices"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2022-09-15/Microsoft.BotService.json#/resourceDefinitions/botServices_channels"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2022-09-15/Microsoft.BotService.json#/resourceDefinitions/botServices_connections"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2022-09-15/Microsoft.BotService.json#/resourceDefinitions/botServices_privateEndpointConnections"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2023-09-15-preview/Microsoft.BotService.json#/resourceDefinitions/botServices"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2023-09-15-preview/Microsoft.BotService.json#/resourceDefinitions/botServices_channels"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2023-09-15-preview/Microsoft.BotService.json#/resourceDefinitions/botServices_connections"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2023-09-15-preview/Microsoft.BotService.json#/resourceDefinitions/botServices_privateEndpointConnections"
+        },
+        {
           "$ref": "https://schema.management.azure.com/schemas/2020-10-01-preview/Microsoft.Cache.Enterprise.json#/resourceDefinitions/redisEnterprise"
         },
         {


### PR DESCRIPTION
## Summary

Re-enables schema auto-generation for **Microsoft.BotService** and regenerates all BotService ARM schemas.

## Root Cause

The BotService resource provider was disabled for schema auto-generation due to a `TypeError: Cannot convert undefined or null to object` caused by `"default": null` entries in the BotService swagger spec.

This resulted in missing JSON schemas for `Microsoft.BotService/botServices` at `schema.management.azure.com`, causing ARM template export failures:

```json
{
  "code": "ResourceTypeSchemaNotFound",
  "target": "Microsoft.BotService/botServices",
  "message": "The schema of resource type 'Microsoft.BotService/botServices' is not available."
}
```

## Fix

The underlying swagger issue has been fixed and merged in azure-rest-api-specs (PR Azure/azure-rest-api-specs#41376) — all `"default": null` entries were removed from the BotService spec across all API versions.

This PR:
1. Removes the `disabledForAutogen: true` flag and error comments for Microsoft.BotService in `generator/autogenlist.ts`
2. Regenerates schemas for all BotService API versions (2017-12-01 through 2023-09-15-preview)
3. Updates `schemas/common/autogeneratedResources.json` with new schema references

## Related

- **Swagger fix**: Azure/azure-rest-api-specs#41376 (merged)
- **IcM 755759455**: Customer unable to export ARM template for Azure Bot Service resource
- **IcM 759102395**: ARM JSON schemas missing for Microsoft.BotService
