### PR TITLE
Onboard Microsoft.ManagedServices for C# generation

### DIFF
--- a/.github/prompts/csharp-onboard.md
+++ b/.github/prompts/csharp-onboard.md
@@ -44,7 +44,13 @@ scripts/GenerateCsharp.ps1
 
 ### 4. Verify output
 
-Verify there are no errors
+Run the .NET Tests and verify there are no errors:
+
+```sh
+dotnet test
+```
+
+If any errors come up, attempt to fix them. If the fix is unclear, prompt the user for how to proceed.
 
 ### 5. Create a PR
 

--- a/generator/autogenlist.ts
+++ b/generator/autogenlist.ts
@@ -132,7 +132,7 @@ const csharpGeneratorProviders: CsharpGeneratorConfig[] = [
     { namespace: 'Microsoft.MachineLearningServices', enabled: false },
     { namespace: 'Microsoft.Maintenance', enabled: false },
     { namespace: 'Microsoft.ManagedNetwork', enabled: false },
-    { namespace: 'Microsoft.ManagedServices', enabled: false },
+    { namespace: 'Microsoft.ManagedServices', enabled: true },
     { namespace: 'Microsoft.Management', enabled: false },
     { namespace: 'Microsoft.ManagementPartner', enabled: false },
     { namespace: 'Microsoft.Maps', enabled: true },

--- a/schemas/2018-05-01/subscriptionDeploymentTemplate.json
+++ b/schemas/2018-05-01/subscriptionDeploymentTemplate.json
@@ -1731,46 +1731,46 @@
               "$ref": "https://schema.management.azure.com/schemas/2025-07-28-preview/Microsoft.ManagedOps.json#/subscription_resourceDefinitions/managedOps"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2018-06-01-preview/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationAssignments"
+              "$ref": "https://schema.management.azure.com/schemas/2018-06-01-preview/Microsoft.ManagedServices.json#/subscription_resourceDefinitions/registrationAssignments"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2018-06-01-preview/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationDefinitions"
+              "$ref": "https://schema.management.azure.com/schemas/2018-06-01-preview/Microsoft.ManagedServices.json#/subscription_resourceDefinitions/registrationDefinitions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2019-04-01-preview/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationAssignments"
+              "$ref": "https://schema.management.azure.com/schemas/2019-04-01-preview/Microsoft.ManagedServices.json#/subscription_resourceDefinitions/registrationAssignments"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2019-04-01-preview/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationDefinitions"
+              "$ref": "https://schema.management.azure.com/schemas/2019-04-01-preview/Microsoft.ManagedServices.json#/subscription_resourceDefinitions/registrationDefinitions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2019-06-01/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationAssignments"
+              "$ref": "https://schema.management.azure.com/schemas/2019-06-01/Microsoft.ManagedServices.json#/subscription_resourceDefinitions/registrationAssignments"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2019-06-01/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationDefinitions"
+              "$ref": "https://schema.management.azure.com/schemas/2019-06-01/Microsoft.ManagedServices.json#/subscription_resourceDefinitions/registrationDefinitions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2019-09-01/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationAssignments"
+              "$ref": "https://schema.management.azure.com/schemas/2019-09-01/Microsoft.ManagedServices.json#/subscription_resourceDefinitions/registrationAssignments"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2019-09-01/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationDefinitions"
+              "$ref": "https://schema.management.azure.com/schemas/2019-09-01/Microsoft.ManagedServices.json#/subscription_resourceDefinitions/registrationDefinitions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2020-02-01-preview/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationAssignments"
+              "$ref": "https://schema.management.azure.com/schemas/2020-02-01-preview/Microsoft.ManagedServices.json#/subscription_resourceDefinitions/registrationAssignments"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2020-02-01-preview/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationDefinitions"
+              "$ref": "https://schema.management.azure.com/schemas/2020-02-01-preview/Microsoft.ManagedServices.json#/subscription_resourceDefinitions/registrationDefinitions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2022-01-01-preview/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationAssignments"
+              "$ref": "https://schema.management.azure.com/schemas/2022-01-01-preview/Microsoft.ManagedServices.json#/subscription_resourceDefinitions/registrationAssignments"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2022-01-01-preview/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationDefinitions"
+              "$ref": "https://schema.management.azure.com/schemas/2022-01-01-preview/Microsoft.ManagedServices.json#/subscription_resourceDefinitions/registrationDefinitions"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationAssignments"
+              "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.ManagedServices.json#/subscription_resourceDefinitions/registrationAssignments"
             },
             {
-              "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationDefinitions"
+              "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.ManagedServices.json#/subscription_resourceDefinitions/registrationDefinitions"
             },
             {
               "$ref": "https://schema.management.azure.com/schemas/2020-01-01/Microsoft.Marketplace.json#/subscription_resourceDefinitions/privateStores_offers"

--- a/schemas/2018-06-01-preview/Microsoft.ManagedServices.json
+++ b/schemas/2018-06-01-preview/Microsoft.ManagedServices.json
@@ -3,7 +3,7 @@
   "title": "Microsoft.ManagedServices",
   "description": "Microsoft ManagedServices Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "unknown_resourceDefinitions": {
+  "tenant_resourceDefinitions": {
     "registrationAssignments": {
       "description": "Microsoft.ManagedServices/registrationAssignments",
       "properties": {
@@ -14,7 +14,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Guid of the registration assignment.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -53,7 +53,280 @@
           "type": "string"
         },
         "name": {
-          "description": "Guid of the registration definition.",
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "Plan details for the managed services.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "Properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "managementGroup_resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2018-06-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "Properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2018-06-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "Plan details for the managed services.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "Properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "subscription_resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2018-06-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "Properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2018-06-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "Plan details for the managed services.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "Properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2018-06-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "Properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2018-06-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
           "type": "string"
         },
         "plan": {
@@ -96,14 +369,15 @@
   },
   "definitions": {
     "Authorization": {
-      "description": "Authorization tuple containing principal Id (of user/service principal/security group) and role definition id.",
       "properties": {
         "delegatedRoleDefinitionIds": {
           "description": "The delegatedRoleDefinitionIds field is required when the roleDefinitionId refers to the User Access Administrator Role. It is the list of role definition ids which define all the permissions that the user in the authorization can assign to other security groups/service principals/users.",
           "oneOf": [
             {
               "items": {
-                "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+                "maxLength": 36,
+                "minLength": 36,
+                "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
                 "type": "string"
               },
               "type": "array"
@@ -133,7 +407,6 @@
       "type": "object"
     },
     "Plan": {
-      "description": "Plan details for the managed services.",
       "properties": {
         "name": {
           "description": "The plan name.",
@@ -154,14 +427,13 @@
       },
       "required": [
         "name",
-        "publisher",
         "product",
+        "publisher",
         "version"
       ],
       "type": "object"
     },
     "RegistrationAssignmentProperties": {
-      "description": "Properties of a registration assignment.",
       "properties": {
         "registrationDefinitionId": {
           "description": "Fully qualified path of the registration definition.",
@@ -174,7 +446,6 @@
       "type": "object"
     },
     "RegistrationDefinitionProperties": {
-      "description": "Properties of a registration definition.",
       "properties": {
         "authorizations": {
           "description": "Authorization tuple containing principal id of the user/security group or service principal and id of the build-in role.",

--- a/schemas/2018-06-01-preview/Microsoft.ManagedServices.json
+++ b/schemas/2018-06-01-preview/Microsoft.ManagedServices.json
@@ -367,6 +367,14 @@
       "type": "object"
     }
   },
+  "unknown_resourceDefinitions": {
+    "registrationAssignments": {
+      "$ref": "#/resourceDefinitions/registrationAssignments"
+    },
+    "registrationDefinitions": {
+      "$ref": "#/resourceDefinitions/registrationDefinitions"
+    }
+  },
   "definitions": {
     "Authorization": {
       "properties": {

--- a/schemas/2019-04-01-preview/Microsoft.ManagedServices.json
+++ b/schemas/2019-04-01-preview/Microsoft.ManagedServices.json
@@ -3,7 +3,7 @@
   "title": "Microsoft.ManagedServices",
   "description": "Microsoft ManagedServices Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "unknown_resourceDefinitions": {
+  "tenant_resourceDefinitions": {
     "registrationAssignments": {
       "description": "Microsoft.ManagedServices/registrationAssignments",
       "properties": {
@@ -14,7 +14,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Guid of the registration assignment.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -53,7 +53,280 @@
           "type": "string"
         },
         "name": {
-          "description": "Guid of the registration definition.",
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "Plan details for the managed services.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "Properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "managementGroup_resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-04-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "Properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-04-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "Plan details for the managed services.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "Properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "subscription_resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-04-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "Properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-04-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "Plan details for the managed services.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "Properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-04-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "Properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-04-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
           "type": "string"
         },
         "plan": {
@@ -96,14 +369,15 @@
   },
   "definitions": {
     "Authorization": {
-      "description": "Authorization tuple containing principal Id (of user/service principal/security group) and role definition id.",
       "properties": {
         "delegatedRoleDefinitionIds": {
           "description": "The delegatedRoleDefinitionIds field is required when the roleDefinitionId refers to the User Access Administrator Role. It is the list of role definition ids which define all the permissions that the user in the authorization can assign to other security groups/service principals/users.",
           "oneOf": [
             {
               "items": {
-                "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+                "maxLength": 36,
+                "minLength": 36,
+                "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
                 "type": "string"
               },
               "type": "array"
@@ -133,7 +407,6 @@
       "type": "object"
     },
     "Plan": {
-      "description": "Plan details for the managed services.",
       "properties": {
         "name": {
           "description": "The plan name.",
@@ -154,14 +427,13 @@
       },
       "required": [
         "name",
-        "publisher",
         "product",
+        "publisher",
         "version"
       ],
       "type": "object"
     },
     "RegistrationAssignmentProperties": {
-      "description": "Properties of a registration assignment.",
       "properties": {
         "registrationDefinitionId": {
           "description": "Fully qualified path of the registration definition.",
@@ -174,7 +446,6 @@
       "type": "object"
     },
     "RegistrationDefinitionProperties": {
-      "description": "Properties of a registration definition.",
       "properties": {
         "authorizations": {
           "description": "Authorization tuple containing principal id of the user/security group or service principal and id of the build-in role.",

--- a/schemas/2019-06-01/Microsoft.ManagedServices.json
+++ b/schemas/2019-06-01/Microsoft.ManagedServices.json
@@ -367,6 +367,14 @@
       "type": "object"
     }
   },
+  "unknown_resourceDefinitions": {
+    "registrationAssignments": {
+      "$ref": "#/resourceDefinitions/registrationAssignments"
+    },
+    "registrationDefinitions": {
+      "$ref": "#/resourceDefinitions/registrationDefinitions"
+    }
+  },
   "definitions": {
     "Authorization": {
       "properties": {

--- a/schemas/2019-06-01/Microsoft.ManagedServices.json
+++ b/schemas/2019-06-01/Microsoft.ManagedServices.json
@@ -3,7 +3,7 @@
   "title": "Microsoft.ManagedServices",
   "description": "Microsoft ManagedServices Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "unknown_resourceDefinitions": {
+  "tenant_resourceDefinitions": {
     "registrationAssignments": {
       "description": "Microsoft.ManagedServices/registrationAssignments",
       "properties": {
@@ -14,7 +14,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Guid of the registration assignment.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -53,7 +53,280 @@
           "type": "string"
         },
         "name": {
-          "description": "Guid of the registration definition.",
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "Plan details for the managed services.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "Properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "managementGroup_resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-06-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "Properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-06-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "Plan details for the managed services.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "Properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "subscription_resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-06-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "Properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-06-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "Plan details for the managed services.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "Properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-06-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "Properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-06-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
           "type": "string"
         },
         "plan": {
@@ -96,14 +369,15 @@
   },
   "definitions": {
     "Authorization": {
-      "description": "Authorization tuple containing principal Id (of user/service principal/security group) and role definition id.",
       "properties": {
         "delegatedRoleDefinitionIds": {
           "description": "The delegatedRoleDefinitionIds field is required when the roleDefinitionId refers to the User Access Administrator Role. It is the list of role definition ids which define all the permissions that the user in the authorization can assign to other security groups/service principals/users.",
           "oneOf": [
             {
               "items": {
-                "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+                "maxLength": 36,
+                "minLength": 36,
+                "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
                 "type": "string"
               },
               "type": "array"
@@ -133,7 +407,6 @@
       "type": "object"
     },
     "Plan": {
-      "description": "Plan details for the managed services.",
       "properties": {
         "name": {
           "description": "The plan name.",
@@ -154,14 +427,13 @@
       },
       "required": [
         "name",
-        "publisher",
         "product",
+        "publisher",
         "version"
       ],
       "type": "object"
     },
     "RegistrationAssignmentProperties": {
-      "description": "Properties of a registration assignment.",
       "properties": {
         "registrationDefinitionId": {
           "description": "Fully qualified path of the registration definition.",
@@ -174,7 +446,6 @@
       "type": "object"
     },
     "RegistrationDefinitionProperties": {
-      "description": "Properties of a registration definition.",
       "properties": {
         "authorizations": {
           "description": "Authorization tuple containing principal id of the user/security group or service principal and id of the build-in role.",

--- a/schemas/2019-08-01/managementGroupDeploymentTemplate.json
+++ b/schemas/2019-08-01/managementGroupDeploymentTemplate.json
@@ -1251,6 +1251,48 @@
               "$ref": "https://schema.management.azure.com/schemas/2024-12-01-preview/Microsoft.LoadTestService.loadtesting.json#/unknown_resourceDefinitions/loadTestProfileMappings"
             },
             {
+              "$ref": "https://schema.management.azure.com/schemas/2018-06-01-preview/Microsoft.ManagedServices.json#/managementGroup_resourceDefinitions/registrationAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2018-06-01-preview/Microsoft.ManagedServices.json#/managementGroup_resourceDefinitions/registrationDefinitions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2019-04-01-preview/Microsoft.ManagedServices.json#/managementGroup_resourceDefinitions/registrationAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2019-04-01-preview/Microsoft.ManagedServices.json#/managementGroup_resourceDefinitions/registrationDefinitions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2019-06-01/Microsoft.ManagedServices.json#/managementGroup_resourceDefinitions/registrationAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2019-06-01/Microsoft.ManagedServices.json#/managementGroup_resourceDefinitions/registrationDefinitions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2019-09-01/Microsoft.ManagedServices.json#/managementGroup_resourceDefinitions/registrationAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2019-09-01/Microsoft.ManagedServices.json#/managementGroup_resourceDefinitions/registrationDefinitions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-02-01-preview/Microsoft.ManagedServices.json#/managementGroup_resourceDefinitions/registrationAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2020-02-01-preview/Microsoft.ManagedServices.json#/managementGroup_resourceDefinitions/registrationDefinitions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2022-01-01-preview/Microsoft.ManagedServices.json#/managementGroup_resourceDefinitions/registrationAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2022-01-01-preview/Microsoft.ManagedServices.json#/managementGroup_resourceDefinitions/registrationDefinitions"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.ManagedServices.json#/managementGroup_resourceDefinitions/registrationAssignments"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.ManagedServices.json#/managementGroup_resourceDefinitions/registrationDefinitions"
+            },
+            {
               "$ref": "https://schema.management.azure.com/schemas/2024-06-01-preview/Microsoft.Mission.json#/unknown_resourceDefinitions/approvals"
             },
             {

--- a/schemas/2019-08-01/tenantDeploymentTemplate.json
+++ b/schemas/2019-08-01/tenantDeploymentTemplate.json
@@ -1286,6 +1286,48 @@
                   "$ref": "https://schema.management.azure.com/schemas/2024-12-01-preview/Microsoft.LoadTestService.loadtesting.json#/unknown_resourceDefinitions/loadTestProfileMappings"
                 },
                 {
+                  "$ref": "https://schema.management.azure.com/schemas/2018-06-01-preview/Microsoft.ManagedServices.json#/tenant_resourceDefinitions/registrationAssignments"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2018-06-01-preview/Microsoft.ManagedServices.json#/tenant_resourceDefinitions/registrationDefinitions"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2019-04-01-preview/Microsoft.ManagedServices.json#/tenant_resourceDefinitions/registrationAssignments"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2019-04-01-preview/Microsoft.ManagedServices.json#/tenant_resourceDefinitions/registrationDefinitions"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2019-06-01/Microsoft.ManagedServices.json#/tenant_resourceDefinitions/registrationAssignments"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2019-06-01/Microsoft.ManagedServices.json#/tenant_resourceDefinitions/registrationDefinitions"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2019-09-01/Microsoft.ManagedServices.json#/tenant_resourceDefinitions/registrationAssignments"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2019-09-01/Microsoft.ManagedServices.json#/tenant_resourceDefinitions/registrationDefinitions"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2020-02-01-preview/Microsoft.ManagedServices.json#/tenant_resourceDefinitions/registrationAssignments"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2020-02-01-preview/Microsoft.ManagedServices.json#/tenant_resourceDefinitions/registrationDefinitions"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2022-01-01-preview/Microsoft.ManagedServices.json#/tenant_resourceDefinitions/registrationAssignments"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2022-01-01-preview/Microsoft.ManagedServices.json#/tenant_resourceDefinitions/registrationDefinitions"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.ManagedServices.json#/tenant_resourceDefinitions/registrationAssignments"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.ManagedServices.json#/tenant_resourceDefinitions/registrationDefinitions"
+                },
+                {
                   "$ref": "https://schema.management.azure.com/schemas/2017-11-01-preview/Microsoft.Management.json#/tenant_resourceDefinitions/managementGroups"
                 },
                 {

--- a/schemas/2019-09-01/Microsoft.ManagedServices.json
+++ b/schemas/2019-09-01/Microsoft.ManagedServices.json
@@ -3,7 +3,7 @@
   "title": "Microsoft.ManagedServices",
   "description": "Microsoft ManagedServices Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "unknown_resourceDefinitions": {
+  "tenant_resourceDefinitions": {
     "registrationAssignments": {
       "description": "Microsoft.ManagedServices/registrationAssignments",
       "properties": {
@@ -14,7 +14,7 @@
           "type": "string"
         },
         "name": {
-          "description": "Guid of the registration assignment.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -53,7 +53,280 @@
           "type": "string"
         },
         "name": {
-          "description": "Guid of the registration definition.",
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "Plan details for the managed services.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "Properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "managementGroup_resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-09-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "Properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-09-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "Plan details for the managed services.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "Properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "subscription_resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-09-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "Properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-09-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "Plan details for the managed services.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "Properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-09-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "Properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2019-09-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
           "type": "string"
         },
         "plan": {
@@ -96,14 +369,15 @@
   },
   "definitions": {
     "Authorization": {
-      "description": "Authorization tuple containing principal Id (of user/service principal/security group) and role definition id.",
       "properties": {
         "delegatedRoleDefinitionIds": {
           "description": "The delegatedRoleDefinitionIds field is required when the roleDefinitionId refers to the User Access Administrator Role. It is the list of role definition ids which define all the permissions that the user in the authorization can assign to other security groups/service principals/users.",
           "oneOf": [
             {
               "items": {
-                "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+                "maxLength": 36,
+                "minLength": 36,
+                "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
                 "type": "string"
               },
               "type": "array"
@@ -133,7 +407,6 @@
       "type": "object"
     },
     "Plan": {
-      "description": "Plan details for the managed services.",
       "properties": {
         "name": {
           "description": "The plan name.",
@@ -154,14 +427,13 @@
       },
       "required": [
         "name",
-        "publisher",
         "product",
+        "publisher",
         "version"
       ],
       "type": "object"
     },
     "RegistrationAssignmentProperties": {
-      "description": "Properties of a registration assignment.",
       "properties": {
         "registrationDefinitionId": {
           "description": "Fully qualified path of the registration definition.",
@@ -174,7 +446,6 @@
       "type": "object"
     },
     "RegistrationDefinitionProperties": {
-      "description": "Properties of a registration definition.",
       "properties": {
         "authorizations": {
           "description": "Authorization tuple containing principal id of the user/security group or service principal and id of the build-in role.",

--- a/schemas/2020-02-01-preview/Microsoft.ManagedServices.json
+++ b/schemas/2020-02-01-preview/Microsoft.ManagedServices.json
@@ -3,7 +3,7 @@
   "title": "Microsoft.ManagedServices",
   "description": "Microsoft ManagedServices Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "unknown_resourceDefinitions": {
+  "tenant_resourceDefinitions": {
     "registrationAssignments": {
       "description": "Microsoft.ManagedServices/registrationAssignments",
       "properties": {
@@ -14,7 +14,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The GUID of the registration assignment.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -53,7 +53,280 @@
           "type": "string"
         },
         "name": {
-          "description": "The GUID of the registration definition.",
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "The details for the Managed Services offer’s plan in Azure Marketplace.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "The properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "managementGroup_resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2020-02-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2020-02-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "The details for the Managed Services offer’s plan in Azure Marketplace.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "The properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "subscription_resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2020-02-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2020-02-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "The details for the Managed Services offer’s plan in Azure Marketplace.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "The properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2020-02-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2020-02-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
           "type": "string"
         },
         "plan": {
@@ -96,14 +369,15 @@
   },
   "definitions": {
     "Authorization": {
-      "description": "The Azure Active Directory principal identifier and Azure built-in role that describes the access the principal will receive on the delegated resource in the managed tenant.",
       "properties": {
         "delegatedRoleDefinitionIds": {
           "description": "The delegatedRoleDefinitionIds field is required when the roleDefinitionId refers to the User Access Administrator Role. It is the list of role definition ids which define all the permissions that the user in the authorization can assign to other principals.",
           "oneOf": [
             {
               "items": {
-                "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+                "maxLength": 36,
+                "minLength": 36,
+                "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
                 "type": "string"
               },
               "type": "array"
@@ -133,7 +407,6 @@
       "type": "object"
     },
     "EligibleApprover": {
-      "description": "Defines the Azure Active Directory principal that can approve any just-in-time access requests by the principal defined in the EligibleAuthorization.",
       "properties": {
         "principalId": {
           "description": "The identifier of the Azure Active Directory principal.",
@@ -150,7 +423,6 @@
       "type": "object"
     },
     "EligibleAuthorization": {
-      "description": "The Azure Active Directory principal identifier, Azure built-in role, and just-in-time access policy that describes the just-in-time access the principal will receive on the delegated resource in the managed tenant.",
       "properties": {
         "justInTimeAccessPolicy": {
           "description": "The just-in-time access policy setting.",
@@ -183,7 +455,6 @@
       "type": "object"
     },
     "JustInTimeAccessPolicy": {
-      "description": "Just-in-time access policy setting.",
       "properties": {
         "managedByTenantApprovers": {
           "description": "The list of managedByTenant approvers for the eligible authorization.",
@@ -200,7 +471,6 @@
           ]
         },
         "maximumActivationDuration": {
-          "default": "PT8H",
           "description": "The maximum access duration in ISO 8601 format for just-in-time access requests.",
           "type": "string"
         },
@@ -226,7 +496,6 @@
       "type": "object"
     },
     "Plan": {
-      "description": "The details for the Managed Services offer’s plan in Azure Marketplace.",
       "properties": {
         "name": {
           "description": "Azure Marketplace plan name.",
@@ -247,14 +516,13 @@
       },
       "required": [
         "name",
-        "publisher",
         "product",
+        "publisher",
         "version"
       ],
       "type": "object"
     },
     "RegistrationAssignmentProperties": {
-      "description": "The properties of the registration assignment.",
       "properties": {
         "registrationDefinitionId": {
           "description": "The fully qualified path of the registration definition.",
@@ -267,7 +535,6 @@
       "type": "object"
     },
     "RegistrationDefinitionProperties": {
-      "description": "The properties of a registration definition.",
       "properties": {
         "authorizations": {
           "description": "The collection of authorization objects describing the access Azure Active Directory principals in the managedBy tenant will receive on the delegated resource in the managed tenant.",

--- a/schemas/2022-01-01-preview/Microsoft.ManagedServices.json
+++ b/schemas/2022-01-01-preview/Microsoft.ManagedServices.json
@@ -3,7 +3,7 @@
   "title": "Microsoft.ManagedServices",
   "description": "Microsoft ManagedServices Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "unknown_resourceDefinitions": {
+  "tenant_resourceDefinitions": {
     "registrationAssignments": {
       "description": "Microsoft.ManagedServices/registrationAssignments",
       "properties": {
@@ -14,7 +14,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The GUID of the registration assignment.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -53,7 +53,280 @@
           "type": "string"
         },
         "name": {
-          "description": "The GUID of the registration definition.",
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "The details for the Managed Services offer’s plan in Azure Marketplace.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "The properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "managementGroup_resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-01-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-01-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "The details for the Managed Services offer’s plan in Azure Marketplace.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "The properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "subscription_resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-01-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-01-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "The details for the Managed Services offer’s plan in Azure Marketplace.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "The properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-01-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-01-01-preview"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
           "type": "string"
         },
         "plan": {
@@ -96,14 +369,15 @@
   },
   "definitions": {
     "Authorization": {
-      "description": "The Azure Active Directory principal identifier and Azure built-in role that describes the access the principal will receive on the delegated resource in the managed tenant.",
       "properties": {
         "delegatedRoleDefinitionIds": {
           "description": "The delegatedRoleDefinitionIds field is required when the roleDefinitionId refers to the User Access Administrator Role. It is the list of role definition ids which define all the permissions that the user in the authorization can assign to other principals.",
           "oneOf": [
             {
               "items": {
-                "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+                "maxLength": 36,
+                "minLength": 36,
+                "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
                 "type": "string"
               },
               "type": "array"
@@ -133,7 +407,6 @@
       "type": "object"
     },
     "EligibleApprover": {
-      "description": "Defines the Azure Active Directory principal that can approve any just-in-time access requests by the principal defined in the EligibleAuthorization.",
       "properties": {
         "principalId": {
           "description": "The identifier of the Azure Active Directory principal.",
@@ -150,7 +423,6 @@
       "type": "object"
     },
     "EligibleAuthorization": {
-      "description": "The Azure Active Directory principal identifier, Azure built-in role, and just-in-time access policy that describes the just-in-time access the principal will receive on the delegated resource in the managed tenant.",
       "properties": {
         "justInTimeAccessPolicy": {
           "description": "The just-in-time access policy setting.",
@@ -183,7 +455,6 @@
       "type": "object"
     },
     "JustInTimeAccessPolicy": {
-      "description": "Just-in-time access policy setting.",
       "properties": {
         "managedByTenantApprovers": {
           "description": "The list of managedByTenant approvers for the eligible authorization.",
@@ -200,7 +471,6 @@
           ]
         },
         "maximumActivationDuration": {
-          "default": "PT8H",
           "description": "The maximum access duration in ISO 8601 format for just-in-time access requests.",
           "type": "string"
         },
@@ -226,7 +496,6 @@
       "type": "object"
     },
     "Plan": {
-      "description": "The details for the Managed Services offer’s plan in Azure Marketplace.",
       "properties": {
         "name": {
           "description": "Azure Marketplace plan name.",
@@ -247,14 +516,13 @@
       },
       "required": [
         "name",
-        "publisher",
         "product",
+        "publisher",
         "version"
       ],
       "type": "object"
     },
     "RegistrationAssignmentProperties": {
-      "description": "The properties of the registration assignment.",
       "properties": {
         "registrationDefinitionId": {
           "description": "The fully qualified path of the registration definition.",
@@ -267,7 +535,6 @@
       "type": "object"
     },
     "RegistrationDefinitionProperties": {
-      "description": "The properties of a registration definition.",
       "properties": {
         "authorizations": {
           "description": "The collection of authorization objects describing the access Azure Active Directory principals in the managedBy tenant will receive on the delegated resource in the managed tenant.",

--- a/schemas/2022-10-01/Microsoft.ManagedServices.json
+++ b/schemas/2022-10-01/Microsoft.ManagedServices.json
@@ -3,7 +3,7 @@
   "title": "Microsoft.ManagedServices",
   "description": "Microsoft ManagedServices Resource Types",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "unknown_resourceDefinitions": {
+  "tenant_resourceDefinitions": {
     "registrationAssignments": {
       "description": "Microsoft.ManagedServices/registrationAssignments",
       "properties": {
@@ -14,7 +14,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The GUID of the registration assignment.",
+          "description": "The resource name",
           "type": "string"
         },
         "properties": {
@@ -53,7 +53,280 @@
           "type": "string"
         },
         "name": {
-          "description": "The GUID of the registration definition.",
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "The details for the Managed Services offer’s plan in Azure Marketplace.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "The properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "managementGroup_resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-10-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-10-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "The details for the Managed Services offer’s plan in Azure Marketplace.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "The properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "subscription_resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-10-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-10-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "plan": {
+          "description": "The details for the Managed Services offer’s plan in Azure Marketplace.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "The properties of a registration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationDefinitionProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationDefinitions"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "resourceDefinitions": {
+    "registrationAssignments": {
+      "description": "Microsoft.ManagedServices/registrationAssignments",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-10-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of a registration assignment.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RegistrationAssignmentProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.ManagedServices/registrationAssignments"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "registrationDefinitions": {
+      "description": "Microsoft.ManagedServices/registrationDefinitions",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2022-10-01"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name",
           "type": "string"
         },
         "plan": {
@@ -96,14 +369,15 @@
   },
   "definitions": {
     "Authorization": {
-      "description": "The Azure Active Directory principal identifier and Azure built-in role that describes the access the principal will receive on the delegated resource in the managed tenant.",
       "properties": {
         "delegatedRoleDefinitionIds": {
           "description": "The delegatedRoleDefinitionIds field is required when the roleDefinitionId refers to the User Access Administrator Role. It is the list of role definition ids which define all the permissions that the user in the authorization can assign to other principals.",
           "oneOf": [
             {
               "items": {
-                "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$",
+                "maxLength": 36,
+                "minLength": 36,
+                "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
                 "type": "string"
               },
               "type": "array"
@@ -133,7 +407,6 @@
       "type": "object"
     },
     "EligibleApprover": {
-      "description": "Defines the Azure Active Directory principal that can approve any just-in-time access requests by the principal defined in the EligibleAuthorization.",
       "properties": {
         "principalId": {
           "description": "The identifier of the Azure Active Directory principal.",
@@ -150,7 +423,6 @@
       "type": "object"
     },
     "EligibleAuthorization": {
-      "description": "The Azure Active Directory principal identifier, Azure built-in role, and just-in-time access policy that describes the just-in-time access the principal will receive on the delegated resource in the managed tenant.",
       "properties": {
         "justInTimeAccessPolicy": {
           "description": "The just-in-time access policy setting.",
@@ -183,7 +455,6 @@
       "type": "object"
     },
     "JustInTimeAccessPolicy": {
-      "description": "Just-in-time access policy setting.",
       "properties": {
         "managedByTenantApprovers": {
           "description": "The list of managedByTenant approvers for the eligible authorization.",
@@ -200,7 +471,6 @@
           ]
         },
         "maximumActivationDuration": {
-          "default": "PT8H",
           "description": "The maximum access duration in ISO 8601 format for just-in-time access requests.",
           "type": "string"
         },
@@ -226,7 +496,6 @@
       "type": "object"
     },
     "Plan": {
-      "description": "The details for the Managed Services offer’s plan in Azure Marketplace.",
       "properties": {
         "name": {
           "description": "Azure Marketplace plan name.",
@@ -247,14 +516,13 @@
       },
       "required": [
         "name",
-        "publisher",
         "product",
+        "publisher",
         "version"
       ],
       "type": "object"
     },
     "RegistrationAssignmentProperties": {
-      "description": "The properties of the registration assignment.",
       "properties": {
         "registrationDefinitionId": {
           "description": "The fully qualified path of the registration definition.",
@@ -267,7 +535,6 @@
       "type": "object"
     },
     "RegistrationDefinitionProperties": {
-      "description": "The properties of a registration definition.",
       "properties": {
         "authorizations": {
           "description": "The collection of authorization objects describing the access Azure Active Directory principals in the managedBy tenant will receive on the delegated resource in the managed tenant.",

--- a/schemas/common/autogeneratedResources.json
+++ b/schemas/common/autogeneratedResources.json
@@ -35783,25 +35783,46 @@
           "$ref": "https://schema.management.azure.com/schemas/2024-06-15-preview/Microsoft.ManagedNetworkFabric.json#/resourceDefinitions/routePolicies"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2018-06-01-preview/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationAssignments"
+          "$ref": "https://schema.management.azure.com/schemas/2018-06-01-preview/Microsoft.ManagedServices.json#/resourceDefinitions/registrationAssignments"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2019-04-01-preview/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationAssignments"
+          "$ref": "https://schema.management.azure.com/schemas/2018-06-01-preview/Microsoft.ManagedServices.json#/resourceDefinitions/registrationDefinitions"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2019-06-01/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationAssignments"
+          "$ref": "https://schema.management.azure.com/schemas/2019-04-01-preview/Microsoft.ManagedServices.json#/resourceDefinitions/registrationAssignments"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2019-09-01/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationAssignments"
+          "$ref": "https://schema.management.azure.com/schemas/2019-04-01-preview/Microsoft.ManagedServices.json#/resourceDefinitions/registrationDefinitions"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2020-02-01-preview/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationAssignments"
+          "$ref": "https://schema.management.azure.com/schemas/2019-06-01/Microsoft.ManagedServices.json#/resourceDefinitions/registrationAssignments"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2022-01-01-preview/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationAssignments"
+          "$ref": "https://schema.management.azure.com/schemas/2019-06-01/Microsoft.ManagedServices.json#/resourceDefinitions/registrationDefinitions"
         },
         {
-          "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.ManagedServices.json#/unknown_resourceDefinitions/registrationAssignments"
+          "$ref": "https://schema.management.azure.com/schemas/2019-09-01/Microsoft.ManagedServices.json#/resourceDefinitions/registrationAssignments"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2019-09-01/Microsoft.ManagedServices.json#/resourceDefinitions/registrationDefinitions"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-02-01-preview/Microsoft.ManagedServices.json#/resourceDefinitions/registrationAssignments"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2020-02-01-preview/Microsoft.ManagedServices.json#/resourceDefinitions/registrationDefinitions"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2022-01-01-preview/Microsoft.ManagedServices.json#/resourceDefinitions/registrationAssignments"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2022-01-01-preview/Microsoft.ManagedServices.json#/resourceDefinitions/registrationDefinitions"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.ManagedServices.json#/resourceDefinitions/registrationAssignments"
+        },
+        {
+          "$ref": "https://schema.management.azure.com/schemas/2022-10-01/Microsoft.ManagedServices.json#/resourceDefinitions/registrationDefinitions"
         },
         {
           "$ref": "https://schema.management.azure.com/schemas/2025-03-01/Microsoft.ManufacturingPlatform.json#/resourceDefinitions/manufacturingDataServices"


### PR DESCRIPTION
## Summary
- Enable `Microsoft.ManagedServices` in C# generator onboarding list
- Regenerate schemas through the C# generation pipeline

## Validation
- Ran `scripts/GenerateCsharp.ps1`
- Generation succeeded including `Microsoft.ManagedServices`