### PR TITLE
Onboard Microsoft.Advisor for C# generation

### DIFF
--- a/generator/autogenlist.ts
+++ b/generator/autogenlist.ts
@@ -34,7 +34,7 @@ const csharpGeneratorProviders: CsharpGeneratorConfig[] = [
     { namespace: 'Microsoft.Addons', enabled: false },
     { namespace: 'Microsoft.ADHybridHealthService', enabled: false },
     { namespace: 'Microsoft.Advisor', enabled: false },
-    { namespace: 'Microsoft.AgFoodPlatform', enabled: false },
+    { namespace: 'Microsoft.AgFoodPlatform', enabled: true },
     { namespace: 'Microsoft.AlertsManagement', enabled: false },
     { namespace: 'Microsoft.AnalysisServices', enabled: false },
     { namespace: 'Microsoft.ApiManagement', enabled: false },

--- a/generator/autogenlist.ts
+++ b/generator/autogenlist.ts
@@ -33,7 +33,7 @@ const csharpGeneratorProviders: CsharpGeneratorConfig[] = [
     { namespace: 'Microsoft.Aadiam', enabled: false },
     { namespace: 'Microsoft.Addons', enabled: false },
     { namespace: 'Microsoft.ADHybridHealthService', enabled: false },
-    { namespace: 'Microsoft.Advisor', enabled: false },
+    { namespace: 'Microsoft.Advisor', enabled: true },
     { namespace: 'Microsoft.AgFoodPlatform', enabled: true },
     { namespace: 'Microsoft.AlertsManagement', enabled: false },
     { namespace: 'Microsoft.AnalysisServices', enabled: false },

--- a/schemas/2016-07-12-preview/Microsoft.Advisor.json
+++ b/schemas/2016-07-12-preview/Microsoft.Advisor.json
@@ -3,7 +3,7 @@
   "title": "Microsoft.Advisor",
   "description": "Microsoft Advisor Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "unknown_resourceDefinitions": {
+  "tenant_resourceDefinitions": {
     "recommendations_suppressions": {
       "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
@@ -18,7 +18,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the suppression.",
+          "description": "The resource name",
           "type": "string"
         },
         "suppressionId": {
@@ -59,5 +59,181 @@
       "type": "object"
     }
   },
-  "definitions": {}
+  "managementGroup_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2016-07-12-preview"
+          ],
+          "type": "string"
+        },
+        "location": {
+          "description": "The location of the resource. This cannot be changed after the resource is created.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "suppressionId": {
+          "description": "The GUID of the suppression.",
+          "type": "string"
+        },
+        "tags": {
+          "description": "The tags of the resource.",
+          "oneOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {},
+              "type": "object"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "ttl": {
+          "description": "The duration for which the suppression is valid.",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "subscription_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2016-07-12-preview"
+          ],
+          "type": "string"
+        },
+        "location": {
+          "description": "The location of the resource. This cannot be changed after the resource is created.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "suppressionId": {
+          "description": "The GUID of the suppression.",
+          "type": "string"
+        },
+        "tags": {
+          "description": "The tags of the resource.",
+          "oneOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {},
+              "type": "object"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "ttl": {
+          "description": "The duration for which the suppression is valid.",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2016-07-12-preview"
+          ],
+          "type": "string"
+        },
+        "location": {
+          "description": "The location of the resource. This cannot be changed after the resource is created.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "suppressionId": {
+          "description": "The GUID of the suppression.",
+          "type": "string"
+        },
+        "tags": {
+          "description": "The tags of the resource.",
+          "oneOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {},
+              "type": "object"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "ttl": {
+          "description": "The duration for which the suppression is valid.",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "definitions": {
+    "ResourceTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    }
+  }
 }

--- a/schemas/2017-03-31/Microsoft.Advisor.json
+++ b/schemas/2017-03-31/Microsoft.Advisor.json
@@ -3,7 +3,7 @@
   "title": "Microsoft.Advisor",
   "description": "Microsoft Advisor Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "unknown_resourceDefinitions": {
+  "tenant_resourceDefinitions": {
     "recommendations_suppressions": {
       "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
@@ -14,7 +14,130 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the suppression.",
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "managementGroup_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2017-03-31"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "subscription_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2017-03-31"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2017-03-31"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -46,7 +169,6 @@
   },
   "definitions": {
     "SuppressionProperties": {
-      "description": "The properties of the suppression.",
       "properties": {
         "suppressionId": {
           "description": "The GUID of the suppression.",

--- a/schemas/2017-04-19/Microsoft.Advisor.json
+++ b/schemas/2017-04-19/Microsoft.Advisor.json
@@ -3,7 +3,7 @@
   "title": "Microsoft.Advisor",
   "description": "Microsoft Advisor Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "unknown_resourceDefinitions": {
+  "tenant_resourceDefinitions": {
     "recommendations_suppressions": {
       "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
@@ -14,7 +14,130 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the suppression.",
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "managementGroup_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2017-04-19"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "subscription_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2017-04-19"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2017-04-19"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -46,7 +169,6 @@
   },
   "definitions": {
     "SuppressionProperties": {
-      "description": "The properties of the suppression.",
       "properties": {
         "suppressionId": {
           "description": "The GUID of the suppression.",

--- a/schemas/2018-05-01/subscriptionDeploymentTemplate.json
+++ b/schemas/2018-05-01/subscriptionDeploymentTemplate.json
@@ -507,37 +507,37 @@
               "$ref": "https://schema.management.azure.com/schemas/2018-03-01/Microsoft.Addons.json#/subscription_resourceDefinitions/supportProviders_supportPlanTypes"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2016-07-12-preview/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2016-07-12-preview/Microsoft.Advisor.json#/subscription_resourceDefinitions/recommendations_suppressions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2017-03-31/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2017-03-31/Microsoft.Advisor.json#/subscription_resourceDefinitions/recommendations_suppressions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2017-04-19/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2017-04-19/Microsoft.Advisor.json#/subscription_resourceDefinitions/recommendations_suppressions"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/2020-01-01/Microsoft.Advisor.json#/subscription_resourceDefinitions/configurations"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2020-01-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2020-01-01/Microsoft.Advisor.json#/subscription_resourceDefinitions/recommendations_suppressions"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/2022-09-01/Microsoft.Advisor.json#/subscription_resourceDefinitions/configurations"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2022-09-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2022-09-01/Microsoft.Advisor.json#/subscription_resourceDefinitions/recommendations_suppressions"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.Advisor.json#/subscription_resourceDefinitions/configurations"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.Advisor.json#/subscription_resourceDefinitions/recommendations_suppressions"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/2023-01-01/Microsoft.Advisor.json#/subscription_resourceDefinitions/configurations"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2023-01-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2023-01-01/Microsoft.Advisor.json#/subscription_resourceDefinitions/recommendations_suppressions"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/2023-09-01-preview/Microsoft.Advisor.json#/subscription_resourceDefinitions/assessments"
@@ -546,7 +546,7 @@
               "$ref": "https://schema.management.azure.com/schemas/2023-09-01-preview/Microsoft.Advisor.json#/subscription_resourceDefinitions/configurations"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2023-09-01-preview/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2023-09-01-preview/Microsoft.Advisor.json#/subscription_resourceDefinitions/recommendations_suppressions"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/2024-11-18-preview/Microsoft.Advisor.json#/subscription_resourceDefinitions/assessments"
@@ -555,13 +555,13 @@
               "$ref": "https://schema.management.azure.com/schemas/2024-11-18-preview/Microsoft.Advisor.json#/subscription_resourceDefinitions/configurations"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2024-11-18-preview/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2024-11-18-preview/Microsoft.Advisor.json#/subscription_resourceDefinitions/recommendations_suppressions"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/2025-01-01/Microsoft.Advisor.json#/subscription_resourceDefinitions/configurations"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2025-01-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2025-01-01/Microsoft.Advisor.json#/subscription_resourceDefinitions/recommendations_suppressions"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/2025-05-01-preview/Microsoft.Advisor.json#/subscription_resourceDefinitions/assessments"
@@ -570,7 +570,7 @@
               "$ref": "https://schema.management.azure.com/schemas/2025-05-01-preview/Microsoft.Advisor.json#/subscription_resourceDefinitions/configurations"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2025-05-01-preview/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2025-05-01-preview/Microsoft.Advisor.json#/subscription_resourceDefinitions/recommendations_suppressions"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/2025-03-01-preview/Microsoft.AlertsManagement.Legacy.json#/unknown_resourceDefinitions/issues"

--- a/schemas/2019-08-01/managementGroupDeploymentTemplate.json
+++ b/schemas/2019-08-01/managementGroupDeploymentTemplate.json
@@ -501,37 +501,37 @@
         {
           "oneOf": [
             {
-              "$ref": "https://schema.management.azure.com/schemas/2016-07-12-preview/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2016-07-12-preview/Microsoft.Advisor.json#/managementGroup_resourceDefinitions/recommendations_suppressions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2017-03-31/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2017-03-31/Microsoft.Advisor.json#/managementGroup_resourceDefinitions/recommendations_suppressions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2017-04-19/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2017-04-19/Microsoft.Advisor.json#/managementGroup_resourceDefinitions/recommendations_suppressions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2020-01-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2020-01-01/Microsoft.Advisor.json#/managementGroup_resourceDefinitions/recommendations_suppressions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2022-09-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2022-09-01/Microsoft.Advisor.json#/managementGroup_resourceDefinitions/recommendations_suppressions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.Advisor.json#/managementGroup_resourceDefinitions/recommendations_suppressions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2023-01-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2023-01-01/Microsoft.Advisor.json#/managementGroup_resourceDefinitions/recommendations_suppressions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2023-09-01-preview/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2023-09-01-preview/Microsoft.Advisor.json#/managementGroup_resourceDefinitions/recommendations_suppressions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2024-11-18-preview/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2024-11-18-preview/Microsoft.Advisor.json#/managementGroup_resourceDefinitions/recommendations_suppressions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2025-01-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2025-01-01/Microsoft.Advisor.json#/managementGroup_resourceDefinitions/recommendations_suppressions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2025-05-01-preview/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+              "$ref": "https://schema.management.azure.com/schemas/2025-05-01-preview/Microsoft.Advisor.json#/managementGroup_resourceDefinitions/recommendations_suppressions"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/2025-03-01-preview/Microsoft.AlertsManagement.Legacy.json#/unknown_resourceDefinitions/issues"

--- a/schemas/2019-08-01/tenantDeploymentTemplate.json
+++ b/schemas/2019-08-01/tenantDeploymentTemplate.json
@@ -509,37 +509,37 @@
                   "$ref": "https://schema.management.azure.com/schemas/2017-04-01-preview/Microsoft.Aadiam.json#/tenant_resourceDefinitions/diagnosticSettings"
                 },
                 {
-                  "$ref": "https://schema.management.azure.com/schemas/2016-07-12-preview/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+                  "$ref": "https://schema.management.azure.com/schemas/2016-07-12-preview/Microsoft.Advisor.json#/tenant_resourceDefinitions/recommendations_suppressions"
                 },
                 {
-                  "$ref": "https://schema.management.azure.com/schemas/2017-03-31/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+                  "$ref": "https://schema.management.azure.com/schemas/2017-03-31/Microsoft.Advisor.json#/tenant_resourceDefinitions/recommendations_suppressions"
                 },
                 {
-                  "$ref": "https://schema.management.azure.com/schemas/2017-04-19/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+                  "$ref": "https://schema.management.azure.com/schemas/2017-04-19/Microsoft.Advisor.json#/tenant_resourceDefinitions/recommendations_suppressions"
                 },
                 {
-                  "$ref": "https://schema.management.azure.com/schemas/2020-01-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+                  "$ref": "https://schema.management.azure.com/schemas/2020-01-01/Microsoft.Advisor.json#/tenant_resourceDefinitions/recommendations_suppressions"
                 },
                 {
-                  "$ref": "https://schema.management.azure.com/schemas/2022-09-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+                  "$ref": "https://schema.management.azure.com/schemas/2022-09-01/Microsoft.Advisor.json#/tenant_resourceDefinitions/recommendations_suppressions"
                 },
                 {
-                  "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+                  "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.Advisor.json#/tenant_resourceDefinitions/recommendations_suppressions"
                 },
                 {
-                  "$ref": "https://schema.management.azure.com/schemas/2023-01-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+                  "$ref": "https://schema.management.azure.com/schemas/2023-01-01/Microsoft.Advisor.json#/tenant_resourceDefinitions/recommendations_suppressions"
                 },
                 {
-                  "$ref": "https://schema.management.azure.com/schemas/2023-09-01-preview/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+                  "$ref": "https://schema.management.azure.com/schemas/2023-09-01-preview/Microsoft.Advisor.json#/tenant_resourceDefinitions/recommendations_suppressions"
                 },
                 {
-                  "$ref": "https://schema.management.azure.com/schemas/2024-11-18-preview/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+                  "$ref": "https://schema.management.azure.com/schemas/2024-11-18-preview/Microsoft.Advisor.json#/tenant_resourceDefinitions/recommendations_suppressions"
                 },
                 {
-                  "$ref": "https://schema.management.azure.com/schemas/2025-01-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+                  "$ref": "https://schema.management.azure.com/schemas/2025-01-01/Microsoft.Advisor.json#/tenant_resourceDefinitions/recommendations_suppressions"
                 },
                 {
-                  "$ref": "https://schema.management.azure.com/schemas/2025-05-01-preview/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+                  "$ref": "https://schema.management.azure.com/schemas/2025-05-01-preview/Microsoft.Advisor.json#/tenant_resourceDefinitions/recommendations_suppressions"
                 },
                 {
                   "$ref": "https://schema.management.azure.com/schemas/2025-03-01-preview/Microsoft.AlertsManagement.Legacy.json#/unknown_resourceDefinitions/issues"

--- a/schemas/2020-01-01/Microsoft.Advisor.json
+++ b/schemas/2020-01-01/Microsoft.Advisor.json
@@ -3,9 +3,9 @@
   "title": "Microsoft.Advisor",
   "description": "Microsoft Advisor Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "resourceDefinitions": {
-    "configurations": {
-      "description": "Microsoft.Advisor/configurations",
+  "tenant_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -14,24 +14,14 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor configuration name. Value must be 'default'",
-          "oneOf": [
-            {
-              "enum": [
-                "default"
-              ],
-              "type": "string"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
-          ]
+          "description": "The resource name",
+          "type": "string"
         },
         "properties": {
-          "description": "The Advisor configuration data structure.",
+          "description": "The properties of the suppression.",
           "oneOf": [
             {
-              "$ref": "#/definitions/ConfigDataProperties"
+              "$ref": "#/definitions/SuppressionProperties"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
@@ -40,7 +30,48 @@
         },
         "type": {
           "enum": [
-            "Microsoft.Advisor/configurations"
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "managementGroup_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2020-01-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
           ],
           "type": "string"
         }
@@ -65,7 +96,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor configuration name. Value must be 'default'",
+          "description": "The resource name",
           "oneOf": [
             {
               "enum": [
@@ -103,9 +134,7 @@
         "type"
       ],
       "type": "object"
-    }
-  },
-  "unknown_resourceDefinitions": {
+    },
     "recommendations_suppressions": {
       "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
@@ -116,7 +145,97 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the suppression.",
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "configurations": {
+      "description": "Microsoft.Advisor/configurations",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2020-01-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "oneOf": [
+            {
+              "enum": [
+                "default"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "The Advisor configuration data structure.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ConfigDataProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/configurations"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2020-01-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -148,7 +267,6 @@
   },
   "definitions": {
     "ConfigDataProperties": {
-      "description": "Configuration data properties",
       "properties": {
         "digests": {
           "description": "Advisor digest configuration. Valid only for subscriptions",
@@ -196,7 +314,6 @@
       "type": "object"
     },
     "DigestConfig": {
-      "description": "Advisor Digest configuration entity",
       "properties": {
         "actionGroupResourceId": {
           "description": "Action group resource id used by digest.",
@@ -261,7 +378,6 @@
       "type": "object"
     },
     "SuppressionProperties": {
-      "description": "The properties of the suppression.",
       "properties": {
         "suppressionId": {
           "description": "The GUID of the suppression.",

--- a/schemas/2020-05-12-preview/Microsoft.AgFoodPlatform.json
+++ b/schemas/2020-05-12-preview/Microsoft.AgFoodPlatform.json
@@ -18,7 +18,7 @@
           "type": "string"
         },
         "name": {
-          "description": "FarmBeats resource name.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -76,6 +76,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",
@@ -93,7 +94,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Id of extension resource.",
+          "description": "The resource name",
           "type": "string"
         },
         "type": {
@@ -113,12 +114,10 @@
   },
   "definitions": {
     "FarmBeatsProperties": {
-      "description": "FarmBeats ARM Resource properties.",
       "properties": {},
       "type": "object"
     },
     "Sku": {
-      "description": "The resource model definition representing SKU",
       "properties": {
         "capacity": {
           "description": "If the SKU supports scale out/in then the capacity integer should be included. If scale out/in is not possible for the resource this may be omitted.",
@@ -140,7 +139,7 @@
           "type": "string"
         },
         "size": {
-          "description": "The SKU size. When the name field is the combination of tier and some other value, this would be the standalone code. ",
+          "description": "The SKU size. When the name field is the combination of tier and some other value, this would be the standalone code.",
           "type": "string"
         },
         "tier": {
@@ -166,8 +165,15 @@
       ],
       "type": "object"
     },
+    "TrackedResourceTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "farmBeats_extensions_childResource": {
-      "description": "Microsoft.AgFoodPlatform/farmBeats/extensions",
+      "description": "extensions",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -176,7 +182,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Id of extension resource.",
+          "description": "The resource name",
           "type": "string"
         },
         "type": {

--- a/schemas/2021-09-01-preview/Microsoft.AgFoodPlatform.json
+++ b/schemas/2021-09-01-preview/Microsoft.AgFoodPlatform.json
@@ -29,7 +29,7 @@
           "type": "string"
         },
         "name": {
-          "description": "FarmBeats resource name.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -47,13 +47,13 @@
           "items": {
             "oneOf": [
               {
-                "$ref": "#/definitions/farmBeats_solutions_childResource"
-              },
-              {
                 "$ref": "#/definitions/farmBeats_extensions_childResource"
               },
               {
                 "$ref": "#/definitions/farmBeats_privateEndpointConnections_childResource"
+              },
+              {
+                "$ref": "#/definitions/farmBeats_solutions_childResource"
               }
             ]
           },
@@ -82,6 +82,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",
@@ -115,12 +116,19 @@
         },
         "extensionVersion": {
           "description": "Extension Version.",
-          "maxLength": 10,
-          "minLength": 3,
-          "type": "string"
+          "oneOf": [
+            {
+              "maxLength": 10,
+              "minLength": 3,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "name": {
-          "description": "Id of extension resource.",
+          "description": "The resource name",
           "type": "string"
         },
         "type": {
@@ -147,7 +155,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Private endpoint connection name.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -186,7 +194,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Solution Id of the solution.",
+          "description": "The resource name",
           "oneOf": [
             {
               "pattern": "^[a-zA-Z]{3,50}[.][a-zA-Z]{3,100}$",
@@ -226,7 +234,6 @@
   },
   "definitions": {
     "ApiProperties": {
-      "description": "Api properties.",
       "properties": {
         "apiFreshnessTimeInMinutes": {
           "description": "Interval in minutes for which the weather data for the api needs to be refreshed.",
@@ -245,12 +252,10 @@
       "type": "object"
     },
     "ErrorDetail": {
-      "description": "The error detail.",
       "properties": {},
       "type": "object"
     },
     "ErrorResponse": {
-      "description": "Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).",
       "properties": {
         "error": {
           "description": "The error object.",
@@ -266,8 +271,14 @@
       },
       "type": "object"
     },
+    "ExtensionInstallationRequestAdditionalApiProperties": {
+      "additionalProperties": {
+        "$ref": "#/definitions/ApiProperties"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "FarmBeatsProperties": {
-      "description": "FarmBeats ARM Resource properties.",
       "properties": {
         "publicNetworkAccess": {
           "description": "Property to allow or block public traffic for an Azure FarmBeats resource.",
@@ -299,7 +310,6 @@
       "type": "object"
     },
     "Identity": {
-      "description": "Identity for the resource.",
       "properties": {
         "type": {
           "description": "The identity type.",
@@ -319,12 +329,10 @@
       "type": "object"
     },
     "PrivateEndpoint": {
-      "description": "The private endpoint resource.",
       "properties": {},
       "type": "object"
     },
     "PrivateEndpointConnectionProperties": {
-      "description": "Properties of the private endpoint connection.",
       "properties": {
         "privateEndpoint": {
           "description": "The private endpoint resource.",
@@ -355,7 +363,6 @@
       "type": "object"
     },
     "PrivateLinkServiceConnectionState": {
-      "description": "A collection of information about the state of the connection between service consumer and provider.",
       "properties": {
         "actionsRequired": {
           "description": "A message indicating if changes on the service provider require any updates on the consumer.",
@@ -385,7 +392,6 @@
       "type": "object"
     },
     "SensorIntegration": {
-      "description": "Sensor integration request model.",
       "properties": {
         "enabled": {
           "description": "Sensor integration enable state. Allowed values are True, None",
@@ -407,51 +413,99 @@
     },
     "SolutionProperties": {
       "additionalProperties": {},
-      "description": "Solution resource properties.",
       "properties": {
         "marketplacePublisherId": {
           "description": "SaaS application Publisher Id.",
-          "minLength": 1,
-          "type": "string"
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "offerId": {
           "description": "SaaS application Offer Id.",
-          "minLength": 1,
-          "type": "string"
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "planId": {
           "description": "SaaS application Plan Id.",
-          "minLength": 1,
-          "type": "string"
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "saasSubscriptionId": {
           "description": "SaaS subscriptionId of the installed SaaS application.",
-          "minLength": 1,
-          "type": "string"
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "saasSubscriptionName": {
           "description": "SaaS subscription name of the installed SaaS application.",
-          "minLength": 1,
-          "type": "string"
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "termId": {
           "description": "SaaS application Term Id.",
-          "minLength": 1,
-          "type": "string"
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         }
       },
       "required": [
+        "marketplacePublisherId",
+        "offerId",
+        "planId",
         "saasSubscriptionId",
         "saasSubscriptionName",
-        "marketplacePublisherId",
-        "planId",
-        "offerId",
         "termId"
       ],
       "type": "object"
     },
+    "TrackedResourceTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "farmBeats_extensions_childResource": {
-      "description": "Microsoft.AgFoodPlatform/farmBeats/extensions",
+      "description": "extensions",
       "properties": {
         "additionalApiProperties": {
           "description": "Additional Api Properties.",
@@ -476,12 +530,19 @@
         },
         "extensionVersion": {
           "description": "Extension Version.",
-          "maxLength": 10,
-          "minLength": 3,
-          "type": "string"
+          "oneOf": [
+            {
+              "maxLength": 10,
+              "minLength": 3,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "name": {
-          "description": "Id of extension resource.",
+          "description": "The resource name",
           "type": "string"
         },
         "type": {
@@ -499,7 +560,7 @@
       "type": "object"
     },
     "farmBeats_privateEndpointConnections_childResource": {
-      "description": "Microsoft.AgFoodPlatform/farmBeats/privateEndpointConnections",
+      "description": "privateEndpointConnections",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -508,7 +569,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Private endpoint connection name.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -538,7 +599,7 @@
       "type": "object"
     },
     "farmBeats_solutions_childResource": {
-      "description": "Microsoft.AgFoodPlatform/farmBeats/solutions",
+      "description": "solutions",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -547,7 +608,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Solution Id of the solution.",
+          "description": "The resource name",
           "oneOf": [
             {
               "pattern": "^[a-zA-Z]{3,50}[.][a-zA-Z]{3,100}$",

--- a/schemas/2022-09-01/Microsoft.Advisor.json
+++ b/schemas/2022-09-01/Microsoft.Advisor.json
@@ -3,9 +3,9 @@
   "title": "Microsoft.Advisor",
   "description": "Microsoft Advisor Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "resourceDefinitions": {
-    "configurations": {
-      "description": "Microsoft.Advisor/configurations",
+  "tenant_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -14,24 +14,14 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor configuration name. Value must be 'default'",
-          "oneOf": [
-            {
-              "enum": [
-                "default"
-              ],
-              "type": "string"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
-          ]
+          "description": "The resource name",
+          "type": "string"
         },
         "properties": {
-          "description": "The Advisor configuration data structure.",
+          "description": "The properties of the suppression.",
           "oneOf": [
             {
-              "$ref": "#/definitions/ConfigDataProperties"
+              "$ref": "#/definitions/SuppressionProperties"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
@@ -40,7 +30,48 @@
         },
         "type": {
           "enum": [
-            "Microsoft.Advisor/configurations"
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "managementGroup_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-09-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
           ],
           "type": "string"
         }
@@ -65,7 +96,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor configuration name. Value must be 'default'",
+          "description": "The resource name",
           "oneOf": [
             {
               "enum": [
@@ -103,9 +134,7 @@
         "type"
       ],
       "type": "object"
-    }
-  },
-  "unknown_resourceDefinitions": {
+    },
     "recommendations_suppressions": {
       "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
@@ -116,7 +145,97 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the suppression.",
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "configurations": {
+      "description": "Microsoft.Advisor/configurations",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-09-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "oneOf": [
+            {
+              "enum": [
+                "default"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "The Advisor configuration data structure.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ConfigDataProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/configurations"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-09-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -148,7 +267,6 @@
   },
   "definitions": {
     "ConfigDataProperties": {
-      "description": "Configuration data properties",
       "properties": {
         "digests": {
           "description": "Advisor digest configuration. Valid only for subscriptions",
@@ -215,7 +333,6 @@
       "type": "object"
     },
     "DigestConfig": {
-      "description": "Advisor Digest configuration entity",
       "properties": {
         "actionGroupResourceId": {
           "description": "Action group resource id used by digest.",
@@ -280,7 +397,6 @@
       "type": "object"
     },
     "SuppressionProperties": {
-      "description": "The properties of the suppression.",
       "properties": {
         "suppressionId": {
           "description": "The GUID of the suppression.",

--- a/schemas/2022-10-01/Microsoft.Advisor.json
+++ b/schemas/2022-10-01/Microsoft.Advisor.json
@@ -3,9 +3,9 @@
   "title": "Microsoft.Advisor",
   "description": "Microsoft Advisor Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "resourceDefinitions": {
-    "configurations": {
-      "description": "Microsoft.Advisor/configurations",
+  "tenant_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -14,24 +14,14 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor configuration name. Value must be 'default'",
-          "oneOf": [
-            {
-              "enum": [
-                "default"
-              ],
-              "type": "string"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
-          ]
+          "description": "The resource name",
+          "type": "string"
         },
         "properties": {
-          "description": "The Advisor configuration data structure.",
+          "description": "The properties of the suppression.",
           "oneOf": [
             {
-              "$ref": "#/definitions/ConfigDataProperties"
+              "$ref": "#/definitions/SuppressionProperties"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
@@ -40,7 +30,48 @@
         },
         "type": {
           "enum": [
-            "Microsoft.Advisor/configurations"
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "managementGroup_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-10-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
           ],
           "type": "string"
         }
@@ -65,7 +96,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor configuration name. Value must be 'default'",
+          "description": "The resource name",
           "oneOf": [
             {
               "enum": [
@@ -103,9 +134,7 @@
         "type"
       ],
       "type": "object"
-    }
-  },
-  "unknown_resourceDefinitions": {
+    },
     "recommendations_suppressions": {
       "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
@@ -116,7 +145,97 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the suppression.",
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "configurations": {
+      "description": "Microsoft.Advisor/configurations",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-10-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "oneOf": [
+            {
+              "enum": [
+                "default"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "The Advisor configuration data structure.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ConfigDataProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/configurations"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-10-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -148,7 +267,6 @@
   },
   "definitions": {
     "ConfigDataProperties": {
-      "description": "Configuration data properties",
       "properties": {
         "digests": {
           "description": "Advisor digest configuration. Valid only for subscriptions",
@@ -215,7 +333,6 @@
       "type": "object"
     },
     "DigestConfig": {
-      "description": "Advisor Digest configuration entity",
       "properties": {
         "actionGroupResourceId": {
           "description": "Action group resource id used by digest.",
@@ -280,7 +397,6 @@
       "type": "object"
     },
     "SuppressionProperties": {
-      "description": "The properties of the suppression.",
       "properties": {
         "suppressionId": {
           "description": "The GUID of the suppression.",

--- a/schemas/2023-01-01/Microsoft.Advisor.json
+++ b/schemas/2023-01-01/Microsoft.Advisor.json
@@ -3,9 +3,9 @@
   "title": "Microsoft.Advisor",
   "description": "Microsoft Advisor Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "resourceDefinitions": {
-    "configurations": {
-      "description": "Microsoft.Advisor/configurations",
+  "tenant_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -14,24 +14,14 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor configuration name. Value must be 'default'",
-          "oneOf": [
-            {
-              "enum": [
-                "default"
-              ],
-              "type": "string"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
-          ]
+          "description": "The resource name",
+          "type": "string"
         },
         "properties": {
-          "description": "The Advisor configuration data structure.",
+          "description": "The properties of the suppression.",
           "oneOf": [
             {
-              "$ref": "#/definitions/ConfigDataProperties"
+              "$ref": "#/definitions/SuppressionProperties"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
@@ -40,7 +30,48 @@
         },
         "type": {
           "enum": [
-            "Microsoft.Advisor/configurations"
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "managementGroup_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2023-01-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
           ],
           "type": "string"
         }
@@ -65,7 +96,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor configuration name. Value must be 'default'",
+          "description": "The resource name",
           "oneOf": [
             {
               "enum": [
@@ -103,9 +134,7 @@
         "type"
       ],
       "type": "object"
-    }
-  },
-  "unknown_resourceDefinitions": {
+    },
     "recommendations_suppressions": {
       "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
@@ -116,7 +145,97 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the suppression.",
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "configurations": {
+      "description": "Microsoft.Advisor/configurations",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2023-01-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "oneOf": [
+            {
+              "enum": [
+                "default"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "The Advisor configuration data structure.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ConfigDataProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/configurations"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2023-01-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -148,7 +267,6 @@
   },
   "definitions": {
     "ConfigDataProperties": {
-      "description": "Configuration data properties",
       "properties": {
         "digests": {
           "description": "Advisor digest configuration. Valid only for subscriptions",
@@ -215,7 +333,6 @@
       "type": "object"
     },
     "DigestConfig": {
-      "description": "Advisor Digest configuration entity",
       "properties": {
         "actionGroupResourceId": {
           "description": "Action group resource id used by digest.",
@@ -280,7 +397,6 @@
       "type": "object"
     },
     "SuppressionProperties": {
-      "description": "The properties of the suppression.",
       "properties": {
         "suppressionId": {
           "description": "The GUID of the suppression.",

--- a/schemas/2023-06-01-preview/Microsoft.AgFoodPlatform.json
+++ b/schemas/2023-06-01-preview/Microsoft.AgFoodPlatform.json
@@ -29,7 +29,7 @@
           "type": "string"
         },
         "name": {
-          "description": "DataManagerForAgriculture resource name.",
+          "description": "The resource name",
           "oneOf": [
             {
               "maxLength": 63,
@@ -57,16 +57,16 @@
           "items": {
             "oneOf": [
               {
-                "$ref": "#/definitions/farmBeats_solutions_childResource"
+                "$ref": "#/definitions/farmBeats_dataConnectors_childResource"
               },
               {
                 "$ref": "#/definitions/farmBeats_extensions_childResource"
               },
               {
-                "$ref": "#/definitions/farmBeats_dataConnectors_childResource"
+                "$ref": "#/definitions/farmBeats_privateEndpointConnections_childResource"
               },
               {
-                "$ref": "#/definitions/farmBeats_privateEndpointConnections_childResource"
+                "$ref": "#/definitions/farmBeats_solutions_childResource"
               }
             ]
           },
@@ -95,6 +95,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",
@@ -112,10 +113,17 @@
           "type": "string"
         },
         "name": {
-          "description": "Connector name.",
-          "maxLength": 63,
-          "minLength": 1,
-          "type": "string"
+          "description": "The resource name",
+          "oneOf": [
+            {
+              "maxLength": 63,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "properties": {
           "description": "DataConnector Properties.",
@@ -169,12 +177,19 @@
         },
         "extensionVersion": {
           "description": "Extension Version.",
-          "maxLength": 10,
-          "minLength": 3,
-          "type": "string"
+          "oneOf": [
+            {
+              "maxLength": 10,
+              "minLength": 3,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "name": {
-          "description": "Id of extension resource.",
+          "description": "The resource name",
           "type": "string"
         },
         "type": {
@@ -201,7 +216,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Private endpoint connection name.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -240,7 +255,7 @@
           "type": "string"
         },
         "name": {
-          "description": "SolutionId for Data Manager For Agriculture Resource.",
+          "description": "The resource name",
           "oneOf": [
             {
               "pattern": "^[a-zA-Z]{3,50}[.][a-zA-Z]{3,100}$",
@@ -279,8 +294,41 @@
     }
   },
   "definitions": {
+    "ApiKeyAuthCredentials": {
+      "properties": {
+        "apiKey": {
+          "description": "Properties of the key vault.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/KeyVaultProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "kind": {
+          "description": "Enum for different types of AuthCredentials supported.",
+          "oneOf": [
+            {
+              "enum": [
+                "ApiKeyAuthCredentials"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "required": [
+        "apiKey",
+        "kind"
+      ],
+      "type": "object"
+    },
     "ApiProperties": {
-      "description": "Api properties.",
       "properties": {
         "apiFreshnessTimeInMinutes": {
           "description": "Interval in minutes for which the weather data for the api needs to be refreshed.",
@@ -299,74 +347,66 @@
       "type": "object"
     },
     "AuthCredentials": {
-      "description": "AuthCredentials abstract base class for Auth Purpose.",
-      "oneOf": [
+      "allOf": [
         {
-          "description": "ApiKeyAuthCredentials class for ApiKey based Auth.",
+          "additionalProperties": false,
           "properties": {
-            "apiKey": {
-              "description": "Properties of the key vault.",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/KeyVaultProperties"
-                },
-                {
-                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-                }
-              ]
-            },
             "kind": {
               "enum": [
-                "ApiKeyAuthCredentials"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "apiKey",
-            "kind"
-          ],
-          "type": "object"
-        },
-        {
-          "description": "OAuthClientCredentials for clientId clientSecret auth.",
-          "properties": {
-            "clientId": {
-              "description": "ClientId associated with the provider.",
-              "minLength": 1,
-              "type": "string"
-            },
-            "clientSecret": {
-              "description": "Properties of the key vault.",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/KeyVaultProperties"
-                },
-                {
-                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-                }
-              ]
-            },
-            "kind": {
-              "enum": [
+                "ApiKeyAuthCredentials",
                 "OAuthClientCredentials"
               ],
               "type": "string"
             }
           },
           "required": [
-            "clientId",
-            "clientSecret",
             "kind"
           ],
           "type": "object"
+        },
+        {
+          "oneOf": [
+            {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ApiKeyAuthCredentials"
+                },
+                {
+                  "properties": {
+                    "kind": {
+                      "const": "ApiKeyAuthCredentials"
+                    }
+                  },
+                  "required": [
+                    "kind"
+                  ],
+                  "type": "object"
+                }
+              ]
+            },
+            {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OAuthClientCredentials"
+                },
+                {
+                  "properties": {
+                    "kind": {
+                      "const": "OAuthClientCredentials"
+                    }
+                  },
+                  "required": [
+                    "kind"
+                  ],
+                  "type": "object"
+                }
+              ]
+            }
+          ]
         }
-      ],
-      "properties": {},
-      "type": "object"
+      ]
     },
     "DataConnectorProperties": {
-      "description": "DataConnector Properties.",
       "properties": {
         "credentials": {
           "description": "AuthCredentials abstract base class for Auth Purpose.",
@@ -386,7 +426,6 @@
       "type": "object"
     },
     "DataManagerForAgricultureProperties": {
-      "description": "Data Manager For Agriculture ARM Resource properties.",
       "properties": {
         "publicNetworkAccess": {
           "description": "Property to allow or block public traffic for an Azure Data Manager For Agriculture resource.",
@@ -418,12 +457,10 @@
       "type": "object"
     },
     "ErrorDetail": {
-      "description": "The error detail.",
       "properties": {},
       "type": "object"
     },
     "ErrorResponse": {
-      "description": "Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).",
       "properties": {
         "error": {
           "description": "The error object.",
@@ -439,8 +476,14 @@
       },
       "type": "object"
     },
+    "ExtensionInstallationRequestAdditionalApiProperties": {
+      "additionalProperties": {
+        "$ref": "#/definitions/ApiProperties"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "Identity": {
-      "description": "Identity for the resource.",
       "properties": {
         "type": {
           "description": "The identity type.",
@@ -460,38 +503,103 @@
       "type": "object"
     },
     "KeyVaultProperties": {
-      "description": "Properties of the key vault.",
       "properties": {
         "keyName": {
           "description": "Name of Key Vault key.",
-          "minLength": 1,
-          "type": "string"
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "keyVaultUri": {
           "description": "Uri of the key vault.",
-          "minLength": 1,
-          "type": "string"
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "keyVersion": {
           "description": "Version of Key Vault key.",
-          "minLength": 1,
-          "type": "string"
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         }
       },
       "required": [
-        "keyVaultUri",
         "keyName",
+        "keyVaultUri",
         "keyVersion"
       ],
       "type": "object"
     },
+    "OAuthClientCredentials": {
+      "properties": {
+        "clientId": {
+          "description": "ClientId associated with the provider.",
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "clientSecret": {
+          "description": "Properties of the key vault.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/KeyVaultProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "kind": {
+          "description": "Enum for different types of AuthCredentials supported.",
+          "oneOf": [
+            {
+              "enum": [
+                "OAuthClientCredentials"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "required": [
+        "clientId",
+        "clientSecret",
+        "kind"
+      ],
+      "type": "object"
+    },
     "PrivateEndpoint": {
-      "description": "The private endpoint resource.",
       "properties": {},
       "type": "object"
     },
     "PrivateEndpointConnectionProperties": {
-      "description": "Properties of the private endpoint connection.",
       "properties": {
         "privateEndpoint": {
           "description": "The private endpoint resource.",
@@ -522,7 +630,6 @@
       "type": "object"
     },
     "PrivateLinkServiceConnectionState": {
-      "description": "A collection of information about the state of the connection between service consumer and provider.",
       "properties": {
         "actionsRequired": {
           "description": "A message indicating if changes on the service provider require any updates on the consumer.",
@@ -552,7 +659,6 @@
       "type": "object"
     },
     "SensorIntegration": {
-      "description": "Sensor integration request model.",
       "properties": {
         "enabled": {
           "description": "Sensor integration enable state.",
@@ -574,22 +680,42 @@
     },
     "SolutionProperties": {
       "additionalProperties": {},
-      "description": "Solution resource properties.",
       "properties": {
         "marketplacePublisherId": {
           "description": "SaaS application Marketplace Publisher Id.",
-          "minLength": 1,
-          "type": "string"
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "offerId": {
           "description": "SaaS application Offer Id.",
-          "minLength": 1,
-          "type": "string"
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "planId": {
           "description": "SaaS application Plan Id.",
-          "minLength": 1,
-          "type": "string"
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "roleAssignmentId": {
           "description": "Role Assignment Id.",
@@ -597,32 +723,60 @@
         },
         "saasSubscriptionId": {
           "description": "SaaS subscriptionId of the installed SaaS application.",
-          "minLength": 1,
-          "type": "string"
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "saasSubscriptionName": {
           "description": "SaaS subscription name of the installed SaaS application.",
-          "minLength": 1,
-          "type": "string"
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "termId": {
           "description": "SaaS application Term Id.",
-          "minLength": 1,
-          "type": "string"
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         }
       },
       "required": [
+        "marketplacePublisherId",
+        "offerId",
+        "planId",
         "saasSubscriptionId",
         "saasSubscriptionName",
-        "marketplacePublisherId",
-        "planId",
-        "offerId",
         "termId"
       ],
       "type": "object"
     },
+    "TrackedResourceTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "farmBeats_dataConnectors_childResource": {
-      "description": "Microsoft.AgFoodPlatform/farmBeats/dataConnectors",
+      "description": "dataConnectors",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -631,10 +785,17 @@
           "type": "string"
         },
         "name": {
-          "description": "Connector name.",
-          "maxLength": 63,
-          "minLength": 1,
-          "type": "string"
+          "description": "The resource name",
+          "oneOf": [
+            {
+              "maxLength": 63,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "properties": {
           "description": "DataConnector Properties.",
@@ -663,7 +824,7 @@
       "type": "object"
     },
     "farmBeats_extensions_childResource": {
-      "description": "Microsoft.AgFoodPlatform/farmBeats/extensions",
+      "description": "extensions",
       "properties": {
         "additionalApiProperties": {
           "description": "Additional Api Properties.",
@@ -688,12 +849,19 @@
         },
         "extensionVersion": {
           "description": "Extension Version.",
-          "maxLength": 10,
-          "minLength": 3,
-          "type": "string"
+          "oneOf": [
+            {
+              "maxLength": 10,
+              "minLength": 3,
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "name": {
-          "description": "Id of extension resource.",
+          "description": "The resource name",
           "type": "string"
         },
         "type": {
@@ -711,7 +879,7 @@
       "type": "object"
     },
     "farmBeats_privateEndpointConnections_childResource": {
-      "description": "Microsoft.AgFoodPlatform/farmBeats/privateEndpointConnections",
+      "description": "privateEndpointConnections",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -720,7 +888,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Private endpoint connection name.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -750,7 +918,7 @@
       "type": "object"
     },
     "farmBeats_solutions_childResource": {
-      "description": "Microsoft.AgFoodPlatform/farmBeats/solutions",
+      "description": "solutions",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -759,7 +927,7 @@
           "type": "string"
         },
         "name": {
-          "description": "SolutionId for Data Manager For Agriculture Resource.",
+          "description": "The resource name",
           "oneOf": [
             {
               "pattern": "^[a-zA-Z]{3,50}[.][a-zA-Z]{3,100}$",

--- a/schemas/2023-09-01-preview/Microsoft.Advisor.json
+++ b/schemas/2023-09-01-preview/Microsoft.Advisor.json
@@ -3,9 +3,9 @@
   "title": "Microsoft.Advisor",
   "description": "Microsoft Advisor Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "resourceDefinitions": {
-    "configurations": {
-      "description": "Microsoft.Advisor/configurations",
+  "tenant_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -14,24 +14,14 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor configuration name. Value must be 'default'",
-          "oneOf": [
-            {
-              "enum": [
-                "default"
-              ],
-              "type": "string"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
-          ]
+          "description": "The resource name",
+          "type": "string"
         },
         "properties": {
-          "description": "The Advisor configuration data structure.",
+          "description": "The properties of the suppression.",
           "oneOf": [
             {
-              "$ref": "#/definitions/ConfigDataProperties"
+              "$ref": "#/definitions/SuppressionProperties"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
@@ -40,7 +30,48 @@
         },
         "type": {
           "enum": [
-            "Microsoft.Advisor/configurations"
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "managementGroup_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2023-09-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
           ],
           "type": "string"
         }
@@ -65,7 +96,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor assessment name.",
+          "description": "The resource name",
           "oneOf": [
             {
               "pattern": "^[-0-9a-zA-Z_]{1,63}$",
@@ -112,7 +143,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor configuration name. Value must be 'default'",
+          "description": "The resource name",
           "oneOf": [
             {
               "enum": [
@@ -150,9 +181,7 @@
         "type"
       ],
       "type": "object"
-    }
-  },
-  "unknown_resourceDefinitions": {
+    },
     "recommendations_suppressions": {
       "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
@@ -163,7 +192,97 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the suppression.",
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "configurations": {
+      "description": "Microsoft.Advisor/configurations",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2023-09-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "oneOf": [
+            {
+              "enum": [
+                "default"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "The Advisor configuration data structure.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ConfigDataProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/configurations"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2023-09-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -195,7 +314,6 @@
   },
   "definitions": {
     "AssessmentResultProperties": {
-      "description": "Assessment result properties.",
       "properties": {
         "locale": {
           "description": "Assessment Type Locale.",
@@ -213,7 +331,6 @@
       "type": "object"
     },
     "ConfigDataProperties": {
-      "description": "Configuration data properties",
       "properties": {
         "digests": {
           "description": "Advisor digest configuration. Valid only for subscriptions",
@@ -280,7 +397,6 @@
       "type": "object"
     },
     "DigestConfig": {
-      "description": "Advisor Digest configuration entity",
       "properties": {
         "actionGroupResourceId": {
           "description": "Action group resource id used by digest.",
@@ -345,7 +461,6 @@
       "type": "object"
     },
     "SuppressionProperties": {
-      "description": "The properties of the suppression.",
       "properties": {
         "suppressionId": {
           "description": "The GUID of the suppression.",

--- a/schemas/2024-11-18-preview/Microsoft.Advisor.json
+++ b/schemas/2024-11-18-preview/Microsoft.Advisor.json
@@ -3,9 +3,9 @@
   "title": "Microsoft.Advisor",
   "description": "Microsoft Advisor Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "resourceDefinitions": {
-    "configurations": {
-      "description": "Microsoft.Advisor/configurations",
+  "tenant_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -14,24 +14,14 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor configuration name. Value must be 'default'",
-          "oneOf": [
-            {
-              "enum": [
-                "default"
-              ],
-              "type": "string"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
-          ]
+          "description": "The resource name",
+          "type": "string"
         },
         "properties": {
-          "description": "The Advisor configuration data structure.",
+          "description": "The properties of the suppression.",
           "oneOf": [
             {
-              "$ref": "#/definitions/ConfigDataProperties"
+              "$ref": "#/definitions/SuppressionProperties"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
@@ -40,7 +30,48 @@
         },
         "type": {
           "enum": [
-            "Microsoft.Advisor/configurations"
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "managementGroup_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2024-11-18-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
           ],
           "type": "string"
         }
@@ -65,7 +96,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor assessment name.",
+          "description": "The resource name",
           "oneOf": [
             {
               "pattern": "^[-0-9a-zA-Z_]{1,63}$",
@@ -112,7 +143,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor configuration name. Value must be 'default'",
+          "description": "The resource name",
           "oneOf": [
             {
               "enum": [
@@ -150,9 +181,7 @@
         "type"
       ],
       "type": "object"
-    }
-  },
-  "unknown_resourceDefinitions": {
+    },
     "recommendations_suppressions": {
       "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
@@ -163,7 +192,97 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the suppression.",
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "configurations": {
+      "description": "Microsoft.Advisor/configurations",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2024-11-18-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "oneOf": [
+            {
+              "enum": [
+                "default"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "The Advisor configuration data structure.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ConfigDataProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/configurations"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2024-11-18-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -195,7 +314,6 @@
   },
   "definitions": {
     "AssessmentResultProperties": {
-      "description": "Assessment result properties.",
       "properties": {
         "locale": {
           "description": "Assessment Type Locale.",
@@ -213,7 +331,6 @@
       "type": "object"
     },
     "ConfigDataProperties": {
-      "description": "Configuration data properties",
       "properties": {
         "digests": {
           "description": "Advisor digest configuration. Valid only for subscriptions",
@@ -280,7 +397,6 @@
       "type": "object"
     },
     "DigestConfig": {
-      "description": "Advisor Digest configuration entity",
       "properties": {
         "actionGroupResourceId": {
           "description": "Action group resource id used by digest.",
@@ -345,7 +461,6 @@
       "type": "object"
     },
     "SuppressionProperties": {
-      "description": "The properties of the suppression.",
       "properties": {
         "suppressionId": {
           "description": "The GUID of the suppression.",

--- a/schemas/2025-01-01/Microsoft.Advisor.json
+++ b/schemas/2025-01-01/Microsoft.Advisor.json
@@ -3,9 +3,9 @@
   "title": "Microsoft.Advisor",
   "description": "Microsoft Advisor Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "resourceDefinitions": {
-    "configurations": {
-      "description": "Microsoft.Advisor/configurations",
+  "tenant_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -14,24 +14,14 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor configuration name. Value must be 'default'",
-          "oneOf": [
-            {
-              "enum": [
-                "default"
-              ],
-              "type": "string"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
-          ]
+          "description": "The resource name",
+          "type": "string"
         },
         "properties": {
-          "description": "The Advisor configuration data structure.",
+          "description": "The properties of the suppression.",
           "oneOf": [
             {
-              "$ref": "#/definitions/ConfigDataProperties"
+              "$ref": "#/definitions/SuppressionProperties"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
@@ -40,7 +30,48 @@
         },
         "type": {
           "enum": [
-            "Microsoft.Advisor/configurations"
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "managementGroup_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2025-01-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
           ],
           "type": "string"
         }
@@ -65,7 +96,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor configuration name. Value must be 'default'",
+          "description": "The resource name",
           "oneOf": [
             {
               "enum": [
@@ -103,9 +134,7 @@
         "type"
       ],
       "type": "object"
-    }
-  },
-  "unknown_resourceDefinitions": {
+    },
     "recommendations_suppressions": {
       "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
@@ -116,7 +145,97 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the suppression.",
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "configurations": {
+      "description": "Microsoft.Advisor/configurations",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2025-01-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "oneOf": [
+            {
+              "enum": [
+                "default"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "The Advisor configuration data structure.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ConfigDataProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/configurations"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2025-01-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -148,7 +267,6 @@
   },
   "definitions": {
     "ConfigDataProperties": {
-      "description": "Configuration data properties",
       "properties": {
         "digests": {
           "description": "Advisor digest configuration. Valid only for subscriptions",
@@ -215,7 +333,6 @@
       "type": "object"
     },
     "DigestConfig": {
-      "description": "Advisor Digest configuration entity",
       "properties": {
         "actionGroupResourceId": {
           "description": "Action group resource id used by digest.",
@@ -280,7 +397,6 @@
       "type": "object"
     },
     "SuppressionProperties": {
-      "description": "The properties of the suppression.",
       "properties": {
         "suppressionId": {
           "description": "The GUID of the suppression.",

--- a/schemas/2025-05-01-preview/Microsoft.Advisor.json
+++ b/schemas/2025-05-01-preview/Microsoft.Advisor.json
@@ -3,9 +3,9 @@
   "title": "Microsoft.Advisor",
   "description": "Microsoft Advisor Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "resourceDefinitions": {
-    "configurations": {
-      "description": "Microsoft.Advisor/configurations",
+  "tenant_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -14,24 +14,14 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor configuration name. Value must be 'default'",
-          "oneOf": [
-            {
-              "enum": [
-                "default"
-              ],
-              "type": "string"
-            },
-            {
-              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
-            }
-          ]
+          "description": "The resource name",
+          "type": "string"
         },
         "properties": {
-          "description": "The Advisor configuration data structure.",
+          "description": "The properties of the suppression.",
           "oneOf": [
             {
-              "$ref": "#/definitions/ConfigDataProperties"
+              "$ref": "#/definitions/SuppressionProperties"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
@@ -40,7 +30,48 @@
         },
         "type": {
           "enum": [
-            "Microsoft.Advisor/configurations"
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "managementGroup_resourceDefinitions": {
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2025-05-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
           ],
           "type": "string"
         }
@@ -65,7 +96,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor assessment name.",
+          "description": "The resource name",
           "oneOf": [
             {
               "pattern": "^[-0-9a-zA-Z_]{1,63}$",
@@ -112,7 +143,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Advisor configuration name. Value must be 'default'",
+          "description": "The resource name",
           "oneOf": [
             {
               "enum": [
@@ -150,9 +181,7 @@
         "type"
       ],
       "type": "object"
-    }
-  },
-  "unknown_resourceDefinitions": {
+    },
     "recommendations_suppressions": {
       "description": "Microsoft.Advisor/recommendations/suppressions",
       "properties": {
@@ -163,7 +192,97 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the suppression.",
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the suppression.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SuppressionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/recommendations/suppressions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "configurations": {
+      "description": "Microsoft.Advisor/configurations",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2025-05-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "oneOf": [
+            {
+              "enum": [
+                "default"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "The Advisor configuration data structure.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ConfigDataProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Advisor/configurations"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "recommendations_suppressions": {
+      "description": "Microsoft.Advisor/recommendations/suppressions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2025-05-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -195,7 +314,6 @@
   },
   "definitions": {
     "AssessmentResultProperties": {
-      "description": "Assessment result properties.",
       "properties": {
         "locale": {
           "description": "Assessment Type Locale.",
@@ -213,7 +331,6 @@
       "type": "object"
     },
     "ConfigDataProperties": {
-      "description": "Configuration data properties",
       "properties": {
         "digests": {
           "description": "Advisor digest configuration. Valid only for subscriptions",
@@ -280,7 +397,6 @@
       "type": "object"
     },
     "DigestConfig": {
-      "description": "Advisor Digest configuration entity",
       "properties": {
         "actionGroupResourceId": {
           "description": "Action group resource id used by digest.",
@@ -345,7 +461,6 @@
       "type": "object"
     },
     "SuppressionProperties": {
-      "description": "The properties of the suppression.",
       "properties": {
         "suppressionId": {
           "description": "The GUID of the suppression.",

--- a/schemas/common/autogeneratedResources.json
+++ b/schemas/common/autogeneratedResources.json
@@ -245,6 +245,39 @@
           "$ref": "https://schema.management.azure.com/schemas/2025-05-01-preview/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
         },
         {
+          "$ref": "https://schema.management.azure.com/schemas/2020-05-12-preview/Microsoft.AgFoodPlatform.json#/resourceDefinitions/farmBeats"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-05-12-preview/Microsoft.AgFoodPlatform.json#/resourceDefinitions/farmBeats_extensions"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2021-09-01-preview/Microsoft.AgFoodPlatform.json#/resourceDefinitions/farmBeats"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2021-09-01-preview/Microsoft.AgFoodPlatform.json#/resourceDefinitions/farmBeats_extensions"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2021-09-01-preview/Microsoft.AgFoodPlatform.json#/resourceDefinitions/farmBeats_privateEndpointConnections"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2021-09-01-preview/Microsoft.AgFoodPlatform.json#/resourceDefinitions/farmBeats_solutions"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2023-06-01-preview/Microsoft.AgFoodPlatform.json#/resourceDefinitions/farmBeats"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2023-06-01-preview/Microsoft.AgFoodPlatform.json#/resourceDefinitions/farmBeats_dataConnectors"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2023-06-01-preview/Microsoft.AgFoodPlatform.json#/resourceDefinitions/farmBeats_extensions"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2023-06-01-preview/Microsoft.AgFoodPlatform.json#/resourceDefinitions/farmBeats_privateEndpointConnections"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2023-06-01-preview/Microsoft.AgFoodPlatform.json#/resourceDefinitions/farmBeats_solutions"
+        },
+        {
           "$ref": "https://schema.management.azure.com/schemas/2024-06-01-preview/Microsoft.AgriculturePlatform.json#/resourceDefinitions/agriServices"
         },
         {

--- a/schemas/common/autogeneratedResources.json
+++ b/schemas/common/autogeneratedResources.json
@@ -188,61 +188,61 @@
           "$ref": "https://schema.management.azure.com/schemas/2020-07-01-preview/Microsoft.Aadiam.json#/resourceDefinitions/azureADMetrics"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2016-07-12-preview/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+          "$ref": "https://schema.management.azure.com/schemas/2016-07-12-preview/Microsoft.Advisor.json#/resourceDefinitions/recommendations_suppressions"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2017-03-31/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+          "$ref": "https://schema.management.azure.com/schemas/2017-03-31/Microsoft.Advisor.json#/resourceDefinitions/recommendations_suppressions"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2017-04-19/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+          "$ref": "https://schema.management.azure.com/schemas/2017-04-19/Microsoft.Advisor.json#/resourceDefinitions/recommendations_suppressions"
         },
         {
           "$ref": "https://schema.management.azure.com/schemas/2020-01-01/Microsoft.Advisor.json#/resourceDefinitions/configurations"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2020-01-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+          "$ref": "https://schema.management.azure.com/schemas/2020-01-01/Microsoft.Advisor.json#/resourceDefinitions/recommendations_suppressions"
         },
         {
           "$ref": "https://schema.management.azure.com/schemas/2022-09-01/Microsoft.Advisor.json#/resourceDefinitions/configurations"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2022-09-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+          "$ref": "https://schema.management.azure.com/schemas/2022-09-01/Microsoft.Advisor.json#/resourceDefinitions/recommendations_suppressions"
         },
         {
           "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.Advisor.json#/resourceDefinitions/configurations"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+          "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.Advisor.json#/resourceDefinitions/recommendations_suppressions"
         },
         {
           "$ref": "https://schema.management.azure.com/schemas/2023-01-01/Microsoft.Advisor.json#/resourceDefinitions/configurations"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2023-01-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+          "$ref": "https://schema.management.azure.com/schemas/2023-01-01/Microsoft.Advisor.json#/resourceDefinitions/recommendations_suppressions"
         },
         {
           "$ref": "https://schema.management.azure.com/schemas/2023-09-01-preview/Microsoft.Advisor.json#/resourceDefinitions/configurations"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2023-09-01-preview/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+          "$ref": "https://schema.management.azure.com/schemas/2023-09-01-preview/Microsoft.Advisor.json#/resourceDefinitions/recommendations_suppressions"
         },
         {
           "$ref": "https://schema.management.azure.com/schemas/2024-11-18-preview/Microsoft.Advisor.json#/resourceDefinitions/configurations"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2024-11-18-preview/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+          "$ref": "https://schema.management.azure.com/schemas/2024-11-18-preview/Microsoft.Advisor.json#/resourceDefinitions/recommendations_suppressions"
         },
         {
           "$ref": "https://schema.management.azure.com/schemas/2025-01-01/Microsoft.Advisor.json#/resourceDefinitions/configurations"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2025-01-01/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+          "$ref": "https://schema.management.azure.com/schemas/2025-01-01/Microsoft.Advisor.json#/resourceDefinitions/recommendations_suppressions"
         },
         {
           "$ref": "https://schema.management.azure.com/schemas/2025-05-01-preview/Microsoft.Advisor.json#/resourceDefinitions/configurations"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2025-05-01-preview/Microsoft.Advisor.json#/unknown_resourceDefinitions/recommendations_suppressions"
+          "$ref": "https://schema.management.azure.com/schemas/2025-05-01-preview/Microsoft.Advisor.json#/resourceDefinitions/recommendations_suppressions"
         },
         {
           "$ref": "https://schema.management.azure.com/schemas/2020-05-12-preview/Microsoft.AgFoodPlatform.json#/resourceDefinitions/farmBeats"


### PR DESCRIPTION
Enable `Microsoft.Advisor` for the C# schema generator pipeline.

This changes the `enabled` flag from `false` to `true` in the `csharpGeneratorProviders` array, causing schemas to be generated via `TemplateSchemaGenerator` (reading from Bicep types) instead of AutoRest.