### PR TITLE
Disable template schema autogen for Microsoft.ProviderHub

### DIFF
--- a/generator/autogenlist.ts
+++ b/generator/autogenlist.ts
@@ -1058,6 +1058,7 @@ const autoGenList: AutoGenConfig[] = [
     {
         basePath: 'providerhub/resource-manager',
         namespace: 'Microsoft.ProviderHub',
+        disabledForAutogen: true,
         postProcessor: providerHubPostProcessor
     },
     {


### PR DESCRIPTION
## Summary

Sets `disabledForAutogen: true` for `Microsoft.ProviderHub` in `generator/autogenlist.ts`.

## Why

Microsoft.ProviderHub is an internal resource provider. Per this repo's stated policy:

> We only publish template schemas for resource providers that are **publicly available**. This means that there should be no restrictions (private preview, internal-only allowlisting) on who can call your APIs.

ProviderHub does not meet that bar, so its ARM/Bicep template reference schemas should not be published.

## Effect

- Stops generation of the `learn.microsoft.com/azure/templates/microsoft.providerhub/**` reference pages.
- Removes Microsoft.ProviderHub from ARM/Bicep template IntelliSense.

## Change

Single flag added to the existing ProviderHub entry, consistent with the ~13 providers already carrying `disabledForAutogen: true` (e.g. Microsoft.Logic, Microsoft.AgFoodPlatform).