### PR TITLE
Onboard Microsoft.Maps for C# generation

### DIFF
--- a/generator/autogenlist.ts
+++ b/generator/autogenlist.ts
@@ -135,7 +135,7 @@ const csharpGeneratorProviders: CsharpGeneratorConfig[] = [
     { namespace: 'Microsoft.ManagedServices', enabled: false },
     { namespace: 'Microsoft.Management', enabled: false },
     { namespace: 'Microsoft.ManagementPartner', enabled: false },
-    { namespace: 'Microsoft.Maps', enabled: false },
+    { namespace: 'Microsoft.Maps', enabled: true },
     { namespace: 'Microsoft.Marketplace', enabled: false },
     { namespace: 'Microsoft.Media', enabled: false },
     { namespace: 'Microsoft.Migrate', enabled: false },

--- a/schemas/2017-01-01-preview/Microsoft.Maps.json
+++ b/schemas/2017-01-01-preview/Microsoft.Maps.json
@@ -18,7 +18,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Account.",
+          "description": "The resource name",
           "type": "string"
         },
         "sku": {
@@ -55,7 +55,9 @@
         }
       },
       "required": [
+        "location",
         "name",
+        "sku",
         "apiVersion",
         "type"
       ],
@@ -63,8 +65,14 @@
     }
   },
   "definitions": {
+    "MapsAccountCreateParametersTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "Sku": {
-      "description": "The SKU of the Maps Account.",
       "properties": {
         "name": {
           "description": "The name of the SKU, in standard format (such as S0).",

--- a/schemas/2018-05-01/Microsoft.Maps.json
+++ b/schemas/2018-05-01/Microsoft.Maps.json
@@ -18,7 +18,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Account.",
+          "description": "The resource name",
           "type": "string"
         },
         "sku": {
@@ -55,7 +55,9 @@
         }
       },
       "required": [
+        "location",
         "name",
+        "sku",
         "apiVersion",
         "type"
       ],
@@ -63,8 +65,14 @@
     }
   },
   "definitions": {
+    "MapsAccountCreateParametersTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "Sku": {
-      "description": "The SKU of the Maps Account.",
       "properties": {
         "name": {
           "description": "The name of the SKU, in standard format (such as S0).",

--- a/schemas/2020-02-01-preview/Microsoft.Maps.json
+++ b/schemas/2020-02-01-preview/Microsoft.Maps.json
@@ -18,7 +18,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Account.",
+          "description": "The resource name",
           "type": "string"
         },
         "resources": {
@@ -68,7 +68,9 @@
         }
       },
       "required": [
+        "location",
         "name",
+        "sku",
         "apiVersion",
         "type"
       ],
@@ -88,7 +90,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "type": "string"
         },
         "tags": {
@@ -114,6 +116,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "apiVersion",
         "type"
@@ -134,7 +137,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Private Atlas instance.",
+          "description": "The resource name",
           "type": "string"
         },
         "tags": {
@@ -160,6 +163,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "apiVersion",
         "type"
@@ -168,8 +172,28 @@
     }
   },
   "definitions": {
+    "CreatorCreateParametersTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    },
+    "MapsAccountCreateParametersTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    },
+    "PrivateAtlasCreateParametersTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "Sku": {
-      "description": "The SKU of the Maps Account.",
       "properties": {
         "name": {
           "description": "The name of the SKU, in standard format (such as S0).",
@@ -182,7 +206,7 @@
       "type": "object"
     },
     "accounts_creators_childResource": {
-      "description": "Microsoft.Maps/accounts/creators",
+      "description": "creators",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -195,7 +219,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "type": "string"
         },
         "tags": {
@@ -221,6 +245,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "apiVersion",
         "type"
@@ -228,7 +253,7 @@
       "type": "object"
     },
     "accounts_privateAtlases_childResource": {
-      "description": "Microsoft.Maps/accounts/privateAtlases",
+      "description": "privateAtlases",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -241,7 +266,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Private Atlas instance.",
+          "description": "The resource name",
           "type": "string"
         },
         "tags": {
@@ -267,6 +292,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "apiVersion",
         "type"

--- a/schemas/2021-02-01/Microsoft.Maps.json
+++ b/schemas/2021-02-01/Microsoft.Maps.json
@@ -33,7 +33,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Account.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -91,7 +91,9 @@
         }
       },
       "required": [
+        "location",
         "name",
+        "sku",
         "properties",
         "apiVersion",
         "type"
@@ -112,7 +114,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -149,6 +151,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",
@@ -159,7 +162,6 @@
   },
   "definitions": {
     "CreatorProperties": {
-      "description": "Creator resource properties",
       "properties": {
         "storageUnits": {
           "description": "The storage units to be allocated. Integer values from 1 to 100, inclusive.",
@@ -181,13 +183,11 @@
       "type": "object"
     },
     "MapsAccountProperties": {
-      "description": "Additional Map account properties",
       "properties": {
         "disableLocalAuth": {
           "description": "Allows toggle functionality on Azure Policy to disable Azure Maps local authentication support. This will disable Shared Keys authentication from any usage.",
           "oneOf": [
             {
-              "default": false,
               "type": "boolean"
             },
             {
@@ -199,7 +199,6 @@
       "type": "object"
     },
     "Sku": {
-      "description": "The SKU of the Maps Account.",
       "properties": {
         "name": {
           "description": "The name of the SKU, in standard format (such as S0).",
@@ -223,8 +222,15 @@
       ],
       "type": "object"
     },
+    "TrackedResourceTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "accounts_creators_childResource": {
-      "description": "Microsoft.Maps/accounts/creators",
+      "description": "creators",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -237,7 +243,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -274,6 +280,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",

--- a/schemas/2021-07-01-preview/Microsoft.Maps.json
+++ b/schemas/2021-07-01-preview/Microsoft.Maps.json
@@ -44,7 +44,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Account.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -102,7 +102,9 @@
         }
       },
       "required": [
+        "location",
         "name",
+        "sku",
         "properties",
         "apiVersion",
         "type"
@@ -123,7 +125,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -160,6 +162,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",
@@ -174,7 +177,6 @@
       "type": "object"
     },
     "CreatorProperties": {
-      "description": "Creator resource properties",
       "properties": {
         "storageUnits": {
           "description": "The storage units to be allocated. Integer values from 1 to 100, inclusive.",
@@ -196,7 +198,6 @@
       "type": "object"
     },
     "LinkedResource": {
-      "description": "Linked resource is reference to a resource deployed in an Azure subscription, add the linked resource `uniqueName` value as an optional parameter for operations on Azure Maps Geospatial REST APIs.",
       "properties": {
         "id": {
           "description": "ARM resource id in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/accounts/{storageName}'.",
@@ -208,13 +209,12 @@
         }
       },
       "required": [
-        "uniqueName",
-        "id"
+        "id",
+        "uniqueName"
       ],
       "type": "object"
     },
     "ManagedServiceIdentity": {
-      "description": "Identity for the resource.",
       "properties": {
         "type": {
           "description": "The identity type.",
@@ -251,14 +251,19 @@
       },
       "type": "object"
     },
+    "ManagedServiceIdentityUserAssignedIdentities": {
+      "additionalProperties": {
+        "$ref": "#/definitions/Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentitiesAdditionalproperties"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "MapsAccountProperties": {
-      "description": "Additional Map account properties",
       "properties": {
         "disableLocalAuth": {
           "description": "Allows toggle functionality on Azure Policy to disable Azure Maps local authentication support. This will disable Shared Keys authentication from any usage.",
           "oneOf": [
             {
-              "default": false,
               "type": "boolean"
             },
             {
@@ -284,7 +289,6 @@
       "type": "object"
     },
     "Sku": {
-      "description": "The SKU of the Maps Account.",
       "properties": {
         "name": {
           "description": "The name of the SKU, in standard format (such as S0).",
@@ -308,8 +312,15 @@
       ],
       "type": "object"
     },
+    "TrackedResourceTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "accounts_creators_childResource": {
-      "description": "Microsoft.Maps/accounts/creators",
+      "description": "creators",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -322,7 +333,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -359,6 +370,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",

--- a/schemas/2021-12-01-preview/Microsoft.Maps.json
+++ b/schemas/2021-12-01-preview/Microsoft.Maps.json
@@ -44,7 +44,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Account.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -102,7 +102,9 @@
         }
       },
       "required": [
+        "location",
         "name",
+        "sku",
         "properties",
         "apiVersion",
         "type"
@@ -123,7 +125,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -160,6 +162,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",
@@ -174,7 +177,6 @@
       "type": "object"
     },
     "CorsRule": {
-      "description": "Specifies a CORS rule for the Map Account.",
       "properties": {
         "allowedOrigins": {
           "description": "Required if CorsRule element is present. A list of origin domains that will be allowed via CORS, or \"*\" to allow all domains",
@@ -197,10 +199,9 @@
       "type": "object"
     },
     "CorsRules": {
-      "description": "Sets the CORS rules. You can include up to five CorsRule elements in the request. ",
       "properties": {
         "corsRules": {
-          "description": "The list of CORS rules. You can include up to five CorsRule elements in the request. ",
+          "description": "The list of CORS rules. You can include up to five CorsRule elements in the request.",
           "oneOf": [
             {
               "items": {
@@ -217,7 +218,6 @@
       "type": "object"
     },
     "CreatorProperties": {
-      "description": "Creator resource properties",
       "properties": {
         "storageUnits": {
           "description": "The storage units to be allocated. Integer values from 1 to 100, inclusive.",
@@ -239,7 +239,6 @@
       "type": "object"
     },
     "LinkedResource": {
-      "description": "Linked resource is reference to a resource deployed in an Azure subscription, add the linked resource `uniqueName` value as an optional parameter for operations on Azure Maps Geospatial REST APIs.",
       "properties": {
         "id": {
           "description": "ARM resource id in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/accounts/{storageName}'.",
@@ -251,13 +250,12 @@
         }
       },
       "required": [
-        "uniqueName",
-        "id"
+        "id",
+        "uniqueName"
       ],
       "type": "object"
     },
     "ManagedServiceIdentity": {
-      "description": "Identity for the resource.",
       "properties": {
         "type": {
           "description": "The identity type.",
@@ -294,8 +292,14 @@
       },
       "type": "object"
     },
+    "ManagedServiceIdentityUserAssignedIdentities": {
+      "additionalProperties": {
+        "$ref": "#/definitions/Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentitiesAdditionalproperties"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "MapsAccountProperties": {
-      "description": "Additional Map account properties",
       "properties": {
         "cors": {
           "description": "Specifies CORS rules for the Blob service. You can include up to five CorsRule elements in the request. If no CorsRule elements are included in the request body, all CORS rules will be deleted, and CORS will be disabled for the Blob service.",
@@ -312,7 +316,6 @@
           "description": "Allows toggle functionality on Azure Policy to disable Azure Maps local authentication support. This will disable Shared Keys authentication from any usage.",
           "oneOf": [
             {
-              "default": false,
               "type": "boolean"
             },
             {
@@ -338,7 +341,6 @@
       "type": "object"
     },
     "Sku": {
-      "description": "The SKU of the Maps Account.",
       "properties": {
         "name": {
           "description": "The name of the SKU, in standard format (such as S0).",
@@ -362,8 +364,15 @@
       ],
       "type": "object"
     },
+    "TrackedResourceTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "accounts_creators_childResource": {
-      "description": "Microsoft.Maps/accounts/creators",
+      "description": "creators",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -376,7 +385,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -413,6 +422,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",

--- a/schemas/2023-06-01/Microsoft.Maps.json
+++ b/schemas/2023-06-01/Microsoft.Maps.json
@@ -44,7 +44,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Account.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -102,7 +102,9 @@
         }
       },
       "required": [
+        "location",
         "name",
+        "sku",
         "properties",
         "apiVersion",
         "type"
@@ -123,7 +125,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -160,6 +162,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",
@@ -170,7 +173,6 @@
   },
   "definitions": {
     "CorsRule": {
-      "description": "Specifies a CORS rule for the Map Account.",
       "properties": {
         "allowedOrigins": {
           "description": "Required if CorsRule element is present. A list of origin domains that will be allowed via CORS, or \"*\" to allow all domains",
@@ -193,10 +195,9 @@
       "type": "object"
     },
     "CorsRules": {
-      "description": "Sets the CORS rules. You can include up to five CorsRule elements in the request. ",
       "properties": {
         "corsRules": {
-          "description": "The list of CORS rules. You can include up to five CorsRule elements in the request. ",
+          "description": "The list of CORS rules. You can include up to five CorsRule elements in the request.",
           "oneOf": [
             {
               "items": {
@@ -213,7 +214,6 @@
       "type": "object"
     },
     "CreatorProperties": {
-      "description": "Creator resource properties",
       "properties": {
         "storageUnits": {
           "description": "The storage units to be allocated. Integer values from 1 to 100, inclusive.",
@@ -235,7 +235,6 @@
       "type": "object"
     },
     "CustomerManagedKeyEncryption": {
-      "description": "All Customer-managed key encryption properties for the resource.",
       "properties": {
         "keyEncryptionKeyIdentity": {
           "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault.",
@@ -256,13 +255,14 @@
       "type": "object"
     },
     "CustomerManagedKeyEncryptionKeyIdentity": {
-      "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault.",
       "properties": {
         "delegatedIdentityClientId": {
           "description": "delegated identity to use for accessing key encryption key Url. Ex: /subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/<resource group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myId. Mutually exclusive with identityType systemAssignedIdentity and userAssignedIdentity - internal use only.",
           "oneOf": [
             {
-              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+              "maxLength": 36,
+              "minLength": 36,
+              "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
               "type": "string"
             },
             {
@@ -294,7 +294,6 @@
       "type": "object"
     },
     "Encryption": {
-      "description": "(Optional) Discouraged to include in resource definition. Only needed where it is possible to disable platform (AKA infrastructure) encryption. Azure SQL TDE is an example of this. Values are enabled and disabled.",
       "properties": {
         "customerManagedKeyEncryption": {
           "description": "All Customer-managed key encryption properties for the resource.",
@@ -326,7 +325,6 @@
       "type": "object"
     },
     "LinkedResource": {
-      "description": "Linked resource is reference to a resource deployed in an Azure subscription, add the linked resource `uniqueName` value as an optional parameter for operations on Azure Maps Geospatial REST APIs.",
       "properties": {
         "id": {
           "description": "ARM resource id in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/accounts/{storageName}'.",
@@ -338,13 +336,12 @@
         }
       },
       "required": [
-        "uniqueName",
-        "id"
+        "id",
+        "uniqueName"
       ],
       "type": "object"
     },
     "ManagedServiceIdentity": {
-      "description": "Managed service identity (system assigned and/or user assigned identities)",
       "properties": {
         "type": {
           "description": "Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).",
@@ -385,7 +382,6 @@
       "type": "object"
     },
     "MapsAccountProperties": {
-      "description": "Additional Map account properties",
       "properties": {
         "cors": {
           "description": "Specifies CORS rules for the Blob service. You can include up to five CorsRule elements in the request. If no CorsRule elements are included in the request body, all CORS rules will be deleted, and CORS will be disabled for the Blob service.",
@@ -402,7 +398,6 @@
           "description": "Allows toggle functionality on Azure Policy to disable Azure Maps local authentication support. This will disable Shared Keys and Shared Access Signature Token authentication from any usage.",
           "oneOf": [
             {
-              "default": false,
               "type": "boolean"
             },
             {
@@ -439,7 +434,6 @@
       "type": "object"
     },
     "Sku": {
-      "description": "The SKU of the Maps Account.",
       "properties": {
         "name": {
           "description": "The name of the SKU, in standard format (such as S0).",
@@ -463,13 +457,26 @@
       ],
       "type": "object"
     },
+    "TrackedResourceTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    },
+    "UserAssignedIdentities": {
+      "additionalProperties": {
+        "$ref": "#/definitions/UserAssignedIdentity"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "UserAssignedIdentity": {
-      "description": "User assigned identity properties",
       "properties": {},
       "type": "object"
     },
     "accounts_creators_childResource": {
-      "description": "Microsoft.Maps/accounts/creators",
+      "description": "creators",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -482,7 +489,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -519,6 +526,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",

--- a/schemas/2023-08-01-preview/Microsoft.Maps.json
+++ b/schemas/2023-08-01-preview/Microsoft.Maps.json
@@ -44,7 +44,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Account.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -102,7 +102,9 @@
         }
       },
       "required": [
+        "location",
         "name",
+        "sku",
         "properties",
         "apiVersion",
         "type"
@@ -123,7 +125,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -160,6 +162,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",
@@ -170,7 +173,6 @@
   },
   "definitions": {
     "CorsRule": {
-      "description": "Specifies a CORS rule for the Map Account.",
       "properties": {
         "allowedOrigins": {
           "description": "Required if CorsRule element is present. A list of origin domains that will be allowed via CORS, or \"*\" to allow all domains",
@@ -193,10 +195,9 @@
       "type": "object"
     },
     "CorsRules": {
-      "description": "Sets the CORS rules. You can include up to five CorsRule elements in the request. ",
       "properties": {
         "corsRules": {
-          "description": "The list of CORS rules. You can include up to five CorsRule elements in the request. ",
+          "description": "The list of CORS rules. You can include up to five CorsRule elements in the request.",
           "oneOf": [
             {
               "items": {
@@ -213,7 +214,6 @@
       "type": "object"
     },
     "CreatorProperties": {
-      "description": "Creator resource properties",
       "properties": {
         "consumedStorageUnitSizeInBytes": {
           "description": "The consumed storage unit size in bytes for the creator resource.",
@@ -257,7 +257,6 @@
       "type": "object"
     },
     "CustomerManagedKeyEncryption": {
-      "description": "All Customer-managed key encryption properties for the resource.",
       "properties": {
         "keyEncryptionKeyIdentity": {
           "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault.",
@@ -278,13 +277,14 @@
       "type": "object"
     },
     "CustomerManagedKeyEncryptionKeyIdentity": {
-      "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault.",
       "properties": {
         "delegatedIdentityClientId": {
           "description": "delegated identity to use for accessing key encryption key Url. Ex: /subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/<resource group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myId. Mutually exclusive with identityType systemAssignedIdentity and userAssignedIdentity - internal use only.",
           "oneOf": [
             {
-              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+              "maxLength": 36,
+              "minLength": 36,
+              "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
               "type": "string"
             },
             {
@@ -316,7 +316,6 @@
       "type": "object"
     },
     "Encryption": {
-      "description": "(Optional) Discouraged to include in resource definition. Only needed where it is possible to disable platform (AKA infrastructure) encryption. Azure SQL TDE is an example of this. Values are enabled and disabled.",
       "properties": {
         "customerManagedKeyEncryption": {
           "description": "All Customer-managed key encryption properties for the resource.",
@@ -348,7 +347,6 @@
       "type": "object"
     },
     "LinkedResource": {
-      "description": "Linked resource is reference to a resource deployed in an Azure subscription, add the linked resource `uniqueName` value as an optional parameter for operations on Azure Maps Geospatial REST APIs.",
       "properties": {
         "id": {
           "description": "ARM resource id in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/accounts/{storageName}'.",
@@ -360,13 +358,12 @@
         }
       },
       "required": [
-        "uniqueName",
-        "id"
+        "id",
+        "uniqueName"
       ],
       "type": "object"
     },
     "ManagedServiceIdentity": {
-      "description": "Managed service identity (system assigned and/or user assigned identities)",
       "properties": {
         "type": {
           "description": "Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).",
@@ -407,7 +404,6 @@
       "type": "object"
     },
     "MapsAccountProperties": {
-      "description": "Additional Map account properties",
       "properties": {
         "cors": {
           "description": "Specifies CORS rules for the Blob service. You can include up to five CorsRule elements in the request. If no CorsRule elements are included in the request body, all CORS rules will be deleted, and CORS will be disabled for the Blob service.",
@@ -424,7 +420,6 @@
           "description": "Allows toggle functionality on Azure Policy to disable Azure Maps local authentication support. This will disable Shared Keys and Shared Access Signature Token authentication from any usage.",
           "oneOf": [
             {
-              "default": false,
               "type": "boolean"
             },
             {
@@ -461,7 +456,6 @@
       "type": "object"
     },
     "Sku": {
-      "description": "The SKU of the Maps Account.",
       "properties": {
         "name": {
           "description": "The name of the SKU, in standard format (such as S0).",
@@ -485,13 +479,26 @@
       ],
       "type": "object"
     },
+    "TrackedResourceTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    },
+    "UserAssignedIdentities": {
+      "additionalProperties": {
+        "$ref": "#/definitions/UserAssignedIdentity"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "UserAssignedIdentity": {
-      "description": "User assigned identity properties",
       "properties": {},
       "type": "object"
     },
     "accounts_creators_childResource": {
-      "description": "Microsoft.Maps/accounts/creators",
+      "description": "creators",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -504,7 +511,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -541,6 +548,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",

--- a/schemas/2023-12-01-preview/Microsoft.Maps.json
+++ b/schemas/2023-12-01-preview/Microsoft.Maps.json
@@ -43,7 +43,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Account.",
+          "description": "The resource name",
           "oneOf": [
             {
               "maxLength": 98,
@@ -114,7 +114,9 @@
         }
       },
       "required": [
+        "location",
         "name",
+        "sku",
         "properties",
         "apiVersion",
         "type"
@@ -135,7 +137,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "oneOf": [
             {
               "maxLength": 98,
@@ -182,6 +184,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",
@@ -199,7 +202,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Private Endpoint Connection.",
+          "description": "The resource name",
           "oneOf": [
             {
               "maxLength": 98,
@@ -241,7 +244,6 @@
   },
   "definitions": {
     "CorsRule": {
-      "description": "Specifies a CORS rule for the Maps Account.",
       "properties": {
         "allowedOrigins": {
           "description": "Required if CorsRule element is present. A list of origin domains that will be allowed via CORS, or \"*\" to allow all domains",
@@ -264,10 +266,9 @@
       "type": "object"
     },
     "CorsRules": {
-      "description": "Sets the CORS rules. You can include up to five CorsRule elements in the request. ",
       "properties": {
         "corsRules": {
-          "description": "The list of CORS rules. You can include up to five CorsRule elements in the request. ",
+          "description": "The list of CORS rules. You can include up to five CorsRule elements in the request.",
           "oneOf": [
             {
               "items": {
@@ -284,7 +285,6 @@
       "type": "object"
     },
     "CreatorProperties": {
-      "description": "Creator resource properties",
       "properties": {
         "consumedStorageUnitSizeInBytes": {
           "description": "The consumed storage unit size in bytes for the creator resource.",
@@ -328,7 +328,6 @@
       "type": "object"
     },
     "Encryption": {
-      "description": "All encryption configuration for a resource.",
       "properties": {
         "customerManagedKeyEncryption": {
           "description": "All Customer-managed key encryption properties for the resource.",
@@ -360,7 +359,6 @@
       "type": "object"
     },
     "EncryptionCustomerManagedKeyEncryption": {
-      "description": "All Customer-managed key encryption properties for the resource.",
       "properties": {
         "keyEncryptionKeyIdentity": {
           "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault.",
@@ -381,13 +379,14 @@
       "type": "object"
     },
     "EncryptionCustomerManagedKeyEncryptionKeyIdentity": {
-      "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault.",
       "properties": {
         "delegatedIdentityClientId": {
           "description": "delegated identity to use for accessing key encryption key Url. Ex: /subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/<resource group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myId. Mutually exclusive with identityType systemAssignedIdentity and userAssignedIdentity - internal use only.",
           "oneOf": [
             {
-              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+              "maxLength": 36,
+              "minLength": 36,
+              "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
               "type": "string"
             },
             {
@@ -399,7 +398,9 @@
           "description": "application client identity to use for accessing key encryption key Url in a different tenant. Ex: f83c6b1b-4d34-47e4-bb34-9d83df58b540",
           "oneOf": [
             {
-              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+              "maxLength": 36,
+              "minLength": 36,
+              "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
               "type": "string"
             },
             {
@@ -431,7 +432,6 @@
       "type": "object"
     },
     "LinkedResource": {
-      "description": "Linked resource is reference to a resource deployed in an Azure subscription, add the linked resource `uniqueName` value as an optional parameter for operations on Azure Maps Geospatial REST APIs.",
       "properties": {
         "id": {
           "description": "ARM resource id in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/accounts/{storageName}'.",
@@ -443,13 +443,12 @@
         }
       },
       "required": [
-        "uniqueName",
-        "id"
+        "id",
+        "uniqueName"
       ],
       "type": "object"
     },
     "ManagedServiceIdentity": {
-      "description": "Managed service identity (system assigned and/or user assigned identities)",
       "properties": {
         "type": {
           "description": "Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).",
@@ -490,7 +489,6 @@
       "type": "object"
     },
     "MapsAccountProperties": {
-      "description": "Additional Maps account properties",
       "properties": {
         "cors": {
           "description": "Specifies CORS rules for the Blob service. You can include up to five CorsRule elements in the request. If no CorsRule elements are included in the request body, all CORS rules will be deleted, and CORS will be disabled for the Blob service.",
@@ -507,7 +505,6 @@
           "description": "Allows toggle functionality on Azure Policy to disable Azure Maps local authentication support. This will disable Shared Keys and Shared Access Signature Token authentication from any usage.",
           "oneOf": [
             {
-              "default": false,
               "type": "boolean"
             },
             {
@@ -559,12 +556,10 @@
       "type": "object"
     },
     "PrivateEndpoint": {
-      "description": "The private endpoint resource.",
       "properties": {},
       "type": "object"
     },
     "PrivateEndpointConnectionProperties": {
-      "description": "Properties of the private endpoint connection.",
       "properties": {
         "privateEndpoint": {
           "description": "The private endpoint resource.",
@@ -595,7 +590,6 @@
       "type": "object"
     },
     "PrivateLinkServiceConnectionState": {
-      "description": "A collection of information about the state of the connection between service consumer and provider.",
       "properties": {
         "actionsRequired": {
           "description": "A message indicating if changes on the service provider require any updates on the consumer.",
@@ -625,7 +619,6 @@
       "type": "object"
     },
     "Sku": {
-      "description": "The SKU of the Maps Account.",
       "properties": {
         "name": {
           "description": "The name of the SKU, in standard format (such as G2).",
@@ -647,13 +640,26 @@
       ],
       "type": "object"
     },
+    "TrackedResourceTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    },
+    "UserAssignedIdentities": {
+      "additionalProperties": {
+        "$ref": "#/definitions/UserAssignedIdentity"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "UserAssignedIdentity": {
-      "description": "User assigned identity properties",
       "properties": {},
       "type": "object"
     },
     "accounts_creators_childResource": {
-      "description": "Microsoft.Maps/accounts/creators",
+      "description": "creators",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -666,7 +672,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "oneOf": [
             {
               "maxLength": 98,
@@ -713,6 +719,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",
@@ -721,7 +728,7 @@
       "type": "object"
     },
     "accounts_privateEndpointConnections_childResource": {
-      "description": "Microsoft.Maps/accounts/privateEndpointConnections",
+      "description": "privateEndpointConnections",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -730,7 +737,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Private Endpoint Connection.",
+          "description": "The resource name",
           "oneOf": [
             {
               "maxLength": 98,

--- a/schemas/2024-01-01-preview/Microsoft.Maps.json
+++ b/schemas/2024-01-01-preview/Microsoft.Maps.json
@@ -43,7 +43,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Account.",
+          "description": "The resource name",
           "oneOf": [
             {
               "maxLength": 98,
@@ -114,7 +114,9 @@
         }
       },
       "required": [
+        "location",
         "name",
+        "sku",
         "properties",
         "apiVersion",
         "type"
@@ -135,7 +137,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "oneOf": [
             {
               "maxLength": 98,
@@ -182,6 +184,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",
@@ -199,7 +202,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Private Endpoint Connection.",
+          "description": "The resource name",
           "oneOf": [
             {
               "maxLength": 98,
@@ -241,7 +244,6 @@
   },
   "definitions": {
     "CorsRule": {
-      "description": "Specifies a CORS rule for the Maps Account.",
       "properties": {
         "allowedOrigins": {
           "description": "Required if CorsRule element is present. A list of origin domains that will be allowed via CORS, or \"*\" to allow all domains",
@@ -264,10 +266,9 @@
       "type": "object"
     },
     "CorsRules": {
-      "description": "Sets the CORS rules. You can include up to five CorsRule elements in the request. ",
       "properties": {
         "corsRules": {
-          "description": "The list of CORS rules. You can include up to five CorsRule elements in the request. ",
+          "description": "The list of CORS rules. You can include up to five CorsRule elements in the request.",
           "oneOf": [
             {
               "items": {
@@ -284,7 +285,6 @@
       "type": "object"
     },
     "CreatorProperties": {
-      "description": "Creator resource properties",
       "properties": {
         "consumedStorageUnitSizeInBytes": {
           "description": "The consumed storage unit size in bytes for the creator resource.",
@@ -328,7 +328,6 @@
       "type": "object"
     },
     "Encryption": {
-      "description": "All encryption configuration for a resource.",
       "properties": {
         "customerManagedKeyEncryption": {
           "description": "All Customer-managed key encryption properties for the resource.",
@@ -360,7 +359,6 @@
       "type": "object"
     },
     "EncryptionCustomerManagedKeyEncryption": {
-      "description": "All Customer-managed key encryption properties for the resource.",
       "properties": {
         "keyEncryptionKeyIdentity": {
           "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault.",
@@ -381,13 +379,14 @@
       "type": "object"
     },
     "EncryptionCustomerManagedKeyEncryptionKeyIdentity": {
-      "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault.",
       "properties": {
         "delegatedIdentityClientId": {
           "description": "delegated identity to use for accessing key encryption key Url. Ex: /subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/<resource group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myId. Mutually exclusive with identityType systemAssignedIdentity and userAssignedIdentity - internal use only.",
           "oneOf": [
             {
-              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+              "maxLength": 36,
+              "minLength": 36,
+              "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
               "type": "string"
             },
             {
@@ -399,7 +398,9 @@
           "description": "application client identity to use for accessing key encryption key Url in a different tenant. Ex: f83c6b1b-4d34-47e4-bb34-9d83df58b540",
           "oneOf": [
             {
-              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+              "maxLength": 36,
+              "minLength": 36,
+              "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
               "type": "string"
             },
             {
@@ -431,7 +432,6 @@
       "type": "object"
     },
     "LinkedResource": {
-      "description": "Linked resource is reference to a resource deployed in an Azure subscription, add the linked resource `uniqueName` value as an optional parameter for operations on Azure Maps Geospatial REST APIs.",
       "properties": {
         "id": {
           "description": "ARM resource id in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/accounts/{storageName}'.",
@@ -443,13 +443,12 @@
         }
       },
       "required": [
-        "uniqueName",
-        "id"
+        "id",
+        "uniqueName"
       ],
       "type": "object"
     },
     "LocationsItem": {
-      "description": "Data processing location.",
       "properties": {
         "locationName": {
           "description": "The location name.",
@@ -462,7 +461,6 @@
       "type": "object"
     },
     "ManagedServiceIdentity": {
-      "description": "Managed service identity (system assigned and/or user assigned identities)",
       "properties": {
         "type": {
           "description": "Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).",
@@ -503,7 +501,6 @@
       "type": "object"
     },
     "MapsAccountProperties": {
-      "description": "Additional Maps account properties",
       "properties": {
         "cors": {
           "description": "Specifies CORS rules for the Blob service. You can include up to five CorsRule elements in the request. If no CorsRule elements are included in the request body, all CORS rules will be deleted, and CORS will be disabled for the Blob service.",
@@ -520,7 +517,6 @@
           "description": "Allows toggle functionality on Azure Policy to disable Azure Maps local authentication support. This will disable Shared Keys and Shared Access Signature Token authentication from any usage.",
           "oneOf": [
             {
-              "default": false,
               "type": "boolean"
             },
             {
@@ -586,12 +582,10 @@
       "type": "object"
     },
     "PrivateEndpoint": {
-      "description": "The private endpoint resource.",
       "properties": {},
       "type": "object"
     },
     "PrivateEndpointConnectionProperties": {
-      "description": "Properties of the private endpoint connection.",
       "properties": {
         "privateEndpoint": {
           "description": "The private endpoint resource.",
@@ -622,7 +616,6 @@
       "type": "object"
     },
     "PrivateLinkServiceConnectionState": {
-      "description": "A collection of information about the state of the connection between service consumer and provider.",
       "properties": {
         "actionsRequired": {
           "description": "A message indicating if changes on the service provider require any updates on the consumer.",
@@ -652,7 +645,6 @@
       "type": "object"
     },
     "Sku": {
-      "description": "The SKU of the Maps Account.",
       "properties": {
         "name": {
           "description": "The name of the SKU, in standard format (such as G2).",
@@ -674,13 +666,26 @@
       ],
       "type": "object"
     },
+    "TrackedResourceTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    },
+    "UserAssignedIdentities": {
+      "additionalProperties": {
+        "$ref": "#/definitions/UserAssignedIdentity"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "UserAssignedIdentity": {
-      "description": "User assigned identity properties",
       "properties": {},
       "type": "object"
     },
     "accounts_creators_childResource": {
-      "description": "Microsoft.Maps/accounts/creators",
+      "description": "creators",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -693,7 +698,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "oneOf": [
             {
               "maxLength": 98,
@@ -740,6 +745,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",
@@ -748,7 +754,7 @@
       "type": "object"
     },
     "accounts_privateEndpointConnections_childResource": {
-      "description": "Microsoft.Maps/accounts/privateEndpointConnections",
+      "description": "privateEndpointConnections",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -757,7 +763,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Private Endpoint Connection.",
+          "description": "The resource name",
           "oneOf": [
             {
               "maxLength": 98,

--- a/schemas/2024-07-01-preview/Microsoft.Maps.json
+++ b/schemas/2024-07-01-preview/Microsoft.Maps.json
@@ -43,7 +43,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Account.",
+          "description": "The resource name",
           "oneOf": [
             {
               "minLength": 1,
@@ -110,7 +110,9 @@
         }
       },
       "required": [
+        "location",
         "name",
+        "sku",
         "properties",
         "apiVersion",
         "type"
@@ -131,7 +133,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "oneOf": [
             {
               "minLength": 1,
@@ -177,6 +179,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",
@@ -187,7 +190,6 @@
   },
   "definitions": {
     "CorsRule": {
-      "description": "Specifies a CORS rule for the Map Account.",
       "properties": {
         "allowedOrigins": {
           "description": "Required if CorsRule element is present. A list of origin domains that will be allowed via CORS, or \"*\" to allow all domains",
@@ -210,10 +212,9 @@
       "type": "object"
     },
     "CorsRules": {
-      "description": "Sets the CORS rules. You can include up to five CorsRule elements in the request. ",
       "properties": {
         "corsRules": {
-          "description": "The list of CORS rules. You can include up to five CorsRule elements in the request. ",
+          "description": "The list of CORS rules. You can include up to five CorsRule elements in the request.",
           "oneOf": [
             {
               "items": {
@@ -230,7 +231,6 @@
       "type": "object"
     },
     "CreatorProperties": {
-      "description": "Creator resource properties",
       "properties": {
         "consumedStorageUnitSizeInBytes": {
           "description": "The consumed storage unit size in bytes for the creator resource.",
@@ -274,7 +274,6 @@
       "type": "object"
     },
     "Encryption": {
-      "description": "All encryption configuration for a resource.",
       "properties": {
         "customerManagedKeyEncryption": {
           "description": "All Customer-managed key encryption properties for the resource.",
@@ -306,7 +305,6 @@
       "type": "object"
     },
     "EncryptionCustomerManagedKeyEncryption": {
-      "description": "All Customer-managed key encryption properties for the resource.",
       "properties": {
         "keyEncryptionKeyIdentity": {
           "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault.",
@@ -327,13 +325,14 @@
       "type": "object"
     },
     "EncryptionCustomerManagedKeyEncryptionKeyIdentity": {
-      "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault.",
       "properties": {
         "delegatedIdentityClientId": {
           "description": "delegated identity to use for accessing key encryption key Url. Ex: /subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/<resource group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myId. Mutually exclusive with identityType systemAssignedIdentity and userAssignedIdentity - internal use only.",
           "oneOf": [
             {
-              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+              "maxLength": 36,
+              "minLength": 36,
+              "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
               "type": "string"
             },
             {
@@ -345,7 +344,9 @@
           "description": "application client identity to use for accessing key encryption key Url in a different tenant. Ex: f83c6b1b-4d34-47e4-bb34-9d83df58b540",
           "oneOf": [
             {
-              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+              "maxLength": 36,
+              "minLength": 36,
+              "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
               "type": "string"
             },
             {
@@ -377,7 +378,6 @@
       "type": "object"
     },
     "LinkedResource": {
-      "description": "Linked resource is reference to a resource deployed in an Azure subscription, add the linked resource `uniqueName` value as an optional parameter for operations on Azure Maps Geospatial REST APIs.",
       "properties": {
         "id": {
           "description": "ARM resource id in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/accounts/{storageName}'.",
@@ -389,13 +389,12 @@
         }
       },
       "required": [
-        "uniqueName",
-        "id"
+        "id",
+        "uniqueName"
       ],
       "type": "object"
     },
     "LocationsItem": {
-      "description": "Data processing location.",
       "properties": {
         "locationName": {
           "description": "The location name.",
@@ -408,7 +407,6 @@
       "type": "object"
     },
     "ManagedServiceIdentity": {
-      "description": "Managed service identity (system assigned and/or user assigned identities)",
       "properties": {
         "type": {
           "description": "Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).",
@@ -449,7 +447,6 @@
       "type": "object"
     },
     "MapsAccountProperties": {
-      "description": "Additional Maps account properties",
       "properties": {
         "cors": {
           "description": "Specifies CORS rules for the Blob service. You can include up to five CorsRule elements in the request. If no CorsRule elements are included in the request body, all CORS rules will be deleted, and CORS will be disabled for the Blob service.",
@@ -466,7 +463,6 @@
           "description": "Allows toggle functionality on Azure Policy to disable Azure Maps local authentication support. This will disable Shared Keys and Shared Access Signature Token authentication from any usage.",
           "oneOf": [
             {
-              "default": false,
               "type": "boolean"
             },
             {
@@ -517,7 +513,6 @@
       "type": "object"
     },
     "Sku": {
-      "description": "The SKU of the Maps Account.",
       "properties": {
         "name": {
           "description": "The name of the SKU, in standard format (such as G2).",
@@ -539,13 +534,26 @@
       ],
       "type": "object"
     },
+    "TrackedResourceTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    },
+    "UserAssignedIdentities": {
+      "additionalProperties": {
+        "$ref": "#/definitions/UserAssignedIdentity"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "UserAssignedIdentity": {
-      "description": "User assigned identity properties",
       "properties": {},
       "type": "object"
     },
     "accounts_creators_childResource": {
-      "description": "Microsoft.Maps/accounts/creators",
+      "description": "creators",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -558,7 +566,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "oneOf": [
             {
               "minLength": 1,
@@ -604,6 +612,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",

--- a/schemas/2025-10-01-preview/Microsoft.Maps.json
+++ b/schemas/2025-10-01-preview/Microsoft.Maps.json
@@ -43,7 +43,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Account.",
+          "description": "The resource name",
           "oneOf": [
             {
               "minLength": 1,
@@ -113,7 +113,9 @@
         }
       },
       "required": [
+        "location",
         "name",
+        "sku",
         "properties",
         "apiVersion",
         "type"
@@ -134,7 +136,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "oneOf": [
             {
               "minLength": 1,
@@ -180,6 +182,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",
@@ -197,7 +200,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the private endpoint connection associated with the Azure resource.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -229,7 +232,6 @@
   },
   "definitions": {
     "CorsRule": {
-      "description": "Specifies a CORS rule for the Map Account.",
       "properties": {
         "allowedOrigins": {
           "description": "Required if CorsRule element is present. A list of origin domains that will be allowed via CORS, or \"*\" to allow all domains",
@@ -252,7 +254,6 @@
       "type": "object"
     },
     "CorsRules": {
-      "description": "Sets the CORS rules. You can include up to five CorsRule elements in the request.",
       "properties": {
         "corsRules": {
           "description": "The list of CORS rules. You can include up to five CorsRule elements in the request.",
@@ -272,7 +273,6 @@
       "type": "object"
     },
     "CreatorProperties": {
-      "description": "Creator resource properties",
       "properties": {
         "consumedStorageUnitSizeInBytes": {
           "description": "The consumed storage unit size in bytes for the creator resource.",
@@ -316,7 +316,6 @@
       "type": "object"
     },
     "Encryption": {
-      "description": "All encryption configuration for a resource.",
       "properties": {
         "customerManagedKeyEncryption": {
           "description": "All Customer-managed key encryption properties for the resource.",
@@ -348,7 +347,6 @@
       "type": "object"
     },
     "EncryptionCustomerManagedKeyEncryption": {
-      "description": "All Customer-managed key encryption properties for the resource.",
       "properties": {
         "keyEncryptionKeyIdentity": {
           "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault.",
@@ -369,13 +367,14 @@
       "type": "object"
     },
     "EncryptionCustomerManagedKeyEncryptionKeyIdentity": {
-      "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault.",
       "properties": {
         "delegatedIdentityClientId": {
           "description": "delegated identity to use for accessing key encryption key Url. Ex: /subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/<resource group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myId. Mutually exclusive with identityType systemAssignedIdentity and userAssignedIdentity - internal use only.",
           "oneOf": [
             {
-              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+              "maxLength": 36,
+              "minLength": 36,
+              "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
               "type": "string"
             },
             {
@@ -387,7 +386,9 @@
           "description": "application client identity to use for accessing key encryption key Url in a different tenant. Ex: f83c6b1b-4d34-47e4-bb34-9d83df58b540",
           "oneOf": [
             {
-              "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+              "maxLength": 36,
+              "minLength": 36,
+              "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
               "type": "string"
             },
             {
@@ -419,7 +420,6 @@
       "type": "object"
     },
     "LinkedResource": {
-      "description": "Linked resource is reference to a resource deployed in an Azure subscription, add the linked resource `uniqueName` value as an optional parameter for operations on Azure Maps Geospatial REST APIs.",
       "properties": {
         "id": {
           "description": "ARM resource id in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/accounts/{storageName}'.",
@@ -431,13 +431,12 @@
         }
       },
       "required": [
-        "uniqueName",
-        "id"
+        "id",
+        "uniqueName"
       ],
       "type": "object"
     },
     "LocationsItem": {
-      "description": "Data processing location.",
       "properties": {
         "locationName": {
           "description": "The location name.",
@@ -450,7 +449,6 @@
       "type": "object"
     },
     "ManagedServiceIdentity": {
-      "description": "Managed service identity (system assigned and/or user assigned identities)",
       "properties": {
         "type": {
           "description": "Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).",
@@ -490,8 +488,14 @@
       ],
       "type": "object"
     },
+    "ManagedServiceIdentityUserAssignedIdentities": {
+      "additionalProperties": {
+        "$ref": "#/definitions/UserAssignedIdentity"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "MapsAccountProperties": {
-      "description": "Additional Maps account properties",
       "properties": {
         "cors": {
           "description": "Specifies CORS rules for the Blob service. You can include up to five CorsRule elements in the request. If no CorsRule elements are included in the request body, all CORS rules will be deleted, and CORS will be disabled for the Blob service.",
@@ -508,7 +512,6 @@
           "description": "Allows toggle functionality on Azure Policy to disable Azure Maps local authentication support. This will disable Shared Keys and Shared Access Signature Token authentication from any usage.",
           "oneOf": [
             {
-              "default": false,
               "type": "boolean"
             },
             {
@@ -574,12 +577,10 @@
       "type": "object"
     },
     "PrivateEndpoint": {
-      "description": "The private endpoint resource.",
       "properties": {},
       "type": "object"
     },
     "PrivateEndpointConnectionProperties": {
-      "description": "Properties of the private endpoint connection.",
       "properties": {
         "privateEndpoint": {
           "description": "The private endpoint resource.",
@@ -610,7 +611,6 @@
       "type": "object"
     },
     "PrivateLinkServiceConnectionState": {
-      "description": "A collection of information about the state of the connection between service consumer and provider.",
       "properties": {
         "actionsRequired": {
           "description": "A message indicating if changes on the service provider require any updates on the consumer.",
@@ -640,7 +640,6 @@
       "type": "object"
     },
     "Sku": {
-      "description": "The SKU of the Maps Account.",
       "properties": {
         "name": {
           "description": "The name of the SKU, in standard format (such as G2).",
@@ -662,13 +661,19 @@
       ],
       "type": "object"
     },
+    "TrackedResourceTags": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {},
+      "type": "object"
+    },
     "UserAssignedIdentity": {
-      "description": "User assigned identity properties",
       "properties": {},
       "type": "object"
     },
     "accounts_creators_childResource": {
-      "description": "Microsoft.Maps/accounts/creators",
+      "description": "creators",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -681,7 +686,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the Maps Creator instance.",
+          "description": "The resource name",
           "oneOf": [
             {
               "minLength": 1,
@@ -727,6 +732,7 @@
         }
       },
       "required": [
+        "location",
         "name",
         "properties",
         "apiVersion",
@@ -735,7 +741,7 @@
       "type": "object"
     },
     "accounts_privateEndpointConnections_childResource": {
-      "description": "Microsoft.Maps/accounts/privateEndpointConnections",
+      "description": "privateEndpointConnections",
       "properties": {
         "apiVersion": {
           "enum": [
@@ -744,7 +750,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the private endpoint connection associated with the Azure resource.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {


### PR DESCRIPTION
Enables `Microsoft.Maps` in the `csharpGeneratorProviders` list so schemas are generated via the C# generator instead of AutoRest.

12 schema files regenerated across all existing API versions.